### PR TITLE
VB-4368 - Move visits event publishing outside of transaction

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/service/VisitSchedulerService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/service/VisitSchedulerService.kt
@@ -120,7 +120,13 @@ class VisitSchedulerService(
   }
 
   fun bookVisit(applicationReference: String, requestDto: BookingOrchestrationRequestDto): VisitDto? {
-    return visitSchedulerClient.bookVisitSlot(
+    val existingBooking = visitSchedulerClient.getBookedVisitByApplicationReference(applicationReference)
+    return existingBooking?.let {
+      visitSchedulerClient.updateBookedVisit(
+        applicationReference,
+        BookingRequestDto(requestDto.actionedBy, requestDto.applicationMethodType, requestDto.allowOverBooking),
+      )
+    } ?: visitSchedulerClient.bookVisitSlot(
       applicationReference,
       BookingRequestDto(requestDto.actionedBy, requestDto.applicationMethodType, requestDto.allowOverBooking),
     )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/mock/VisitSchedulerMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/mock/VisitSchedulerMockServer.kt
@@ -244,6 +244,38 @@ class VisitSchedulerMockServer : WireMockServer(8092) {
     )
   }
 
+  fun stubUpdateVisit(applicationReference: String, visitDto: VisitDto?) {
+    val responseBuilder = createJsonResponseBuilder()
+
+    stubFor(
+      put("/visits/$applicationReference/visit/update")
+        .willReturn(
+          if (visitDto == null) {
+            responseBuilder.withStatus(HttpStatus.NOT_FOUND.value())
+          } else {
+            responseBuilder.withStatus(HttpStatus.OK.value())
+              .withBody(getJsonString(visitDto))
+          },
+        ),
+    )
+  }
+
+  fun stubGetBookedVisitByApplicationReference(applicationReference: String, existingVisitDto: VisitDto?) {
+    val responseBuilder = createJsonResponseBuilder()
+
+    stubFor(
+      get("/visits/$applicationReference/visit")
+        .willReturn(
+          if (existingVisitDto == null) {
+            responseBuilder.withStatus(HttpStatus.NOT_FOUND.value())
+          } else {
+            responseBuilder.withStatus(HttpStatus.OK.value())
+              .withBody(getJsonString(existingVisitDto))
+          },
+        ),
+    )
+  }
+
   fun stubBookVisitApplicationValidationFailure(applicationReference: String, errorResponse: ApplicationValidationErrorResponse) {
     val responseBuilder = createJsonResponseBuilder()
 
@@ -261,6 +293,37 @@ class VisitSchedulerMockServer : WireMockServer(8092) {
 
     stubFor(
       put("/visits/$applicationReference/book")
+        .willReturn(
+          responseBuilder.withStatus(HttpStatus.UNPROCESSABLE_ENTITY.value())
+            .withBody(
+              """{
+                "status": 422,
+                "validationErrors": [
+                  "INVALID_APPLICATION_VALIDATION_RESPONSE"
+                  ]
+                }""",
+            ),
+        ),
+    )
+  }
+
+  fun stubUpdateVisitApplicationValidationFailure(applicationReference: String, errorResponse: ApplicationValidationErrorResponse) {
+    val responseBuilder = createJsonResponseBuilder()
+
+    stubFor(
+      put("/visits/$applicationReference/visit/update")
+        .willReturn(
+          responseBuilder.withStatus(HttpStatus.UNPROCESSABLE_ENTITY.value())
+            .withBody(getJsonString(errorResponse)),
+        ),
+    )
+  }
+
+  fun stubUpdateVisitApplicationValidationFailureInvalid(applicationReference: String) {
+    val responseBuilder = createJsonResponseBuilder()
+
+    stubFor(
+      put("/visits/$applicationReference/visit/update")
         .willReturn(
           responseBuilder.withStatus(HttpStatus.UNPROCESSABLE_ENTITY.value())
             .withBody(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/visit/BookVisitTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/visit/BookVisitTest.kt
@@ -23,6 +23,7 @@ class BookVisitTest : IntegrationTestBase() {
     val applicationReference = "aaa-bbb-ccc-ddd"
     val reference = "aa-bb-cc-dd"
     val visitDto = createVisitDto(reference = reference, applicationReference = applicationReference)
+    visitSchedulerMockServer.stubGetBookedVisitByApplicationReference(applicationReference, null)
     visitSchedulerMockServer.stubBookVisit(applicationReference, visitDto)
     val requestDto = BookingOrchestrationRequestDto(actionedBy = "booker", EMAIL)
 
@@ -40,6 +41,7 @@ class BookVisitTest : IntegrationTestBase() {
     // Given
     val applicationReference = "aaa-bbb-ccc-ddd"
     val visitDto = null
+    visitSchedulerMockServer.stubGetBookedVisitByApplicationReference(applicationReference, null)
     visitSchedulerMockServer.stubBookVisit(applicationReference, visitDto)
 
     val requestDto = BookingOrchestrationRequestDto(actionedBy = "booker", EMAIL)
@@ -55,6 +57,7 @@ class BookVisitTest : IntegrationTestBase() {
   fun `when book visit slot fails application validation then UNPROCESSABLE_ENTITY status is returned`() {
     // Given
     val applicationReference = "aaa-bbb-ccc-ddd"
+    visitSchedulerMockServer.stubGetBookedVisitByApplicationReference(applicationReference, null)
     visitSchedulerMockServer.stubBookVisitApplicationValidationFailure(
       applicationReference,
       ApplicationValidationErrorResponse(
@@ -80,9 +83,94 @@ class BookVisitTest : IntegrationTestBase() {
   fun `when book visit slot fails application validation parsing then INTERNAL_SERVER_ERROR status is returned`() {
     // Given
     val applicationReference = "aaa-bbb-ccc-ddd"
+    visitSchedulerMockServer.stubGetBookedVisitByApplicationReference(applicationReference, null)
     visitSchedulerMockServer.stubBookVisitApplicationValidationFailureInvalid(
       applicationReference,
     )
+
+    val requestDto = BookingOrchestrationRequestDto(actionedBy = "booker", EMAIL)
+
+    // When
+    val responseSpec = callBookVisit(webTestClient, applicationReference, requestDto, roleVSIPOrchestrationServiceHttpHeaders)
+
+    // Then
+    responseSpec.expectStatus().isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR)
+  }
+
+  @Test
+  fun `when update visit slot is successful then OK status is returned`() {
+    // Given
+    val applicationReference = "aaa-bbb-ccc-ddd"
+    val reference = "aa-bb-cc-dd"
+    val visitDto = createVisitDto(reference = reference, applicationReference = applicationReference)
+    visitSchedulerMockServer.stubGetBookedVisitByApplicationReference(applicationReference, visitDto)
+    visitSchedulerMockServer.stubUpdateVisit(applicationReference, visitDto)
+    val requestDto = BookingOrchestrationRequestDto(actionedBy = "booker", EMAIL)
+
+    // When
+    val responseSpec = callBookVisit(webTestClient, applicationReference, requestDto, roleVSIPOrchestrationServiceHttpHeaders)
+
+    // Then
+    responseSpec.expectStatus().isOk
+      .expectBody()
+      .jsonPath("$.reference").isEqualTo(reference)
+  }
+
+  @Test
+  fun `when update visit slot is unsuccessful then NOT_FOUND status is returned`() {
+    // Given
+    val applicationReference = "aaa-bbb-ccc-ddd"
+    val reference = "aa-bb-cc-dd"
+    val visitDto = createVisitDto(reference = reference, applicationReference = applicationReference)
+    visitSchedulerMockServer.stubGetBookedVisitByApplicationReference(applicationReference, visitDto)
+    visitSchedulerMockServer.stubUpdateVisit(applicationReference, null)
+
+    val requestDto = BookingOrchestrationRequestDto(actionedBy = "booker", EMAIL)
+
+    // When
+    val responseSpec = callBookVisit(webTestClient, applicationReference, requestDto, roleVSIPOrchestrationServiceHttpHeaders)
+
+    // Then
+    responseSpec.expectStatus().isNotFound
+  }
+
+  @Test
+  fun `when update visit slot fails application validation then UNPROCESSABLE_ENTITY status is returned`() {
+    // Given
+    val applicationReference = "aaa-bbb-ccc-ddd"
+    val reference = "aa-bb-cc-dd"
+    val visitDto = createVisitDto(reference = reference, applicationReference = applicationReference)
+    visitSchedulerMockServer.stubGetBookedVisitByApplicationReference(applicationReference, visitDto)
+
+    visitSchedulerMockServer.stubUpdateVisitApplicationValidationFailure(
+      applicationReference,
+      ApplicationValidationErrorResponse(
+        status = HttpStatus.UNPROCESSABLE_ENTITY.value(),
+        validationErrors = listOf(APPLICATION_INVALID_NON_ASSOCIATION_VISITS, APPLICATION_INVALID_NO_VO_BALANCE),
+      ),
+    )
+
+    val requestDto = BookingOrchestrationRequestDto(actionedBy = "booker", EMAIL)
+
+    // When
+    val responseSpec = callBookVisit(webTestClient, applicationReference, requestDto, roleVSIPOrchestrationServiceHttpHeaders)
+
+    // Then
+    responseSpec.expectStatus().isEqualTo(HttpStatus.UNPROCESSABLE_ENTITY)
+    val errorResponse = getValidationErrorResponse(responseSpec)
+    assertThat(errorResponse.validationErrors.size).isEqualTo(2)
+    assertThat(errorResponse.validationErrors).contains(APPLICATION_INVALID_NON_ASSOCIATION_VISITS)
+    assertThat(errorResponse.validationErrors).contains(APPLICATION_INVALID_NO_VO_BALANCE)
+  }
+
+  @Test
+  fun `when update visit slot fails application validation parsing then INTERNAL_SERVER_ERROR status is returned`() {
+    // Given
+    val applicationReference = "aaa-bbb-ccc-ddd"
+    val reference = "aa-bb-cc-dd"
+    val visitDto = createVisitDto(reference = reference, applicationReference = applicationReference)
+    visitSchedulerMockServer.stubGetBookedVisitByApplicationReference(applicationReference, visitDto)
+    visitSchedulerMockServer.stubUpdateVisitApplicationValidationFailureInvalid(applicationReference)
 
     val requestDto = BookingOrchestrationRequestDto(actionedBy = "booker", EMAIL)
 


### PR DESCRIPTION
## What does this PR do?
As part of a rework on the visit-scheduler, the create and update endpoints have been split from their original combined /book endpoint.

To stop the frontend needing to do any extra logic, the orchestration service will figure this out and direct to the right endpoint