### PR TITLE
Update dependencies as a fix for security failures.

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -7,15 +7,9 @@
 # To stop the dps-gradle-spring-boot project from overwriting any project specific customisations here, remove the
 # warning at the top of this file.
 #
-# Suppression for jackson databind 2.13.4 as no release for it yet
-#   Can be suppressed as UNWRAP_SINGLE_VALUE_ARRAYS is not enabled
-CVE-2022-42003
-# Suppression for jackson databind 2.13.3 as bundled with application insights
-#   Can be suppressed as don't parse untrusted json in application insights
-CVE-2022-42004
-# Suppression for apache common-text 1.9 as bundled with application insights
-#   can be suppressed for the time being as it will be fixed in next version of application insights
-CVE-2022-42889
 # Suppression for h2 2.1.214 password on command line vulnerability
 #   can be suppressed as we only run h2 locally and not on build environments
 CVE-2022-45868
+# Suppression for logback-classic and logback-core as we don't let third parties control our appenders.
+# See https://logback.qos.ch/news.html#1.3.12 for further information.
+CVE-2023-6378

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-  id("uk.gov.justice.hmpps.gradle-spring-boot") version "5.10.0"
+  id("uk.gov.justice.hmpps.gradle-spring-boot") version "5.10.1"
   kotlin("plugin.spring") version "1.9.21"
   id("org.jetbrains.kotlin.plugin.noarg") version "1.9.21"
 }
@@ -28,9 +28,9 @@ dependencies {
 
   implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.16.0")
   implementation("org.springframework.data:spring-data-commons:3.2.0")
-  implementation("org.springdoc:springdoc-openapi-starter-webmvc-api:2.2.0")
-  implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0")
-  implementation("org.springdoc:springdoc-openapi-starter-common:2.2.0")
+  implementation("org.springdoc:springdoc-openapi-starter-webmvc-api:2.3.0")
+  implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0")
+  implementation("org.springdoc:springdoc-openapi-starter-common:2.3.0")
 
   annotationProcessor("org.springframework.boot:spring-boot-configuration-processor")
 
@@ -45,13 +45,13 @@ dependencies {
 }
 
 java {
-  toolchain.languageVersion.set(JavaLanguageVersion.of(20))
+  toolchain.languageVersion.set(JavaLanguageVersion.of(21))
 }
 
 tasks {
   withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
     kotlinOptions {
-      jvmTarget = "20"
+      jvmTarget = "21"
     }
   }
 }


### PR DESCRIPTION
Update dependencies as a fix for security failures.
Update JVM to version 21