### PR TITLE
VB-2225 - update config for prisoner profile's past and future visits duration 

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -95,9 +95,9 @@ prisoner:
   profile:
     timeout: 10s
     past-visits:
-      duration-in-months: P6M
+      duration-in-months: P3M
     future-visits:
-      duration-in-months: P2M
+      duration-in-months: P12M
 
 hmpps:
   auth:


### PR DESCRIPTION
VB-2225 - reduce past visits duration to last 3 months and future visits duration to last 12 months.