### PR TITLE
VB-3728 Add allowOverBooking to BookingOrchestrationRequestDto

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/dto/orchestration/BookingOrchestrationRequestDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/dto/orchestration/BookingOrchestrationRequestDto.kt
@@ -8,4 +8,7 @@ data class BookingOrchestrationRequestDto(
   @Schema(description = "application method", required = true)
   @field:NotNull
   val applicationMethodType: ApplicationMethodType,
+  @Schema(description = "allow over booking method", required = false)
+  @field:NotNull
+  val allowOverBooking: Boolean = false,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/service/VisitSchedulerService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/service/VisitSchedulerService.kt
@@ -112,7 +112,7 @@ class VisitSchedulerService(
   fun bookVisit(applicationReference: String, requestDto: BookingOrchestrationRequestDto): VisitDto? {
     return visitSchedulerClient.bookVisitSlot(
       applicationReference,
-      BookingRequestDto(authenticationHelperService.currentUserName, requestDto.applicationMethodType),
+      BookingRequestDto(authenticationHelperService.currentUserName, requestDto.applicationMethodType, requestDto.allowOverBooking),
     )
   }
 


### PR DESCRIPTION
Add `allowOverBooking` parameter to `BookingOrchestrationRequestDto` (in #191 it was only added to `BookingRequestDto`.