### PR TITLE
VB-3901 - Use personId to capture visitorId not contactPersonid

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/service/listeners/events/additionalinfo/PersonRestrictionUpsertedInfo.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/service/listeners/events/additionalinfo/PersonRestrictionUpsertedInfo.kt
@@ -11,7 +11,7 @@ data class PersonRestrictionUpsertedInfo(
   val prisonerNumber: String,
 
   @NotBlank
-  @JsonProperty("contactPersonId")
+  @JsonProperty("personId")
   val visitorId: String,
 
   @NotBlank

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/domainevents/PrisonVisitsEventsIntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/domainevents/PrisonVisitsEventsIntegrationTestBase.kt
@@ -255,7 +255,7 @@ abstract class PrisonVisitsEventsIntegrationTestBase {
       jsonValues["nomsNumber"] = nomsNumber
     }
     visitorId?.let {
-      jsonValues["contactPersonId"] = visitorId
+      jsonValues["personId"] = visitorId
     }
     effectiveDate?.let {
       jsonValues["effectiveDate"] = effectiveDate


### PR DESCRIPTION
## What does this PR do?
A change was made on NOMIS side for this event, to include the personId (visitorId). That is the field we want to be listening to.

## JIRA Link
https://dsdmoj.atlassian.net/browse/VB-3901