### PR TITLE
VB-4000 - Fix issue where unapproved visitors were not displaying correctly

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/client/PrisonerContactRegistryClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/client/PrisonerContactRegistryClient.kt
@@ -32,13 +32,14 @@ class PrisonerContactRegistryClient(
   fun getPrisonersSocialContacts(
     prisonerId: String,
     withAddress: Boolean,
+    approvedVisitorsOnly: Boolean,
     personId: Long? = null,
     hasDateOfBirth: Boolean? = null,
     notBannedBeforeDate: LocalDate? = null,
   ): List<PrisonerContactDto> {
-    val uri = "/prisoners/$prisonerId/approved/social/contacts"
+    val uri = "/prisoners/$prisonerId/contacts/social"
     return webClient.get().uri(uri) {
-      getApprovedSocialContactsUriBuilder(personId, withAddress, hasDateOfBirth, notBannedBeforeDate, it).build()
+      getSocialContactsUriBuilder(personId, withAddress, hasDateOfBirth, notBannedBeforeDate, approvedVisitorsOnly, it).build()
     }
       .retrieve()
       .bodyToMono<List<PrisonerContactDto>>()
@@ -55,17 +56,19 @@ class PrisonerContactRegistryClient(
       .blockOptional(apiTimeout).orElseThrow { NotFoundException("Social Contacts for prisonerId - $prisonerId not found on prisoner-contact-registry") }
   }
 
-  private fun getApprovedSocialContactsUriBuilder(
+  private fun getSocialContactsUriBuilder(
     personId: Long?,
     withAddress: Boolean,
     hasDateOfBirth: Boolean? = null,
     notBannedBeforeDate: LocalDate? = null,
+    approvedVisitorsOnly: Boolean,
     uriBuilder: UriBuilder,
   ): UriBuilder {
     uriBuilder.queryParamIfPresent("id", Optional.ofNullable(personId))
     uriBuilder.queryParamIfPresent("hasDateOfBirth", Optional.ofNullable(hasDateOfBirth))
     uriBuilder.queryParamIfPresent("notBannedBeforeDate", Optional.ofNullable(notBannedBeforeDate))
     uriBuilder.queryParam("withAddress", withAddress)
+    uriBuilder.queryParam("approvedVisitorsOnly", approvedVisitorsOnly)
     return uriBuilder
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/client/PrisonerProfileClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/client/PrisonerProfileClient.kt
@@ -63,7 +63,7 @@ class PrisonerProfileClient(
 
   private fun getContactsForPrisoner(prisonerProfile: PrisonerProfileDto): Map<Long?, PrisonerContactDto>? {
     try {
-      val contacts = prisonerContactRegistryClient.getPrisonersSocialContacts(prisonerProfile.prisonerId, withAddress = false)
+      val contacts = prisonerContactRegistryClient.getPrisonersSocialContacts(prisonerProfile.prisonerId, withAddress = false, approvedVisitorsOnly = false)
       return contacts.associateBy { it.personId }
     } catch (e: Exception) {
       // log a message if there is an error but do not terminate the call

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/service/PrisonerContactService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/service/PrisonerContactService.kt
@@ -17,6 +17,6 @@ class PrisonerContactService(
 
   fun getPrisonersSocialContactsWithDOBAndNotBannedBeforeDate(prisonerNumber: String, notBannedBeforeDate: LocalDate): List<PrisonerContactDto> {
     LOG.debug("Getting approved social contacts with a DOB for prisoner - {}, notBannedBeforeDate - {}", prisonerNumber, notBannedBeforeDate)
-    return prisonerContactRegistryClient.getPrisonersSocialContacts(prisonerNumber, withAddress = false, hasDateOfBirth = true, notBannedBeforeDate = notBannedBeforeDate)
+    return prisonerContactRegistryClient.getPrisonersSocialContacts(prisonerNumber, withAddress = false, approvedVisitorsOnly = true, hasDateOfBirth = true, notBannedBeforeDate = notBannedBeforeDate)
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/booker/GetPermittedVisitorsForPermittedPrisonerForBookerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/booker/GetPermittedVisitorsForPermittedPrisonerForBookerTest.kt
@@ -150,7 +150,7 @@ class GetPermittedVisitorsForPermittedPrisonerForBookerTest : IntegrationTestBas
   fun `when booker's prisoners has valid visitors then all allowed visitors are returned`() {
     // Given
     prisonOffenderSearchMockServer.stubGetPrisonerById(PRISONER_ID, prisonerDto)
-    prisonerContactRegistryMockServer.stubGetPrisonerContacts(PRISONER_ID, false, null, true, BAN_END_DATE, contactsList)
+    prisonerContactRegistryMockServer.stubGetPrisonerContacts(PRISONER_ID, withAddress = false, approvedVisitorsOnly = true, null, true, BAN_END_DATE, contactsList)
     visitSchedulerMockServer.stubGetPrison(PRISON_CODE, prisonDto)
     prisonVisitBookerRegistryMockServer.stubGetBookersPrisoners(BOOKER_REFERENCE, listOf(bookerRegistryPrisonerDto))
     prisonVisitBookerRegistryMockServer.stubGetBookersPrisonerVisitors(
@@ -177,14 +177,14 @@ class GetPermittedVisitorsForPermittedPrisonerForBookerTest : IntegrationTestBas
     verify(prisonVisitBookerRegistryClientSpy, times(1)).getPermittedVisitorsForBookersAssociatedPrisoner(BOOKER_REFERENCE, PRISONER_ID)
     verify(prisonerSearchClientSpy, times(1)).getPrisonerById(PRISONER_ID)
     verify(visitSchedulerClientSpy, times(1)).getPrison(PRISON_CODE)
-    verify(prisonerContactRegistryClientSpy, times(1)).getPrisonersSocialContacts(PRISONER_ID, false, null, true, BAN_END_DATE)
+    verify(prisonerContactRegistryClientSpy, times(1)).getPrisonersSocialContacts(PRISONER_ID, withAddress = false, approvedVisitorsOnly = true, null, true, BAN_END_DATE)
   }
 
   @Test
   fun `when booker's prisoners has no valid visitors then no visitors are returned`() {
     // Given
     prisonOffenderSearchMockServer.stubGetPrisonerById(PRISONER_ID, prisonerDto)
-    prisonerContactRegistryMockServer.stubGetPrisonerContacts(PRISONER_ID, false, null, true, BAN_END_DATE, contactsList)
+    prisonerContactRegistryMockServer.stubGetPrisonerContacts(PRISONER_ID, withAddress = false, approvedVisitorsOnly = true, null, true, BAN_END_DATE, contactsList)
     visitSchedulerMockServer.stubGetPrison(PRISON_CODE, prisonDto)
     prisonVisitBookerRegistryMockServer.stubGetBookersPrisoners(BOOKER_REFERENCE, listOf(bookerRegistryPrisonerDto))
     prisonVisitBookerRegistryMockServer.stubGetBookersPrisonerVisitors(
@@ -206,7 +206,7 @@ class GetPermittedVisitorsForPermittedPrisonerForBookerTest : IntegrationTestBas
     verify(prisonVisitBookerRegistryClientSpy, times(1)).getPermittedVisitorsForBookersAssociatedPrisoner(BOOKER_REFERENCE, PRISONER_ID)
     verify(prisonerSearchClientSpy, times(1)).getPrisonerById(PRISONER_ID)
     verify(visitSchedulerClientSpy, times(1)).getPrison(PRISON_CODE)
-    verify(prisonerContactRegistryClientSpy, times(0)).getPrisonersSocialContacts(PRISONER_ID, false)
+    verify(prisonerContactRegistryClientSpy, times(0)).getPrisonersSocialContacts(PRISONER_ID, withAddress = false, approvedVisitorsOnly = true)
   }
 
   @Test
@@ -218,7 +218,7 @@ class GetPermittedVisitorsForPermittedPrisonerForBookerTest : IntegrationTestBas
       null,
     )
     prisonOffenderSearchMockServer.stubGetPrisonerById(PRISONER_ID, prisonerDto)
-    prisonerContactRegistryMockServer.stubGetPrisonerContacts(PRISONER_ID, false, null, true, BAN_END_DATE, contactsList)
+    prisonerContactRegistryMockServer.stubGetPrisonerContacts(PRISONER_ID, withAddress = false, approvedVisitorsOnly = true, null, true, BAN_END_DATE, contactsList)
 
     visitSchedulerMockServer.stubGetPrison(PRISON_CODE, prisonDto)
 
@@ -233,7 +233,7 @@ class GetPermittedVisitorsForPermittedPrisonerForBookerTest : IntegrationTestBas
     verify(prisonVisitBookerRegistryClientSpy, times(0)).getPermittedVisitorsForBookersAssociatedPrisoner(BOOKER_REFERENCE, PRISONER_ID)
     verify(prisonerSearchClientSpy, times(0)).getPrisonerById(PRISONER_ID)
     verify(visitSchedulerClientSpy, times(0)).getPrison(PRISON_CODE)
-    verify(prisonerContactRegistryClientSpy, times(0)).getPrisonersSocialContacts(PRISONER_ID, false)
+    verify(prisonerContactRegistryClientSpy, times(0)).getPrisonersSocialContacts(PRISONER_ID, withAddress = false, approvedVisitorsOnly = true)
   }
 
   @Test
@@ -248,7 +248,7 @@ class GetPermittedVisitorsForPermittedPrisonerForBookerTest : IntegrationTestBas
         PermittedVisitorsForPermittedPrisonerBookerDto(expiredBanVisitor.personId, true),
       ),
     )
-    prisonerContactRegistryMockServer.stubGetPrisonerContacts(PRISONER_ID, false, null, true, BAN_END_DATE, contactsList)
+    prisonerContactRegistryMockServer.stubGetPrisonerContacts(PRISONER_ID, withAddress = false, approvedVisitorsOnly = true, null, true, BAN_END_DATE, contactsList)
     prisonOffenderSearchMockServer.stubGetPrisonerById(PRISONER_ID, prisonerDto)
     visitSchedulerMockServer.stubGetPrison(PRISON_CODE, null)
 
@@ -262,7 +262,7 @@ class GetPermittedVisitorsForPermittedPrisonerForBookerTest : IntegrationTestBas
     verify(prisonerSearchClientSpy, times(1)).getPrisonerById(PRISONER_ID)
     verify(prisonVisitBookerRegistryClientSpy, times(0)).getPermittedVisitorsForBookersAssociatedPrisoner(BOOKER_REFERENCE, PRISONER_ID)
     verify(visitSchedulerClientSpy, times(1)).getPrison(PRISON_CODE)
-    verify(prisonerContactRegistryClientSpy, times(0)).getPrisonersSocialContacts(PRISONER_ID, false)
+    verify(prisonerContactRegistryClientSpy, times(0)).getPrisonersSocialContacts(PRISONER_ID, withAddress = false, approvedVisitorsOnly = true)
   }
 
   @Test
@@ -277,7 +277,7 @@ class GetPermittedVisitorsForPermittedPrisonerForBookerTest : IntegrationTestBas
         PermittedVisitorsForPermittedPrisonerBookerDto(expiredBanVisitor.personId, true),
       ),
     )
-    prisonerContactRegistryMockServer.stubGetPrisonerContacts(PRISONER_ID, false, null, true, BAN_END_DATE, contactsList)
+    prisonerContactRegistryMockServer.stubGetPrisonerContacts(PRISONER_ID, withAddress = false, approvedVisitorsOnly = true, null, true, BAN_END_DATE, contactsList)
     prisonOffenderSearchMockServer.stubGetPrisonerById(PRISONER_ID, prisonerDto)
     visitSchedulerMockServer.stubGetPrison(PRISON_CODE, createPrison(PRISON_CODE, active = false))
 
@@ -291,7 +291,7 @@ class GetPermittedVisitorsForPermittedPrisonerForBookerTest : IntegrationTestBas
     verify(prisonerSearchClientSpy, times(1)).getPrisonerById(PRISONER_ID)
     verify(prisonVisitBookerRegistryClientSpy, times(0)).getPermittedVisitorsForBookersAssociatedPrisoner(BOOKER_REFERENCE, PRISONER_ID)
     verify(visitSchedulerClientSpy, times(1)).getPrison(PRISON_CODE)
-    verify(prisonerContactRegistryClientSpy, times(0)).getPrisonersSocialContacts(PRISONER_ID, false)
+    verify(prisonerContactRegistryClientSpy, times(0)).getPrisonersSocialContacts(PRISONER_ID, withAddress = false, approvedVisitorsOnly = true)
   }
 
   @Test
@@ -306,7 +306,7 @@ class GetPermittedVisitorsForPermittedPrisonerForBookerTest : IntegrationTestBas
         PermittedVisitorsForPermittedPrisonerBookerDto(expiredBanVisitor.personId, true),
       ),
     )
-    prisonerContactRegistryMockServer.stubGetPrisonerContacts(PRISONER_ID, false, null, true, BAN_END_DATE, contactsList)
+    prisonerContactRegistryMockServer.stubGetPrisonerContacts(PRISONER_ID, withAddress = false, approvedVisitorsOnly = true, null, true, BAN_END_DATE, contactsList)
     prisonOffenderSearchMockServer.stubGetPrisonerById(PRISONER_ID, prisonerDto)
 
     // prison only active for STAFF
@@ -329,7 +329,7 @@ class GetPermittedVisitorsForPermittedPrisonerForBookerTest : IntegrationTestBas
     verify(prisonerSearchClientSpy, times(1)).getPrisonerById(PRISONER_ID)
     verify(prisonVisitBookerRegistryClientSpy, times(0)).getPermittedVisitorsForBookersAssociatedPrisoner(BOOKER_REFERENCE, PRISONER_ID)
     verify(visitSchedulerClientSpy, times(1)).getPrison(PRISON_CODE)
-    verify(prisonerContactRegistryClientSpy, times(0)).getPrisonersSocialContacts(PRISONER_ID, false)
+    verify(prisonerContactRegistryClientSpy, times(0)).getPrisonersSocialContacts(PRISONER_ID, withAddress = false, approvedVisitorsOnly = true)
   }
 
   @Test
@@ -344,7 +344,7 @@ class GetPermittedVisitorsForPermittedPrisonerForBookerTest : IntegrationTestBas
         PermittedVisitorsForPermittedPrisonerBookerDto(expiredBanVisitor.personId, true),
       ),
     )
-    prisonerContactRegistryMockServer.stubGetPrisonerContacts(PRISONER_ID, false, null, true, BAN_END_DATE, contactsList)
+    prisonerContactRegistryMockServer.stubGetPrisonerContacts(PRISONER_ID, withAddress = false, approvedVisitorsOnly = true, null, true, BAN_END_DATE, contactsList)
     prisonOffenderSearchMockServer.stubGetPrisonerById(PRISONER_ID, prisonerDto)
 
     // prison only active for STAFF
@@ -367,7 +367,7 @@ class GetPermittedVisitorsForPermittedPrisonerForBookerTest : IntegrationTestBas
     verify(prisonerSearchClientSpy, times(1)).getPrisonerById(PRISONER_ID)
     verify(prisonVisitBookerRegistryClientSpy, times(0)).getPermittedVisitorsForBookersAssociatedPrisoner(BOOKER_REFERENCE, PRISONER_ID)
     verify(visitSchedulerClientSpy, times(1)).getPrison(PRISON_CODE)
-    verify(prisonerContactRegistryClientSpy, times(0)).getPrisonersSocialContacts(PRISONER_ID, false)
+    verify(prisonerContactRegistryClientSpy, times(0)).getPrisonersSocialContacts(PRISONER_ID, withAddress = false, approvedVisitorsOnly = true)
   }
 
   @Test
@@ -382,7 +382,7 @@ class GetPermittedVisitorsForPermittedPrisonerForBookerTest : IntegrationTestBas
       HttpStatus.NOT_FOUND,
     )
 
-    prisonerContactRegistryMockServer.stubGetPrisonerContacts(PRISONER_ID, false, null, true, BAN_END_DATE, contactsList)
+    prisonerContactRegistryMockServer.stubGetPrisonerContacts(PRISONER_ID, withAddress = false, approvedVisitorsOnly = true, null, true, BAN_END_DATE, contactsList)
     prisonOffenderSearchMockServer.stubGetPrisonerById(PRISONER_ID, prisonerDto)
     visitSchedulerMockServer.stubGetPrison(PRISON_CODE, prisonDto)
 
@@ -397,7 +397,7 @@ class GetPermittedVisitorsForPermittedPrisonerForBookerTest : IntegrationTestBas
     verify(visitSchedulerClientSpy, times(1)).getPrison(PRISON_CODE)
     verify(prisonerSearchClientSpy, times(1)).getPrisonerById(PRISONER_ID)
     verify(prisonVisitBookerRegistryClientSpy, times(1)).getPermittedVisitorsForBookersAssociatedPrisoner(BOOKER_REFERENCE, PRISONER_ID)
-    verify(prisonerContactRegistryClientSpy, times(0)).getPrisonersSocialContacts(PRISONER_ID, false)
+    verify(prisonerContactRegistryClientSpy, times(0)).getPrisonersSocialContacts(PRISONER_ID, withAddress = false, approvedVisitorsOnly = true)
   }
 
   @Test
@@ -411,7 +411,7 @@ class GetPermittedVisitorsForPermittedPrisonerForBookerTest : IntegrationTestBas
       HttpStatus.INTERNAL_SERVER_ERROR,
     )
 
-    prisonerContactRegistryMockServer.stubGetPrisonerContacts(PRISONER_ID, false, null, true, BAN_END_DATE, contactsList)
+    prisonerContactRegistryMockServer.stubGetPrisonerContacts(PRISONER_ID, withAddress = false, approvedVisitorsOnly = true, null, true, BAN_END_DATE, contactsList)
     prisonOffenderSearchMockServer.stubGetPrisonerById(PRISONER_ID, prisonerDto)
     visitSchedulerMockServer.stubGetPrison(PRISON_CODE, prisonDto)
 
@@ -425,7 +425,7 @@ class GetPermittedVisitorsForPermittedPrisonerForBookerTest : IntegrationTestBas
     verify(prisonVisitBookerRegistryClientSpy, times(1)).getPermittedVisitorsForBookersAssociatedPrisoner(BOOKER_REFERENCE, PRISONER_ID)
     verify(prisonerSearchClientSpy, times(1)).getPrisonerById(PRISONER_ID)
     verify(visitSchedulerClientSpy, times(1)).getPrison(PRISON_CODE)
-    verify(prisonerContactRegistryClientSpy, times(0)).getPrisonersSocialContacts(PRISONER_ID, false)
+    verify(prisonerContactRegistryClientSpy, times(0)).getPrisonersSocialContacts(PRISONER_ID, withAddress = false, approvedVisitorsOnly = true)
   }
 
   @Test
@@ -444,7 +444,7 @@ class GetPermittedVisitorsForPermittedPrisonerForBookerTest : IntegrationTestBas
     )
 
     // prisoner contact registry returns 404
-    prisonerContactRegistryMockServer.stubGetPrisonerContacts(PRISONER_ID, false, null, true, BAN_END_DATE, null, HttpStatus.NOT_FOUND)
+    prisonerContactRegistryMockServer.stubGetPrisonerContacts(PRISONER_ID, withAddress = false, approvedVisitorsOnly = true, null, true, BAN_END_DATE, null, HttpStatus.NOT_FOUND)
 
     visitSchedulerMockServer.stubGetPrison(PRISON_CODE, prisonDto)
 
@@ -461,7 +461,7 @@ class GetPermittedVisitorsForPermittedPrisonerForBookerTest : IntegrationTestBas
     verify(prisonVisitBookerRegistryClientSpy, times(1)).getPermittedVisitorsForBookersAssociatedPrisoner(BOOKER_REFERENCE, PRISONER_ID)
     verify(prisonerSearchClientSpy, times(1)).getPrisonerById(PRISONER_ID)
     verify(visitSchedulerClientSpy, times(1)).getPrison(PRISON_CODE)
-    verify(prisonerContactRegistryClientSpy, times(1)).getPrisonersSocialContacts(PRISONER_ID, false, null, true, BAN_END_DATE)
+    verify(prisonerContactRegistryClientSpy, times(1)).getPrisonersSocialContacts(PRISONER_ID, withAddress = false, approvedVisitorsOnly = true, null, true, BAN_END_DATE)
   }
 
   @Test
@@ -480,7 +480,7 @@ class GetPermittedVisitorsForPermittedPrisonerForBookerTest : IntegrationTestBas
     )
 
     // prisoner contact registry returns INTERNAL_SERVER_ERROR
-    prisonerContactRegistryMockServer.stubGetPrisonerContacts(PRISONER_ID, false, null, true, BAN_END_DATE, null, HttpStatus.INTERNAL_SERVER_ERROR)
+    prisonerContactRegistryMockServer.stubGetPrisonerContacts(PRISONER_ID, withAddress = false, approvedVisitorsOnly = true, null, true, BAN_END_DATE, null, HttpStatus.INTERNAL_SERVER_ERROR)
 
     visitSchedulerMockServer.stubGetPrison(PRISON_CODE, prisonDto)
 
@@ -493,7 +493,7 @@ class GetPermittedVisitorsForPermittedPrisonerForBookerTest : IntegrationTestBas
     verify(prisonVisitBookerRegistryClientSpy, times(1)).getPermittedVisitorsForPermittedPrisonerAndBooker(BOOKER_REFERENCE)
     verify(prisonVisitBookerRegistryClientSpy, times(1)).getPermittedVisitorsForBookersAssociatedPrisoner(BOOKER_REFERENCE, PRISONER_ID)
     verify(prisonerSearchClientSpy, times(1)).getPrisonerById(PRISONER_ID)
-    verify(prisonerContactRegistryClientSpy, times(1)).getPrisonersSocialContacts(PRISONER_ID, false, null, true, BAN_END_DATE)
+    verify(prisonerContactRegistryClientSpy, times(1)).getPrisonersSocialContacts(PRISONER_ID, withAddress = false, approvedVisitorsOnly = true, null, true, BAN_END_DATE)
     verify(visitSchedulerClientSpy, times(1)).getPrison(PRISON_CODE)
   }
 
@@ -514,7 +514,7 @@ class GetPermittedVisitorsForPermittedPrisonerForBookerTest : IntegrationTestBas
       ),
     )
 
-    prisonerContactRegistryMockServer.stubGetPrisonerContacts(PRISONER_ID, false, null, true, BAN_END_DATE, contactsList)
+    prisonerContactRegistryMockServer.stubGetPrisonerContacts(PRISONER_ID, withAddress = false, approvedVisitorsOnly = true, null, true, BAN_END_DATE, contactsList)
 
     visitSchedulerMockServer.stubGetPrison(PRISON_CODE, prisonDto)
 
@@ -528,7 +528,7 @@ class GetPermittedVisitorsForPermittedPrisonerForBookerTest : IntegrationTestBas
     verify(prisonVisitBookerRegistryClientSpy, times(1)).getPermittedVisitorsForPermittedPrisonerAndBooker(BOOKER_REFERENCE)
     verify(prisonVisitBookerRegistryClientSpy, times(0)).getPermittedVisitorsForBookersAssociatedPrisoner(BOOKER_REFERENCE, PRISONER_ID)
     verify(prisonerSearchClientSpy, times(1)).getPrisonerById(PRISONER_ID)
-    verify(prisonerContactRegistryClientSpy, times(0)).getPrisonersSocialContacts(PRISONER_ID, false)
+    verify(prisonerContactRegistryClientSpy, times(0)).getPrisonersSocialContacts(PRISONER_ID, withAddress = false, approvedVisitorsOnly = true)
     verify(visitSchedulerClientSpy, times(0)).getPrison(PRISON_CODE)
   }
 
@@ -549,7 +549,7 @@ class GetPermittedVisitorsForPermittedPrisonerForBookerTest : IntegrationTestBas
       ),
     )
 
-    prisonerContactRegistryMockServer.stubGetPrisonerContacts(PRISONER_ID, false, null, true, BAN_END_DATE, contactsList)
+    prisonerContactRegistryMockServer.stubGetPrisonerContacts(PRISONER_ID, withAddress = false, approvedVisitorsOnly = true, null, true, BAN_END_DATE, contactsList)
 
     visitSchedulerMockServer.stubGetPrison(PRISON_CODE, prisonDto)
 
@@ -563,7 +563,7 @@ class GetPermittedVisitorsForPermittedPrisonerForBookerTest : IntegrationTestBas
     verify(prisonVisitBookerRegistryClientSpy, times(1)).getPermittedVisitorsForPermittedPrisonerAndBooker(BOOKER_REFERENCE)
     verify(prisonVisitBookerRegistryClientSpy, times(0)).getPermittedVisitorsForBookersAssociatedPrisoner(BOOKER_REFERENCE, PRISONER_ID)
     verify(prisonerSearchClientSpy, times(1)).getPrisonerById(PRISONER_ID)
-    verify(prisonerContactRegistryClientSpy, times(0)).getPrisonersSocialContacts(PRISONER_ID, false)
+    verify(prisonerContactRegistryClientSpy, times(0)).getPrisonersSocialContacts(PRISONER_ID, withAddress = false, approvedVisitorsOnly = true)
     verify(visitSchedulerClientSpy, times(0)).getPrison(PRISON_CODE)
   }
 
@@ -584,7 +584,7 @@ class GetPermittedVisitorsForPermittedPrisonerForBookerTest : IntegrationTestBas
       ),
     )
 
-    prisonerContactRegistryMockServer.stubGetPrisonerContacts(PRISONER_ID, false, null, true, BAN_END_DATE, contactsList)
+    prisonerContactRegistryMockServer.stubGetPrisonerContacts(PRISONER_ID, withAddress = false, approvedVisitorsOnly = true, null, true, BAN_END_DATE, contactsList)
 
     visitSchedulerMockServer.stubGetPrison(PRISON_CODE, prisonDto)
 
@@ -597,7 +597,7 @@ class GetPermittedVisitorsForPermittedPrisonerForBookerTest : IntegrationTestBas
     verify(prisonVisitBookerRegistryClientSpy, times(1)).getPermittedVisitorsForPermittedPrisonerAndBooker(BOOKER_REFERENCE)
     verify(prisonVisitBookerRegistryClientSpy, times(0)).getPermittedVisitorsForBookersAssociatedPrisoner(BOOKER_REFERENCE, PRISONER_ID)
     verify(prisonerSearchClientSpy, times(1)).getPrisonerById(PRISONER_ID)
-    verify(prisonerContactRegistryClientSpy, times(0)).getPrisonersSocialContacts(PRISONER_ID, false)
+    verify(prisonerContactRegistryClientSpy, times(0)).getPrisonersSocialContacts(PRISONER_ID, withAddress = false, approvedVisitorsOnly = true)
     verify(visitSchedulerClientSpy, times(0)).getPrison(PRISON_CODE)
   }
 
@@ -615,7 +615,7 @@ class GetPermittedVisitorsForPermittedPrisonerForBookerTest : IntegrationTestBas
     verify(prisonVisitBookerRegistryClientSpy, times(0)).getPermittedVisitorsForPermittedPrisonerAndBooker(BOOKER_REFERENCE)
     verify(prisonVisitBookerRegistryClientSpy, times(0)).getPermittedVisitorsForBookersAssociatedPrisoner(BOOKER_REFERENCE, PRISONER_ID)
     verify(prisonerSearchClientSpy, times(0)).getPrisonerById(PRISONER_ID)
-    verify(prisonerContactRegistryClientSpy, times(0)).getPrisonersSocialContacts(PRISONER_ID, false)
+    verify(prisonerContactRegistryClientSpy, times(0)).getPrisonersSocialContacts(PRISONER_ID, withAddress = false, approvedVisitorsOnly = true)
     verify(visitSchedulerClientSpy, times(0)).getPrison(PRISON_CODE)
   }
 
@@ -631,7 +631,7 @@ class GetPermittedVisitorsForPermittedPrisonerForBookerTest : IntegrationTestBas
     verify(prisonVisitBookerRegistryClientSpy, times(0)).getPermittedVisitorsForPermittedPrisonerAndBooker(BOOKER_REFERENCE)
     verify(prisonVisitBookerRegistryClientSpy, times(0)).getPermittedVisitorsForBookersAssociatedPrisoner(BOOKER_REFERENCE, PRISONER_ID)
     verify(prisonerSearchClientSpy, times(0)).getPrisonerById(PRISONER_ID)
-    verify(prisonerContactRegistryClientSpy, times(0)).getPrisonersSocialContacts(PRISONER_ID, false, null, true, null)
+    verify(prisonerContactRegistryClientSpy, times(0)).getPrisonersSocialContacts(PRISONER_ID, withAddress = false, approvedVisitorsOnly = true, null, true, null)
     verify(visitSchedulerClientSpy, times(0)).getPrison(PRISON_CODE)
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/mock/PrisonerContactRegistryMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/mock/PrisonerContactRegistryMockServer.kt
@@ -14,6 +14,7 @@ class PrisonerContactRegistryMockServer : WireMockServer(8095) {
   fun stubGetPrisonerContacts(
     prisonerId: String,
     withAddress: Boolean = false,
+    approvedVisitorsOnly: Boolean = true,
     personId: Long? = null,
     hasDateOfBirth: Boolean? = null,
     notBannedBeforeDate: LocalDate? = null,
@@ -23,7 +24,7 @@ class PrisonerContactRegistryMockServer : WireMockServer(8095) {
     val responseBuilder = createJsonResponseBuilder()
 
     stubFor(
-      get("/prisoners/$prisonerId/approved/social/contacts?${getContactsQueryParams(personId, hasDateOfBirth, notBannedBeforeDate, withAddress)}")
+      get("/prisoners/$prisonerId/contacts/social?${getContactsQueryParams(personId, hasDateOfBirth, notBannedBeforeDate, withAddress, approvedVisitorsOnly)}")
         .willReturn(
           if (contactsList == null) {
             responseBuilder
@@ -87,6 +88,7 @@ class PrisonerContactRegistryMockServer : WireMockServer(8095) {
     hasDateOfBirth: Boolean? = null,
     notBannedBeforeDate: LocalDate? = null,
     withAddress: Boolean? = null,
+    approvedVisitorsOnly: Boolean? = null,
   ): String {
     val queryParams = ArrayList<String>()
     personId?.let {
@@ -100,6 +102,9 @@ class PrisonerContactRegistryMockServer : WireMockServer(8095) {
     }
     withAddress?.let {
       queryParams.add("withAddress=$it")
+    }
+    approvedVisitorsOnly?.let {
+      queryParams.add("approvedVisitorsOnly=$it")
     }
 
     return queryParams.joinToString("&")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/prisoner/profile/GetPrisonerProfileTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/prisoner/profile/GetPrisonerProfileTest.kt
@@ -151,7 +151,7 @@ class GetPrisonerProfileTest(
     prisonApiMockServer.stubGetInmateDetails(PRISONER_ID, inmateDetailDto)
     prisonApiMockServer.stubGetBookings(PRISON_CODE, PRISONER_ID, listOf(prisonerBookingSummaryDto))
     prisonApiMockServer.stubGetVisitBalances(PRISONER_ID, visitBalancesDto)
-    prisonerContactRegistryMockServer.stubGetPrisonerContacts(PRISONER_ID, false, null, null, null, contactsDto)
+    prisonerContactRegistryMockServer.stubGetPrisonerContacts(PRISONER_ID, withAddress = false, approvedVisitorsOnly = false, null, null, null, contactsDto)
 
     stubGetVisits(listOf(visit1, visit2))
 
@@ -171,7 +171,7 @@ class GetPrisonerProfileTest(
     prisonApiMockServer.stubGetInmateDetails(PRISONER_ID, null)
     prisonApiMockServer.stubGetBookings(PRISON_CODE, PRISONER_ID, listOf(prisonerBookingSummaryDto))
     prisonApiMockServer.stubGetVisitBalances(PRISONER_ID, visitBalancesDto)
-    prisonerContactRegistryMockServer.stubGetPrisonerContacts(PRISONER_ID, false, null, null, null, contactsDto, HttpStatus.NOT_FOUND)
+    prisonerContactRegistryMockServer.stubGetPrisonerContacts(PRISONER_ID, withAddress = false, approvedVisitorsOnly = false, null, null, null, contactsDto, HttpStatus.NOT_FOUND)
     stubGetVisits(listOf(visit1, visit2))
 
     // When
@@ -356,7 +356,7 @@ class GetPrisonerProfileTest(
     prisonApiMockServer.stubGetInmateDetails(PRISONER_ID, inmateDetailDto)
     prisonApiMockServer.stubGetBookings(PRISON_CODE, PRISONER_ID, listOf(prisonerBookingSummaryDto))
     prisonApiMockServer.stubGetVisitBalances(PRISONER_ID, visitBalancesDto)
-    prisonerContactRegistryMockServer.stubGetPrisonerContacts(PRISONER_ID, false, null, null, null, contactsDto)
+    prisonerContactRegistryMockServer.stubGetPrisonerContacts(PRISONER_ID, withAddress = false, approvedVisitorsOnly = false, null, null, null, contactsDto)
     stubGetVisits(listOf(visit1, visit2))
 
     // When
@@ -381,7 +381,7 @@ class GetPrisonerProfileTest(
 
     verifyExternalAPIClientCalls()
     // verify the call to prisoner contact registry is only done once
-    verify(prisonerContactRegistryClientSpy, times(1)).getPrisonersSocialContacts(any(), eq(false), isNull(), isNull(), isNull())
+    verify(prisonerContactRegistryClientSpy, times(1)).getPrisonersSocialContacts(any(), eq(false), eq(false), isNull(), isNull(), isNull())
   }
 
   @Test
@@ -400,7 +400,7 @@ class GetPrisonerProfileTest(
     prisonApiMockServer.stubGetInmateDetails(PRISONER_ID, inmateDetailDto)
     prisonApiMockServer.stubGetBookings(PRISON_CODE, PRISONER_ID, listOf(prisonerBookingSummaryDto))
     prisonApiMockServer.stubGetVisitBalances(PRISONER_ID, visitBalancesDto)
-    prisonerContactRegistryMockServer.stubGetPrisonerContacts(PRISONER_ID, false, null, null, null, contactsDto)
+    prisonerContactRegistryMockServer.stubGetPrisonerContacts(PRISONER_ID, withAddress = false, approvedVisitorsOnly = false, null, null, null, contactsDto)
     stubGetVisits(listOf(visit3))
 
     // When
@@ -423,7 +423,7 @@ class GetPrisonerProfileTest(
 
     verifyExternalAPIClientCalls()
     // verify the call to prisoner contact registry is made once
-    verify(prisonerContactRegistryClientSpy, times(1)).getPrisonersSocialContacts(any(), eq(false), isNull(), isNull(), isNull())
+    verify(prisonerContactRegistryClientSpy, times(1)).getPrisonersSocialContacts(any(), eq(false), eq(false), isNull(), isNull(), isNull())
   }
 
   @Test
@@ -435,7 +435,7 @@ class GetPrisonerProfileTest(
     prisonApiMockServer.stubGetVisitBalances(PRISONER_ID, visitBalancesDto)
 
     // as we are passing null as contacts parameter a 404 will be returned
-    prisonerContactRegistryMockServer.stubGetPrisonerContacts(PRISONER_ID, false, null, null, null, null)
+    prisonerContactRegistryMockServer.stubGetPrisonerContacts(PRISONER_ID, withAddress = false, approvedVisitorsOnly = false, null, null, null, null)
     stubGetVisits(listOf(visit1, visit2))
 
     // When
@@ -459,7 +459,7 @@ class GetPrisonerProfileTest(
 
     verifyExternalAPIClientCalls()
     // verify the call to prisoner contact registry is made once
-    verify(prisonerContactRegistryClientSpy, times(1)).getPrisonersSocialContacts(any(), eq(false), isNull(), isNull(), isNull())
+    verify(prisonerContactRegistryClientSpy, times(1)).getPrisonersSocialContacts(any(), eq(false), eq(false), isNull(), isNull(), isNull())
   }
 
   @Test
@@ -471,7 +471,7 @@ class GetPrisonerProfileTest(
     prisonApiMockServer.stubGetVisitBalances(PRISONER_ID, visitBalancesDto)
 
     // as we are passing null as contacts parameter a 404 will be returned
-    prisonerContactRegistryMockServer.stubGetPrisonerContacts(PRISONER_ID, false, null, null, null, null, HttpStatus.BAD_REQUEST)
+    prisonerContactRegistryMockServer.stubGetPrisonerContacts(PRISONER_ID, withAddress = false, approvedVisitorsOnly = false, null, null, null, null, HttpStatus.BAD_REQUEST)
     stubGetVisits(listOf(visit1, visit2))
 
     // When
@@ -495,7 +495,7 @@ class GetPrisonerProfileTest(
 
     verifyExternalAPIClientCalls()
     // verify the call to prisoner contact registry is made once
-    verify(prisonerContactRegistryClientSpy, times(1)).getPrisonersSocialContacts(any(), eq(false), isNull(), isNull(), isNull())
+    verify(prisonerContactRegistryClientSpy, times(1)).getPrisonersSocialContacts(any(), eq(false), eq(false), isNull(), isNull(), isNull())
   }
 
   @Test
@@ -505,7 +505,7 @@ class GetPrisonerProfileTest(
     prisonApiMockServer.stubGetInmateDetails(PRISONER_ID, inmateDetailDto)
     prisonApiMockServer.stubGetBookings(PRISON_CODE, PRISONER_ID, listOf(prisonerBookingSummaryDto))
     prisonApiMockServer.stubGetVisitBalances(PRISONER_ID, visitBalancesDto)
-    prisonerContactRegistryMockServer.stubGetPrisonerContacts(PRISONER_ID, false, null, null, null, contactsDto)
+    prisonerContactRegistryMockServer.stubGetPrisonerContacts(PRISONER_ID, withAddress = false, approvedVisitorsOnly = false, null, null, null, contactsDto)
     prisonRegisterMockServer.stubGetPrisons(prisons)
     stubGetVisits(listOf(visit1, visit2))
 
@@ -537,7 +537,7 @@ class GetPrisonerProfileTest(
     prisonApiMockServer.stubGetInmateDetails(PRISONER_ID, inmateDetailDto)
     prisonApiMockServer.stubGetBookings(PRISON_CODE, PRISONER_ID, listOf(prisonerBookingSummaryDto))
     prisonApiMockServer.stubGetVisitBalances(PRISONER_ID, visitBalancesDto)
-    prisonerContactRegistryMockServer.stubGetPrisonerContacts(PRISONER_ID, false, null, null, null, contactsDto)
+    prisonerContactRegistryMockServer.stubGetPrisonerContacts(PRISONER_ID, withAddress = false, approvedVisitorsOnly = false, null, null, null, contactsDto)
     prisonRegisterMockServer.stubGetPrisons(prisons)
     stubGetVisits(listOf(incorrectPrisonVisit))
 
@@ -566,7 +566,7 @@ class GetPrisonerProfileTest(
     prisonApiMockServer.stubGetInmateDetails(PRISONER_ID, inmateDetailDto)
     prisonApiMockServer.stubGetBookings(PRISON_CODE, PRISONER_ID, listOf(prisonerBookingSummaryDto))
     prisonApiMockServer.stubGetVisitBalances(PRISONER_ID, visitBalancesDto)
-    prisonerContactRegistryMockServer.stubGetPrisonerContacts(PRISONER_ID, false, null, null, null, contactsDto)
+    prisonerContactRegistryMockServer.stubGetPrisonerContacts(PRISONER_ID, withAddress = false, approvedVisitorsOnly = false, null, null, null, contactsDto)
 
     // as we are passing null as prisons parameter a 404 will be returned
     prisonRegisterMockServer.stubGetPrisons(null)
@@ -597,7 +597,7 @@ class GetPrisonerProfileTest(
     prisonApiMockServer.stubGetInmateDetails(PRISONER_ID, inmateDetailDto)
     prisonApiMockServer.stubGetBookings(PRISON_CODE, PRISONER_ID, listOf(prisonerBookingSummaryDto))
     prisonApiMockServer.stubGetVisitBalances(PRISONER_ID, visitBalancesDto)
-    prisonerContactRegistryMockServer.stubGetPrisonerContacts(PRISONER_ID, false, null, null, null, contactsDto)
+    prisonerContactRegistryMockServer.stubGetPrisonerContacts(PRISONER_ID, withAddress = false, approvedVisitorsOnly = false, null, null, null, contactsDto)
 
     // as we are passing null as prisons parameter a BAD_REQUEST will be returned
     prisonRegisterMockServer.stubGetPrisons(null)


### PR DESCRIPTION
## What does this PR do?

Bug: On the prisoner profile, if a visitor had been unapproved, the past visits they attended would have their name as "undefined". This was due to our API only returning approved visitors.

Fix / Rework: Change the orchestration to use a new endpoint on the prisoner-contact-registry which takes a flag "approvedVisitorsOnly".

The prisoner profile will pass in false for this endpoint and other calls will pass in true to preserve original functionality.

## JIRA Internal Link
https://dsdmoj.atlassian.net/browse/VB-4000