### PR TITLE
VB-2071 Add NOT_APPLICABLE application method type

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/dto/visit/scheduler/enums/ApplicationMethodType.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/dto/visit/scheduler/enums/ApplicationMethodType.kt
@@ -2,5 +2,5 @@ package uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.vi
 
 @Suppress("unused")
 enum class ApplicationMethodType {
-  PHONE, WEBSITE, EMAIL, IN_PERSON, NOT_KNOWN
+  PHONE, WEBSITE, EMAIL, IN_PERSON, NOT_KNOWN, NOT_APPLICABLE
 }


### PR DESCRIPTION
Capturing application method type is for requests by visitors. This new `NOT_APPLICABLE` value is for cases where, for example, a visit might be cancelled by the establishment itself. 