### PR TITLE
Vb 3769 alter application api to cater for public and staff sources

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/dto/visit/scheduler/application/ApplicationDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/dto/visit/scheduler/application/ApplicationDto.kt
@@ -8,6 +8,7 @@ import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.vis
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.visit.scheduler.VisitNoteDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.visit.scheduler.VisitorDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.visit.scheduler.VisitorSupportDto
+import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.visit.scheduler.enums.UserType
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.visit.scheduler.enums.VisitRestriction
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.visit.scheduler.enums.VisitType
 import java.time.LocalDateTime
@@ -54,4 +55,7 @@ data class ApplicationDto(
   @Schema(description = "Is the application complete", example = "true", required = true)
   @field:NotNull
   val completed: Boolean,
+  @Schema(description = "User type", example = "STAFF", required = true)
+  @field:NotNull
+  val userType: UserType,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/dto/visit/scheduler/application/CreateApplicationDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/dto/visit/scheduler/application/CreateApplicationDto.kt
@@ -36,7 +36,7 @@ open class CreateApplicationDto(
   @Schema(description = "User type", example = "STAFF", required = true)
   @field:NotNull
   val userType: UserType,
-  @Schema(description = "Requested by (Booker reference Or User Name)", example = "asd-asd-asd or AFHETTY_GEN", required = true)
+  @Schema(description = "actioned by (Booker reference Or User Name)", example = "asd-asd-asd or AFHETTY_GEN", required = true)
   @field:NotBlank
-  val createdByReference: String,
+  val actionedBy: String,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/dto/visit/scheduler/application/CreateApplicationDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/dto/visit/scheduler/application/CreateApplicationDto.kt
@@ -8,6 +8,7 @@ import jakarta.validation.constraints.NotNull
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.visit.scheduler.ContactDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.visit.scheduler.VisitorDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.visit.scheduler.enums.CreateApplicationRestriction
+import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.visit.scheduler.enums.UserType
 import java.time.LocalDate
 
 open class CreateApplicationDto(
@@ -32,4 +33,7 @@ open class CreateApplicationDto(
   @Schema(description = "additional support associated with the visit, if null support will not be updated", required = false)
   @Valid
   var visitorSupport: ApplicationSupportDto? = null,
+  @Schema(description = "User type", example = "STAFF", required = true)
+  @field:NotNull
+  val userType: UserType,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/dto/visit/scheduler/application/CreateApplicationDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/dto/visit/scheduler/application/CreateApplicationDto.kt
@@ -36,4 +36,7 @@ open class CreateApplicationDto(
   @Schema(description = "User type", example = "STAFF", required = true)
   @field:NotNull
   val userType: UserType,
+  @Schema(description = "Requested by (Booker reference Or User Name)", example = "asd-asd-asd or AFHETTY_GEN", required = true)
+  @field:NotBlank
+  val createdByReference: String,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/dto/visit/scheduler/application/VisitSchedulerCreateApplicationDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/dto/visit/scheduler/application/VisitSchedulerCreateApplicationDto.kt
@@ -1,7 +1,6 @@
 package uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.visit.scheduler.application
 
 import jakarta.validation.Valid
-import jakarta.validation.constraints.NotBlank
 
 class VisitSchedulerCreateApplicationDto(
   /**
@@ -12,8 +11,6 @@ class VisitSchedulerCreateApplicationDto(
   @field:Valid
   private val createApplicationDto: CreateApplicationDto,
 
-  @field:NotBlank
-  val actionedBy: String,
 ) : CreateApplicationDto(
   createApplicationDto.prisonerId,
   createApplicationDto.sessionTemplateReference,
@@ -23,4 +20,5 @@ class VisitSchedulerCreateApplicationDto(
   createApplicationDto.visitors,
   createApplicationDto.visitorSupport,
   createApplicationDto.userType,
+  createApplicationDto.actionedBy,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/dto/visit/scheduler/application/VisitSchedulerCreateApplicationDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/dto/visit/scheduler/application/VisitSchedulerCreateApplicationDto.kt
@@ -22,4 +22,5 @@ class VisitSchedulerCreateApplicationDto(
   createApplicationDto.visitContact,
   createApplicationDto.visitors,
   createApplicationDto.visitorSupport,
+  createApplicationDto.userType,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/service/ApplicationsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/service/ApplicationsService.kt
@@ -19,7 +19,7 @@ class ApplicationsService(
   }
 
   fun createInitialApplication(createApplicationDto: CreateApplicationDto): ApplicationDto? {
-    return visitSchedulerApplicationsClient.createInitialApplication(VisitSchedulerCreateApplicationDto(createApplicationDto, createApplicationDto.createdByReference))
+    return visitSchedulerApplicationsClient.createInitialApplication(VisitSchedulerCreateApplicationDto(createApplicationDto))
   }
 
   fun changeIncompleteApplication(applicationReference: String, changeApplicationDto: ChangeApplicationDto): ApplicationDto? {
@@ -30,6 +30,6 @@ class ApplicationsService(
     visitReference: String,
     createApplicationDto: CreateApplicationDto,
   ): ApplicationDto? {
-    return visitSchedulerApplicationsClient.createApplicationForAnExistingVisit(visitReference, VisitSchedulerCreateApplicationDto(createApplicationDto, authenticationHelperService.currentUserName))
+    return visitSchedulerApplicationsClient.createApplicationForAnExistingVisit(visitReference, VisitSchedulerCreateApplicationDto(createApplicationDto))
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/service/ApplicationsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/service/ApplicationsService.kt
@@ -19,7 +19,7 @@ class ApplicationsService(
   }
 
   fun createInitialApplication(createApplicationDto: CreateApplicationDto): ApplicationDto? {
-    return visitSchedulerApplicationsClient.createInitialApplication(VisitSchedulerCreateApplicationDto(createApplicationDto, authenticationHelperService.currentUserName))
+    return visitSchedulerApplicationsClient.createInitialApplication(VisitSchedulerCreateApplicationDto(createApplicationDto, createApplicationDto.createdByReference))
   }
 
   fun changeIncompleteApplication(applicationReference: String, changeApplicationDto: ChangeApplicationDto): ApplicationDto? {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/IntegrationTestBase.kt
@@ -221,6 +221,7 @@ abstract class IntegrationTestBase {
       visitContact = null,
       visitors = setOf(visitor),
       userType = STAFF,
+      actionedBy = "Aled",
     )
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/IntegrationTestBase.kt
@@ -251,7 +251,7 @@ abstract class IntegrationTestBase {
       visitors = visitors!!,
       completed = false,
       reserved = false,
-      userType = PUBLIC
+      userType = PUBLIC,
     )
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/IntegrationTestBase.kt
@@ -25,6 +25,8 @@ import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.vis
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.visit.scheduler.application.CreateApplicationDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.visit.scheduler.enums.CreateApplicationRestriction
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.visit.scheduler.enums.OutcomeStatus
+import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.visit.scheduler.enums.UserType.PUBLIC
+import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.visit.scheduler.enums.UserType.STAFF
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.visit.scheduler.enums.VisitRestriction
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.visit.scheduler.enums.VisitStatus
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.visit.scheduler.enums.VisitType
@@ -218,6 +220,7 @@ abstract class IntegrationTestBase {
       sessionDate = sessionDate!!,
       visitContact = null,
       visitors = setOf(visitor),
+      userType = STAFF,
     )
   }
 
@@ -248,6 +251,7 @@ abstract class IntegrationTestBase {
       visitors = visitors!!,
       completed = false,
       reserved = false,
+      userType = PUBLIC
     )
   }
 


### PR DESCRIPTION
alter application api to cater for public and staff sources

added some extras into these end points.
```
@Schema(description = "actioned by (Booker reference Or User Name)", example = "asd-asd-asd or AFHETTY_GEN", required = true)
@field:NotBlank
val actionedBy: String,
```
Will need to pass down the Booker Reference in the Public UI and in the Staff the User Name