### PR TITLE
Bug fix: VB-4000 Visitors not showing correctly on past visits

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/client/PrisonerContactRegistryClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/client/PrisonerContactRegistryClient.kt
@@ -35,16 +35,11 @@ class PrisonerContactRegistryClient(
     personId: Long? = null,
     hasDateOfBirth: Boolean? = null,
     notBannedBeforeDate: LocalDate? = null,
-    approvedVisitorsOnly: Boolean = true,
+    approvedVisitorsOnly: Boolean,
   ): List<PrisonerContactDto> {
-    val uri = if (approvedVisitorsOnly) {
-      "/prisoners/$prisonerId/approved/social/contacts"
-    } else {
-      "/prisoners/$prisonerId/contacts/social"
-    }
-
+    val uri = "/prisoners/$prisonerId/contacts/social"
     return webClient.get().uri(uri) {
-      getApprovedSocialContactsUriBuilder(personId, withAddress, hasDateOfBirth, notBannedBeforeDate, it).build()
+      getSocialContactsUriBuilder(personId, withAddress, hasDateOfBirth, notBannedBeforeDate, approvedVisitorsOnly, it).build()
     }
       .retrieve()
       .bodyToMono<List<PrisonerContactDto>>()
@@ -61,17 +56,20 @@ class PrisonerContactRegistryClient(
       .blockOptional(apiTimeout).orElseThrow { NotFoundException("Social Contacts for prisonerId - $prisonerId not found on prisoner-contact-registry") }
   }
 
-  private fun getApprovedSocialContactsUriBuilder(
+  private fun getSocialContactsUriBuilder(
     personId: Long?,
     withAddress: Boolean,
     hasDateOfBirth: Boolean? = null,
     notBannedBeforeDate: LocalDate? = null,
+    approvedVisitorsOnly: Boolean,
     uriBuilder: UriBuilder,
   ): UriBuilder {
     uriBuilder.queryParamIfPresent("id", Optional.ofNullable(personId))
     uriBuilder.queryParamIfPresent("hasDateOfBirth", Optional.ofNullable(hasDateOfBirth))
     uriBuilder.queryParamIfPresent("notBannedBeforeDate", Optional.ofNullable(notBannedBeforeDate))
     uriBuilder.queryParam("withAddress", withAddress)
+    uriBuilder.queryParam("approvedVisitorsOnly", approvedVisitorsOnly)
+
     return uriBuilder
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/client/PrisonerContactRegistryClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/client/PrisonerContactRegistryClient.kt
@@ -35,8 +35,14 @@ class PrisonerContactRegistryClient(
     personId: Long? = null,
     hasDateOfBirth: Boolean? = null,
     notBannedBeforeDate: LocalDate? = null,
+    approvedVisitorsOnly: Boolean = true,
   ): List<PrisonerContactDto> {
-    val uri = "/prisoners/$prisonerId/approved/social/contacts"
+    val uri = if (approvedVisitorsOnly) {
+      "/prisoners/$prisonerId/approved/social/contacts"
+    } else {
+      "/prisoners/$prisonerId/contacts/social"
+    }
+
     return webClient.get().uri(uri) {
       getApprovedSocialContactsUriBuilder(personId, withAddress, hasDateOfBirth, notBannedBeforeDate, it).build()
     }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/client/PrisonerProfileClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/client/PrisonerProfileClient.kt
@@ -63,7 +63,7 @@ class PrisonerProfileClient(
 
   private fun getContactsForPrisoner(prisonerProfile: PrisonerProfileDto): Map<Long?, PrisonerContactDto>? {
     try {
-      val contacts = prisonerContactRegistryClient.getPrisonersSocialContacts(prisonerProfile.prisonerId, withAddress = false)
+      val contacts = prisonerContactRegistryClient.getPrisonersSocialContacts(prisonerProfile.prisonerId, withAddress = false, approvedVisitorsOnly = false)
       return contacts.associateBy { it.personId }
     } catch (e: Exception) {
       // log a message if there is an error but do not terminate the call

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/service/PrisonerContactService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/service/PrisonerContactService.kt
@@ -17,6 +17,6 @@ class PrisonerContactService(
 
   fun getPrisonersSocialContactsWithDOBAndNotBannedBeforeDate(prisonerNumber: String, notBannedBeforeDate: LocalDate): List<PrisonerContactDto> {
     LOG.debug("Getting approved social contacts with a DOB for prisoner - {}, notBannedBeforeDate - {}", prisonerNumber, notBannedBeforeDate)
-    return prisonerContactRegistryClient.getPrisonersSocialContacts(prisonerNumber, withAddress = false, hasDateOfBirth = true, notBannedBeforeDate = notBannedBeforeDate)
+    return prisonerContactRegistryClient.getPrisonersSocialContacts(prisonerNumber, withAddress = false, hasDateOfBirth = true, notBannedBeforeDate = notBannedBeforeDate, approvedVisitorsOnly = true)
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/booker/GetPermittedVisitorsForPermittedPrisonerForBookerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/booker/GetPermittedVisitorsForPermittedPrisonerForBookerTest.kt
@@ -150,7 +150,7 @@ class GetPermittedVisitorsForPermittedPrisonerForBookerTest : IntegrationTestBas
   fun `when booker's prisoners has valid visitors then all allowed visitors are returned`() {
     // Given
     prisonOffenderSearchMockServer.stubGetPrisonerById(PRISONER_ID, prisonerDto)
-    prisonerContactRegistryMockServer.stubGetPrisonerContacts(PRISONER_ID, false, null, true, BAN_END_DATE, contactsList)
+    prisonerContactRegistryMockServer.stubGetPrisonerApprovedContacts(PRISONER_ID, false, null, true, BAN_END_DATE, contactsList)
     visitSchedulerMockServer.stubGetPrison(PRISON_CODE, prisonDto)
     prisonVisitBookerRegistryMockServer.stubGetBookersPrisoners(BOOKER_REFERENCE, listOf(bookerRegistryPrisonerDto))
     prisonVisitBookerRegistryMockServer.stubGetBookersPrisonerVisitors(
@@ -184,7 +184,7 @@ class GetPermittedVisitorsForPermittedPrisonerForBookerTest : IntegrationTestBas
   fun `when booker's prisoners has no valid visitors then no visitors are returned`() {
     // Given
     prisonOffenderSearchMockServer.stubGetPrisonerById(PRISONER_ID, prisonerDto)
-    prisonerContactRegistryMockServer.stubGetPrisonerContacts(PRISONER_ID, false, null, true, BAN_END_DATE, contactsList)
+    prisonerContactRegistryMockServer.stubGetPrisonerApprovedContacts(PRISONER_ID, false, null, true, BAN_END_DATE, contactsList)
     visitSchedulerMockServer.stubGetPrison(PRISON_CODE, prisonDto)
     prisonVisitBookerRegistryMockServer.stubGetBookersPrisoners(BOOKER_REFERENCE, listOf(bookerRegistryPrisonerDto))
     prisonVisitBookerRegistryMockServer.stubGetBookersPrisonerVisitors(
@@ -218,7 +218,7 @@ class GetPermittedVisitorsForPermittedPrisonerForBookerTest : IntegrationTestBas
       null,
     )
     prisonOffenderSearchMockServer.stubGetPrisonerById(PRISONER_ID, prisonerDto)
-    prisonerContactRegistryMockServer.stubGetPrisonerContacts(PRISONER_ID, false, null, true, BAN_END_DATE, contactsList)
+    prisonerContactRegistryMockServer.stubGetPrisonerApprovedContacts(PRISONER_ID, false, null, true, BAN_END_DATE, contactsList)
 
     visitSchedulerMockServer.stubGetPrison(PRISON_CODE, prisonDto)
 
@@ -248,7 +248,7 @@ class GetPermittedVisitorsForPermittedPrisonerForBookerTest : IntegrationTestBas
         PermittedVisitorsForPermittedPrisonerBookerDto(expiredBanVisitor.personId, true),
       ),
     )
-    prisonerContactRegistryMockServer.stubGetPrisonerContacts(PRISONER_ID, false, null, true, BAN_END_DATE, contactsList)
+    prisonerContactRegistryMockServer.stubGetPrisonerApprovedContacts(PRISONER_ID, false, null, true, BAN_END_DATE, contactsList)
     prisonOffenderSearchMockServer.stubGetPrisonerById(PRISONER_ID, prisonerDto)
     visitSchedulerMockServer.stubGetPrison(PRISON_CODE, null)
 
@@ -277,7 +277,7 @@ class GetPermittedVisitorsForPermittedPrisonerForBookerTest : IntegrationTestBas
         PermittedVisitorsForPermittedPrisonerBookerDto(expiredBanVisitor.personId, true),
       ),
     )
-    prisonerContactRegistryMockServer.stubGetPrisonerContacts(PRISONER_ID, false, null, true, BAN_END_DATE, contactsList)
+    prisonerContactRegistryMockServer.stubGetPrisonerApprovedContacts(PRISONER_ID, false, null, true, BAN_END_DATE, contactsList)
     prisonOffenderSearchMockServer.stubGetPrisonerById(PRISONER_ID, prisonerDto)
     visitSchedulerMockServer.stubGetPrison(PRISON_CODE, createPrison(PRISON_CODE, active = false))
 
@@ -306,7 +306,7 @@ class GetPermittedVisitorsForPermittedPrisonerForBookerTest : IntegrationTestBas
         PermittedVisitorsForPermittedPrisonerBookerDto(expiredBanVisitor.personId, true),
       ),
     )
-    prisonerContactRegistryMockServer.stubGetPrisonerContacts(PRISONER_ID, false, null, true, BAN_END_DATE, contactsList)
+    prisonerContactRegistryMockServer.stubGetPrisonerApprovedContacts(PRISONER_ID, false, null, true, BAN_END_DATE, contactsList)
     prisonOffenderSearchMockServer.stubGetPrisonerById(PRISONER_ID, prisonerDto)
 
     // prison only active for STAFF
@@ -344,7 +344,7 @@ class GetPermittedVisitorsForPermittedPrisonerForBookerTest : IntegrationTestBas
         PermittedVisitorsForPermittedPrisonerBookerDto(expiredBanVisitor.personId, true),
       ),
     )
-    prisonerContactRegistryMockServer.stubGetPrisonerContacts(PRISONER_ID, false, null, true, BAN_END_DATE, contactsList)
+    prisonerContactRegistryMockServer.stubGetPrisonerApprovedContacts(PRISONER_ID, false, null, true, BAN_END_DATE, contactsList)
     prisonOffenderSearchMockServer.stubGetPrisonerById(PRISONER_ID, prisonerDto)
 
     // prison only active for STAFF
@@ -382,7 +382,7 @@ class GetPermittedVisitorsForPermittedPrisonerForBookerTest : IntegrationTestBas
       HttpStatus.NOT_FOUND,
     )
 
-    prisonerContactRegistryMockServer.stubGetPrisonerContacts(PRISONER_ID, false, null, true, BAN_END_DATE, contactsList)
+    prisonerContactRegistryMockServer.stubGetPrisonerApprovedContacts(PRISONER_ID, false, null, true, BAN_END_DATE, contactsList)
     prisonOffenderSearchMockServer.stubGetPrisonerById(PRISONER_ID, prisonerDto)
     visitSchedulerMockServer.stubGetPrison(PRISON_CODE, prisonDto)
 
@@ -411,7 +411,7 @@ class GetPermittedVisitorsForPermittedPrisonerForBookerTest : IntegrationTestBas
       HttpStatus.INTERNAL_SERVER_ERROR,
     )
 
-    prisonerContactRegistryMockServer.stubGetPrisonerContacts(PRISONER_ID, false, null, true, BAN_END_DATE, contactsList)
+    prisonerContactRegistryMockServer.stubGetPrisonerApprovedContacts(PRISONER_ID, false, null, true, BAN_END_DATE, contactsList)
     prisonOffenderSearchMockServer.stubGetPrisonerById(PRISONER_ID, prisonerDto)
     visitSchedulerMockServer.stubGetPrison(PRISON_CODE, prisonDto)
 
@@ -444,7 +444,7 @@ class GetPermittedVisitorsForPermittedPrisonerForBookerTest : IntegrationTestBas
     )
 
     // prisoner contact registry returns 404
-    prisonerContactRegistryMockServer.stubGetPrisonerContacts(PRISONER_ID, false, null, true, BAN_END_DATE, null, HttpStatus.NOT_FOUND)
+    prisonerContactRegistryMockServer.stubGetPrisonerApprovedContacts(PRISONER_ID, false, null, true, BAN_END_DATE, null, HttpStatus.NOT_FOUND)
 
     visitSchedulerMockServer.stubGetPrison(PRISON_CODE, prisonDto)
 
@@ -480,7 +480,7 @@ class GetPermittedVisitorsForPermittedPrisonerForBookerTest : IntegrationTestBas
     )
 
     // prisoner contact registry returns INTERNAL_SERVER_ERROR
-    prisonerContactRegistryMockServer.stubGetPrisonerContacts(PRISONER_ID, false, null, true, BAN_END_DATE, null, HttpStatus.INTERNAL_SERVER_ERROR)
+    prisonerContactRegistryMockServer.stubGetPrisonerApprovedContacts(PRISONER_ID, false, null, true, BAN_END_DATE, null, HttpStatus.INTERNAL_SERVER_ERROR)
 
     visitSchedulerMockServer.stubGetPrison(PRISON_CODE, prisonDto)
 
@@ -514,7 +514,7 @@ class GetPermittedVisitorsForPermittedPrisonerForBookerTest : IntegrationTestBas
       ),
     )
 
-    prisonerContactRegistryMockServer.stubGetPrisonerContacts(PRISONER_ID, false, null, true, BAN_END_DATE, contactsList)
+    prisonerContactRegistryMockServer.stubGetPrisonerApprovedContacts(PRISONER_ID, false, null, true, BAN_END_DATE, contactsList)
 
     visitSchedulerMockServer.stubGetPrison(PRISON_CODE, prisonDto)
 
@@ -549,7 +549,7 @@ class GetPermittedVisitorsForPermittedPrisonerForBookerTest : IntegrationTestBas
       ),
     )
 
-    prisonerContactRegistryMockServer.stubGetPrisonerContacts(PRISONER_ID, false, null, true, BAN_END_DATE, contactsList)
+    prisonerContactRegistryMockServer.stubGetPrisonerApprovedContacts(PRISONER_ID, false, null, true, BAN_END_DATE, contactsList)
 
     visitSchedulerMockServer.stubGetPrison(PRISON_CODE, prisonDto)
 
@@ -584,7 +584,7 @@ class GetPermittedVisitorsForPermittedPrisonerForBookerTest : IntegrationTestBas
       ),
     )
 
-    prisonerContactRegistryMockServer.stubGetPrisonerContacts(PRISONER_ID, false, null, true, BAN_END_DATE, contactsList)
+    prisonerContactRegistryMockServer.stubGetPrisonerApprovedContacts(PRISONER_ID, false, null, true, BAN_END_DATE, contactsList)
 
     visitSchedulerMockServer.stubGetPrison(PRISON_CODE, prisonDto)
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/mock/PrisonerContactRegistryMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/mock/PrisonerContactRegistryMockServer.kt
@@ -11,7 +11,7 @@ import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.integra
 import java.time.LocalDate
 
 class PrisonerContactRegistryMockServer : WireMockServer(8095) {
-  fun stubGetPrisonerContacts(
+  fun stubGetPrisonerApprovedContacts(
     prisonerId: String,
     withAddress: Boolean = false,
     personId: Long? = null,
@@ -24,6 +24,32 @@ class PrisonerContactRegistryMockServer : WireMockServer(8095) {
 
     stubFor(
       get("/prisoners/$prisonerId/approved/social/contacts?${getContactsQueryParams(personId, hasDateOfBirth, notBannedBeforeDate, withAddress)}")
+        .willReturn(
+          if (contactsList == null) {
+            responseBuilder
+              .withStatus(httpStatus.value())
+          } else {
+            responseBuilder
+              .withStatus(HttpStatus.OK.value())
+              .withBody(getJsonString(contactsList))
+          },
+        ),
+    )
+  }
+
+  fun stubGetPrisonerContacts(
+    prisonerId: String,
+    withAddress: Boolean = false,
+    personId: Long? = null,
+    hasDateOfBirth: Boolean? = null,
+    notBannedBeforeDate: LocalDate? = null,
+    contactsList: List<PrisonerContactDto>?,
+    httpStatus: HttpStatus = HttpStatus.NOT_FOUND,
+  ) {
+    val responseBuilder = createJsonResponseBuilder()
+
+    stubFor(
+      get("/prisoners/$prisonerId/contacts/social?${getContactsQueryParams(personId, hasDateOfBirth, notBannedBeforeDate, withAddress)}")
         .willReturn(
           if (contactsList == null) {
             responseBuilder

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/prisoner/profile/GetPrisonerProfileTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/prisoner/profile/GetPrisonerProfileTest.kt
@@ -61,9 +61,10 @@ class GetPrisonerProfileTest(
     currentIncentive = currentIncentive,
   )
 
-  private val visitor1 = VisitorDetails(1, "First", "VisitorA")
-  private val visitor2 = VisitorDetails(2, "Second", "VisitorB")
-  private val visitor3 = VisitorDetails(3, "Third", "VisitorC")
+  private val visitor1 = VisitorDetails(1, "First", "VisitorA", approved = false)
+  private val visitor2 = VisitorDetails(2, "Second", "VisitorB", approved = true)
+  private val visitor3 = VisitorDetails(3, "Third", "VisitorC", approved = true)
+  private val visitor4 = VisitorDetails(3, "Third", "VisitorC", approved = false)
 
   private val prison1 = createPrisonNameDto("ABC", "ABC Prison")
   private val prison2 = createPrisonNameDto("DEF", "DEF Prison")
@@ -73,12 +74,13 @@ class GetPrisonerProfileTest(
   private final val alerts = listOf(alert)
   private final val inmateDetailDto = createInmateDetails(PRISONER_ID, PRISONER_CATEGORY, alerts)
   private final val visitBalancesDto = createVisitBalancesDto()
-  private val contactsDto = createContactsList(listOf(visitor1, visitor2, visitor3))
+  private val contactsDto = createContactsList(listOf(visitor1, visitor2, visitor3, visitor4))
   private final val prisonerBookingSummaryDto = createPrisonerBookingSummary(PRISONER_ID, "Convicted")
   private val visit1Visitors = listOf(
     VisitorDto(nomisPersonId = visitor1.personId, visitContact = true),
     VisitorDto(nomisPersonId = visitor2.personId, visitContact = false),
     VisitorDto(nomisPersonId = visitor3.personId, visitContact = false),
+    VisitorDto(nomisPersonId = visitor4.personId, visitContact = true),
   )
 
   private val visit2Visitors = listOf(
@@ -151,7 +153,7 @@ class GetPrisonerProfileTest(
     prisonApiMockServer.stubGetInmateDetails(PRISONER_ID, inmateDetailDto)
     prisonApiMockServer.stubGetBookings(PRISON_CODE, PRISONER_ID, listOf(prisonerBookingSummaryDto))
     prisonApiMockServer.stubGetVisitBalances(PRISONER_ID, visitBalancesDto)
-    prisonerContactRegistryMockServer.stubGetPrisonerContacts(PRISONER_ID, false, null, null, null, contactsDto)
+    prisonerContactRegistryMockServer.stubGetPrisonerApprovedContacts(PRISONER_ID, false, null, null, null, contactsDto)
 
     stubGetVisits(listOf(visit1, visit2))
 
@@ -171,7 +173,7 @@ class GetPrisonerProfileTest(
     prisonApiMockServer.stubGetInmateDetails(PRISONER_ID, null)
     prisonApiMockServer.stubGetBookings(PRISON_CODE, PRISONER_ID, listOf(prisonerBookingSummaryDto))
     prisonApiMockServer.stubGetVisitBalances(PRISONER_ID, visitBalancesDto)
-    prisonerContactRegistryMockServer.stubGetPrisonerContacts(PRISONER_ID, false, null, null, null, contactsDto, HttpStatus.NOT_FOUND)
+    prisonerContactRegistryMockServer.stubGetPrisonerApprovedContacts(PRISONER_ID, false, null, null, null, contactsDto, HttpStatus.NOT_FOUND)
     stubGetVisits(listOf(visit1, visit2))
 
     // When
@@ -370,10 +372,11 @@ class GetPrisonerProfileTest(
     Assertions.assertThat(prisonerProfile.visits).isNotEmpty
 
     val visit1Visitors = prisonerProfile.visits[0].visitors
-    Assertions.assertThat(visit1Visitors?.size).isEqualTo(3)
+    Assertions.assertThat(visit1Visitors?.size).isEqualTo(4)
     assertVisitorDetails(visit1Visitors?.get(0)!!, visitor1.personId, visitor1.firstName, visitor1.lastName)
     assertVisitorDetails(visit1Visitors[1], visitor2.personId, visitor2.firstName, visitor2.lastName)
     assertVisitorDetails(visit1Visitors[2], visitor3.personId, visitor3.firstName, visitor3.lastName)
+    assertVisitorDetails(visit1Visitors[3], visitor4.personId, visitor4.firstName, visitor4.lastName)
 
     val visit2Visitors = prisonerProfile.visits[1].visitors
     Assertions.assertThat(visit2Visitors).isNotNull
@@ -381,7 +384,7 @@ class GetPrisonerProfileTest(
 
     verifyExternalAPIClientCalls()
     // verify the call to prisoner contact registry is only done once
-    verify(prisonerContactRegistryClientSpy, times(1)).getPrisonersSocialContacts(any(), eq(false), isNull(), isNull(), isNull())
+    verify(prisonerContactRegistryClientSpy, times(1)).getPrisonersSocialContacts(any(), eq(false), isNull(), isNull(), isNull(), eq(false))
   }
 
   @Test
@@ -423,7 +426,7 @@ class GetPrisonerProfileTest(
 
     verifyExternalAPIClientCalls()
     // verify the call to prisoner contact registry is made once
-    verify(prisonerContactRegistryClientSpy, times(1)).getPrisonersSocialContacts(any(), eq(false), isNull(), isNull(), isNull())
+    verify(prisonerContactRegistryClientSpy, times(1)).getPrisonersSocialContacts(any(), eq(false), isNull(), isNull(), isNull(), eq(false))
   }
 
   @Test
@@ -459,7 +462,7 @@ class GetPrisonerProfileTest(
 
     verifyExternalAPIClientCalls()
     // verify the call to prisoner contact registry is made once
-    verify(prisonerContactRegistryClientSpy, times(1)).getPrisonersSocialContacts(any(), eq(false), isNull(), isNull(), isNull())
+    verify(prisonerContactRegistryClientSpy, times(1)).getPrisonersSocialContacts(any(), eq(false), isNull(), isNull(), isNull(), eq(false))
   }
 
   @Test
@@ -495,7 +498,7 @@ class GetPrisonerProfileTest(
 
     verifyExternalAPIClientCalls()
     // verify the call to prisoner contact registry is made once
-    verify(prisonerContactRegistryClientSpy, times(1)).getPrisonersSocialContacts(any(), eq(false), isNull(), isNull(), isNull())
+    verify(prisonerContactRegistryClientSpy, times(1)).getPrisonersSocialContacts(any(), eq(false), isNull(), isNull(), isNull(), eq(false))
   }
 
   @Test


### PR DESCRIPTION
Call different endpoint for visitor information to include unapproved visitors in profile

A bug was discovered where visitors from past visits, who have been unapproved, show up as undefined in visit history on prisoner profile page.

Fixing by calling endpoint to get all social contacts instead of just approved