### PR TITLE
VB-4507 - Allow the overriding of the opening and closing booking window for public and pvb services

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/controller/OrchestrationSessionsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/controller/OrchestrationSessionsController.kt
@@ -147,6 +147,12 @@ class OrchestrationSessionsController(private val visitSchedulerSessionsService:
       description = "Advances the available visits slots sought from date by n days. Defaults to 0 if not passed.",
     )
     advanceFromDateByDays: Int? = 0,
+    @RequestParam(value = "fromDateOverride", required = false)
+    @Parameter(description = "minimum override in days for opening session slot booking window, E.g. 2 will set min booking window to today + 2 days")
+    fromDateOverride: Int? = null,
+    @RequestParam(value = "toDateOverride", required = false)
+    @Parameter(description = "maximum override in days for closing session slot booking window, E.g. 28 will set max booking window to today + 28 days")
+    toDateOverride: Int? = null,
     @RequestParam(value = "username", required = false)
     @Parameter(
       description = "Username for the user making the request. Used to exclude user's pending applications from session capacity count. Optional, ignored if not passed in.",
@@ -162,6 +168,8 @@ class OrchestrationSessionsController(private val visitSchedulerSessionsService:
       withAppointmentsCheck = withAppointmentsCheck ?: true,
       excludedApplicationReference = excludedApplicationReference,
       advanceFromDateByDays = advanceFromDateByDays ?: 0,
+      fromDateOverride = fromDateOverride,
+      toDateOverride = toDateOverride,
       username = username,
     )
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/controller/OrchestrationSessionsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/controller/OrchestrationSessionsController.kt
@@ -143,10 +143,9 @@ class OrchestrationSessionsController(private val visitSchedulerSessionsService:
       example = "dfs-wjs-eqr",
     )
     excludedApplicationReference: String? = null,
-    @Parameter(
-      description = "Advances the available visits slots sought from date by n days. Defaults to 0 if not passed.",
-    )
-    advanceFromDateByDays: Int? = 0,
+    @RequestParam(value = "pvbAdvanceFromDateByDays", required = false)
+    @Parameter(description = "For PVB only. Allows service to advance the opening session slot booking window by n days on top of any other overrides. Defaults to 0 if not passed.")
+    pvbAdvanceFromDateByDays: Int? = 0,
     @RequestParam(value = "fromDateOverride", required = false)
     @Parameter(description = "minimum override in days for opening session slot booking window, E.g. 2 will set min booking window to today + 2 days")
     fromDateOverride: Int? = null,
@@ -167,7 +166,7 @@ class OrchestrationSessionsController(private val visitSchedulerSessionsService:
       visitors = visitors,
       withAppointmentsCheck = withAppointmentsCheck ?: true,
       excludedApplicationReference = excludedApplicationReference,
-      advanceFromDateByDays = advanceFromDateByDays ?: 0,
+      pvbAdvanceFromDateByDays = pvbAdvanceFromDateByDays ?: 0,
       fromDateOverride = fromDateOverride,
       toDateOverride = toDateOverride,
       username = username,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/service/PrisonService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/service/PrisonService.kt
@@ -89,9 +89,11 @@ class PrisonService(
 
   fun getToDaysBookableDateRange(
     prisonCode: String,
+    fromDateOverride: Int? = null,
+    toDateOverride: Int? = null,
   ): DateRange {
     val prison = visitSchedulerClient.getPrison(prisonCode)
-    return dateUtils.getToDaysDateRange(prison)
+    return dateUtils.getToDaysDateRange(prison = prison, minOverride = fromDateOverride, maxOverride = toDateOverride)
   }
 
   private fun getExcludeDatesForPrison(prisonCode: String): List<PrisonExcludeDateDto> {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/service/VisitSchedulerSessionsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/service/VisitSchedulerSessionsService.kt
@@ -44,7 +44,7 @@ class VisitSchedulerSessionsService(
     visitors: List<Long>?,
     withAppointmentsCheck: Boolean,
     excludedApplicationReference: String? = null,
-    advanceFromDateByDays: Int,
+    pvbAdvanceFromDateByDays: Int,
     fromDateOverride: Int? = null,
     toDateOverride: Int? = null,
     username: String? = null,
@@ -53,7 +53,7 @@ class VisitSchedulerSessionsService(
 
     // advance from date by n days
     var dateRange = prisonService.getToDaysBookableDateRange(prisonCode = prisonCode, fromDateOverride = fromDateOverride, toDateOverride = toDateOverride)
-    dateRange = dateUtils.advanceFromDate(dateRange, advanceFromDateByDays)
+    dateRange = dateUtils.advanceFromDate(dateRange, pvbAdvanceFromDateByDays)
 
     var availableVisitSessions = try {
       val updatedDateRange =

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/service/VisitSchedulerSessionsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/service/VisitSchedulerSessionsService.kt
@@ -45,12 +45,14 @@ class VisitSchedulerSessionsService(
     withAppointmentsCheck: Boolean,
     excludedApplicationReference: String? = null,
     advanceFromDateByDays: Int,
+    fromDateOverride: Int? = null,
+    toDateOverride: Int? = null,
     username: String? = null,
   ): List<AvailableVisitSessionDto> {
     val sessionRestriction = updateRequestedRestriction(requestedSessionRestriction, prisonerId, visitors)
 
     // advance from date by n days
-    var dateRange = prisonService.getToDaysBookableDateRange(prisonCode)
+    var dateRange = prisonService.getToDaysBookableDateRange(prisonCode = prisonCode, fromDateOverride = fromDateOverride, toDateOverride = toDateOverride)
     dateRange = dateUtils.advanceFromDate(dateRange, advanceFromDateByDays)
 
     var availableVisitSessions = try {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/utils/DateUtils.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/utils/DateUtils.kt
@@ -22,10 +22,10 @@ class DateUtils {
     return DateRange(bookableStartDate, bookableEndDate)
   }
 
-  fun advanceFromDate(dateRange: DateRange, advanceFromDateByDays: Int): DateRange {
-    // if advanceFromDateByDays is greater than zero and new from date is before toDate
-    if (advanceFromDateByDays > 0) {
-      val fromDate = dateRange.fromDate.plusDays(advanceFromDateByDays.toLong())
+  fun advanceFromDate(dateRange: DateRange, pvbAdvanceFromDateByDays: Int): DateRange {
+    // if pvbAdvanceFromDateByDays is greater than zero and new from date is before toDate
+    if (pvbAdvanceFromDateByDays > 0) {
+      val fromDate = dateRange.fromDate.plusDays(pvbAdvanceFromDateByDays.toLong())
 
       // check if new fromDate is before or equal to toDate
       if (fromDate <= dateRange.toDate) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/utils/DateUtils.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/utils/DateUtils.kt
@@ -23,7 +23,7 @@ class DateUtils {
   }
 
   fun advanceFromDate(dateRange: DateRange, advanceFromDateByDays: Int): DateRange {
-    // if advanceFromDateByDays is greater than zero and new from date is beofre toDate
+    // if advanceFromDateByDays is greater than zero and new from date is before toDate
     if (advanceFromDateByDays > 0) {
       val fromDate = dateRange.fromDate.plusDays(advanceFromDateByDays.toLong())
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/IntegrationTestBase.kt
@@ -425,6 +425,8 @@ abstract class IntegrationTestBase {
     authHttpHeaders: (HttpHeaders) -> Unit,
     excludedApplicationReference: String? = null,
     advanceFromDateByDays: Int? = null,
+    fromDateOverride: Int? = null,
+    toDateOverride: Int? = null,
     currentUser: String? = null,
   ): WebTestClient.ResponseSpec {
     val uri = "/visit-sessions/available"
@@ -437,6 +439,8 @@ abstract class IntegrationTestBase {
         visitorIds = visitorIds,
         withAppointmentsCheck = withAppointmentsCheck,
         excludedApplicationReference = excludedApplicationReference,
+        fromDateOverride = fromDateOverride,
+        toDateOverride = toDateOverride,
         advanceFromDateByDays = advanceFromDateByDays,
       ).joinToString("&")
 
@@ -570,6 +574,8 @@ abstract class IntegrationTestBase {
     withAppointmentsCheck: Boolean,
     excludedApplicationReference: String?,
     advanceFromDateByDays: Int?,
+    fromDateOverride: Int? = null,
+    toDateOverride: Int? = null,
     currentUser: String? = null,
   ): List<String> {
     val queryParams = java.util.ArrayList<String>()
@@ -586,6 +592,12 @@ abstract class IntegrationTestBase {
     }
     advanceFromDateByDays?.let {
       queryParams.add("advanceFromDateByDays=$advanceFromDateByDays")
+    }
+    fromDateOverride?.let {
+      queryParams.add("fromDateOverride=$fromDateOverride")
+    }
+    toDateOverride?.let {
+      queryParams.add("toDateOverride=$toDateOverride")
     }
     currentUser?.let {
       queryParams.add("currentUser=$currentUser")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/IntegrationTestBase.kt
@@ -424,7 +424,7 @@ abstract class IntegrationTestBase {
     withAppointmentsCheck: Boolean,
     authHttpHeaders: (HttpHeaders) -> Unit,
     excludedApplicationReference: String? = null,
-    advanceFromDateByDays: Int? = null,
+    pvbAdvanceFromDateByDays: Int? = null,
     fromDateOverride: Int? = null,
     toDateOverride: Int? = null,
     currentUser: String? = null,
@@ -441,7 +441,7 @@ abstract class IntegrationTestBase {
         excludedApplicationReference = excludedApplicationReference,
         fromDateOverride = fromDateOverride,
         toDateOverride = toDateOverride,
-        advanceFromDateByDays = advanceFromDateByDays,
+        pvbAdvanceFromDateByDays = pvbAdvanceFromDateByDays,
       ).joinToString("&")
 
     return webTestClient.get().uri("$uri?$uriParams")
@@ -573,7 +573,7 @@ abstract class IntegrationTestBase {
     visitorIds: List<Long>? = null,
     withAppointmentsCheck: Boolean,
     excludedApplicationReference: String?,
-    advanceFromDateByDays: Int?,
+    pvbAdvanceFromDateByDays: Int?,
     fromDateOverride: Int? = null,
     toDateOverride: Int? = null,
     currentUser: String? = null,
@@ -590,8 +590,8 @@ abstract class IntegrationTestBase {
     excludedApplicationReference?.let {
       queryParams.add("excludedApplicationReference=$excludedApplicationReference")
     }
-    advanceFromDateByDays?.let {
-      queryParams.add("advanceFromDateByDays=$advanceFromDateByDays")
+    pvbAdvanceFromDateByDays?.let {
+      queryParams.add("pvbAdvanceFromDateByDays=$pvbAdvanceFromDateByDays")
     }
     fromDateOverride?.let {
       queryParams.add("fromDateOverride=$fromDateOverride")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/sessions/AvailableVisitSessionsDateRangeTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/sessions/AvailableVisitSessionsDateRangeTest.kt
@@ -40,7 +40,7 @@ class AvailableVisitSessionsDateRangeTest : IntegrationTestBase() {
   }
 
   @Test
-  fun `when advanceFromDateByDays is not passed the original date range is passed`() {
+  fun `when pvbAdvanceFromDateByDays is not passed the original date range is passed`() {
     // Given
     visitSchedulerMockServer.stubGetAvailableVisitSessions(visitSchedulerPrisonDto, prisonerId, OPEN, mutableListOf(visitSession1, visitSession2, visitSession3))
 
@@ -58,7 +58,7 @@ class AvailableVisitSessionsDateRangeTest : IntegrationTestBase() {
       sessionRestriction = OPEN,
       withAppointmentsCheck = true,
       excludedApplicationReference = null,
-      advanceFromDateByDays = null,
+      pvbAdvanceFromDateByDays = null,
       authHttpHeaders = roleVSIPOrchestrationServiceHttpHeaders,
     )
     // Then
@@ -66,14 +66,14 @@ class AvailableVisitSessionsDateRangeTest : IntegrationTestBase() {
   }
 
   @Test
-  fun `when advanceFromDateByDays is passed as 1 the original date range from date is moved by 1`() {
+  fun `when pvbAdvanceFromDateByDays is passed as 1 the original date range from date is moved by 1`() {
     // Given
-    val advanceFromDateByDays = 1
+    val pvbAdvanceFromDateByDays = 1
     visitSchedulerMockServer.stubGetAvailableVisitSessions(visitSchedulerPrisonDto, prisonerId, OPEN, mutableListOf(visitSession1, visitSession2, visitSession3))
 
     // appointment is not on the same date as the visits
     val dateRange = DateRange(
-      fromDate = LocalDate.now().plusDays(visitSchedulerPrisonDto.policyNoticeDaysMin.toLong() + advanceFromDateByDays),
+      fromDate = LocalDate.now().plusDays(visitSchedulerPrisonDto.policyNoticeDaysMin.toLong() + pvbAdvanceFromDateByDays),
       toDate = LocalDate.now().plusDays(visitSchedulerPrisonDto.policyNoticeDaysMax.toLong()),
     )
 
@@ -85,7 +85,7 @@ class AvailableVisitSessionsDateRangeTest : IntegrationTestBase() {
       sessionRestriction = OPEN,
       withAppointmentsCheck = true,
       excludedApplicationReference = null,
-      advanceFromDateByDays = advanceFromDateByDays,
+      pvbAdvanceFromDateByDays = pvbAdvanceFromDateByDays,
       authHttpHeaders = roleVSIPOrchestrationServiceHttpHeaders,
     )
 
@@ -94,14 +94,14 @@ class AvailableVisitSessionsDateRangeTest : IntegrationTestBase() {
   }
 
   @Test
-  fun `when advanceFromDateByDays is passed as 3 the original date range from date is moved by 3`() {
+  fun `when pvbAdvanceFromDateByDays is passed as 3 the original date range from date is moved by 3`() {
     // Given
-    val advanceFromDateByDays = 3
+    val pvbAdvanceFromDateByDays = 3
     visitSchedulerMockServer.stubGetAvailableVisitSessions(visitSchedulerPrisonDto, prisonerId, OPEN, mutableListOf(visitSession1, visitSession2, visitSession3))
 
     // appointment is not on the same date as the visits
     val dateRange = DateRange(
-      fromDate = LocalDate.now().plusDays(visitSchedulerPrisonDto.policyNoticeDaysMin.toLong() + advanceFromDateByDays.toLong()),
+      fromDate = LocalDate.now().plusDays(visitSchedulerPrisonDto.policyNoticeDaysMin.toLong() + pvbAdvanceFromDateByDays.toLong()),
       toDate = LocalDate.now().plusDays(visitSchedulerPrisonDto.policyNoticeDaysMax.toLong()),
     )
 
@@ -113,7 +113,7 @@ class AvailableVisitSessionsDateRangeTest : IntegrationTestBase() {
       sessionRestriction = OPEN,
       withAppointmentsCheck = true,
       excludedApplicationReference = null,
-      advanceFromDateByDays = advanceFromDateByDays,
+      pvbAdvanceFromDateByDays = pvbAdvanceFromDateByDays,
       authHttpHeaders = roleVSIPOrchestrationServiceHttpHeaders,
     )
 
@@ -122,14 +122,14 @@ class AvailableVisitSessionsDateRangeTest : IntegrationTestBase() {
   }
 
   @Test
-  fun `when advanceFromDateByDays is passed as 0 the original date range from date is not moved`() {
+  fun `when pvbAdvanceFromDateByDays is passed as 0 the original date range from date is not moved`() {
     // Given
-    val advanceFromDateByDays = 0
+    val pvbAdvanceFromDateByDays = 0
     visitSchedulerMockServer.stubGetAvailableVisitSessions(visitSchedulerPrisonDto, prisonerId, OPEN, mutableListOf(visitSession1, visitSession2, visitSession3))
 
     // appointment is not on the same date as the visits
     val dateRange = DateRange(
-      fromDate = LocalDate.now().plusDays(visitSchedulerPrisonDto.policyNoticeDaysMin.toLong() + advanceFromDateByDays),
+      fromDate = LocalDate.now().plusDays(visitSchedulerPrisonDto.policyNoticeDaysMin.toLong() + pvbAdvanceFromDateByDays),
       toDate = LocalDate.now().plusDays(visitSchedulerPrisonDto.policyNoticeDaysMax.toLong()),
     )
 
@@ -141,7 +141,7 @@ class AvailableVisitSessionsDateRangeTest : IntegrationTestBase() {
       sessionRestriction = OPEN,
       withAppointmentsCheck = true,
       excludedApplicationReference = null,
-      advanceFromDateByDays = advanceFromDateByDays,
+      pvbAdvanceFromDateByDays = pvbAdvanceFromDateByDays,
       authHttpHeaders = roleVSIPOrchestrationServiceHttpHeaders,
     )
 
@@ -150,9 +150,9 @@ class AvailableVisitSessionsDateRangeTest : IntegrationTestBase() {
   }
 
   @Test
-  fun `when advanceFromDateByDays is passed as more than policy max days the original date range from date is not moved`() {
+  fun `when pvbAdvanceFromDateByDays is passed as more than policy max days the original date range from date is not moved`() {
     // Given
-    val advanceFromDateByDays = 28
+    val pvbAdvanceFromDateByDays = 28
     visitSchedulerMockServer.stubGetAvailableVisitSessions(visitSchedulerPrisonDto, prisonerId, OPEN, mutableListOf(visitSession1, visitSession2, visitSession3))
 
     // appointment is not on the same date as the visits
@@ -169,7 +169,7 @@ class AvailableVisitSessionsDateRangeTest : IntegrationTestBase() {
       sessionRestriction = OPEN,
       withAppointmentsCheck = true,
       excludedApplicationReference = null,
-      advanceFromDateByDays = advanceFromDateByDays,
+      pvbAdvanceFromDateByDays = pvbAdvanceFromDateByDays,
       authHttpHeaders = roleVSIPOrchestrationServiceHttpHeaders,
     )
 
@@ -178,14 +178,14 @@ class AvailableVisitSessionsDateRangeTest : IntegrationTestBase() {
   }
 
   @Test
-  fun `when advanceFromDateByDays passed makes from date same as to date then from date is moved`() {
+  fun `when pvbAdvanceFromDateByDays passed makes from date same as to date then from date is moved`() {
     // Given
-    val advanceFromDateByDays = visitSchedulerPrisonDto.policyNoticeDaysMax - visitSchedulerPrisonDto.policyNoticeDaysMin
+    val pvbAdvanceFromDateByDays = visitSchedulerPrisonDto.policyNoticeDaysMax - visitSchedulerPrisonDto.policyNoticeDaysMin
     visitSchedulerMockServer.stubGetAvailableVisitSessions(visitSchedulerPrisonDto, prisonerId, OPEN, mutableListOf(visitSession1, visitSession2, visitSession3))
 
     // appointment is not on the same date as the visits
     val dateRange = DateRange(
-      fromDate = LocalDate.now().plusDays(visitSchedulerPrisonDto.policyNoticeDaysMin.toLong() + advanceFromDateByDays),
+      fromDate = LocalDate.now().plusDays(visitSchedulerPrisonDto.policyNoticeDaysMin.toLong() + pvbAdvanceFromDateByDays),
       toDate = LocalDate.now().plusDays(visitSchedulerPrisonDto.policyNoticeDaysMax.toLong()),
     )
     Assertions.assertThat(dateRange.fromDate).isEqualTo(dateRange.toDate)
@@ -198,7 +198,7 @@ class AvailableVisitSessionsDateRangeTest : IntegrationTestBase() {
       sessionRestriction = OPEN,
       withAppointmentsCheck = true,
       excludedApplicationReference = null,
-      advanceFromDateByDays = advanceFromDateByDays,
+      pvbAdvanceFromDateByDays = pvbAdvanceFromDateByDays,
       authHttpHeaders = roleVSIPOrchestrationServiceHttpHeaders,
     )
 
@@ -207,9 +207,9 @@ class AvailableVisitSessionsDateRangeTest : IntegrationTestBase() {
   }
 
   @Test
-  fun `when advanceFromDateByDays is passed as a -ve value than policy max days the original date range from date is not moved`() {
+  fun `when pvbAdvanceFromDateByDays is passed as a -ve value than policy max days the original date range from date is not moved`() {
     // Given
-    val advanceFromDateByDays = -2
+    val pvbAdvanceFromDateByDays = -2
     visitSchedulerMockServer.stubGetAvailableVisitSessions(visitSchedulerPrisonDto, prisonerId, OPEN, mutableListOf(visitSession1, visitSession2, visitSession3))
 
     // appointment is not on the same date as the visits
@@ -226,7 +226,7 @@ class AvailableVisitSessionsDateRangeTest : IntegrationTestBase() {
       sessionRestriction = OPEN,
       withAppointmentsCheck = true,
       excludedApplicationReference = null,
-      advanceFromDateByDays = advanceFromDateByDays,
+      pvbAdvanceFromDateByDays = pvbAdvanceFromDateByDays,
       authHttpHeaders = roleVSIPOrchestrationServiceHttpHeaders,
     )
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/sessions/AvailableVisitSessionsDateRangeTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/sessions/AvailableVisitSessionsDateRangeTest.kt
@@ -233,4 +233,58 @@ class AvailableVisitSessionsDateRangeTest : IntegrationTestBase() {
     // Then
     verify(visitSchedulerClient, times(1)).getAvailableVisitSessions(prisonId = prisonCode, prisonerId = prisonerId, sessionRestriction = OPEN, dateRange = dateRange, excludedApplicationReference = null)
   }
+
+  @Test
+  fun `when fromDateOverride is passed as 2 the original opening booking window is today + 2 days`() {
+    // Given
+    val fromDateOverride = 5
+    visitSchedulerMockServer.stubGetAvailableVisitSessions(visitSchedulerPrisonDto, prisonerId, OPEN, mutableListOf(visitSession1, visitSession2, visitSession3))
+
+    // When
+    callGetAvailableVisitSessions(
+      webTestClient,
+      prisonCode = prisonCode,
+      prisonerId = prisonerId,
+      sessionRestriction = OPEN,
+      withAppointmentsCheck = true,
+      excludedApplicationReference = null,
+      fromDateOverride = fromDateOverride,
+      authHttpHeaders = roleVSIPOrchestrationServiceHttpHeaders,
+    )
+
+    // Then
+    val dateRange = DateRange(
+      fromDate = LocalDate.now().plusDays(fromDateOverride.toLong()),
+      toDate = LocalDate.now().plusDays(visitSchedulerPrisonDto.policyNoticeDaysMax.toLong()),
+    )
+
+    verify(visitSchedulerClient, times(1)).getAvailableVisitSessions(prisonId = prisonCode, prisonerId = prisonerId, sessionRestriction = OPEN, dateRange = dateRange, excludedApplicationReference = null)
+  }
+
+  @Test
+  fun `when toDateOverride is passed as 20 the original closing booking window is today + 20 days`() {
+    // Given
+    val toDateOverride = 20
+    visitSchedulerMockServer.stubGetAvailableVisitSessions(visitSchedulerPrisonDto, prisonerId, OPEN, mutableListOf(visitSession1, visitSession2, visitSession3))
+
+    // When
+    callGetAvailableVisitSessions(
+      webTestClient,
+      prisonCode = prisonCode,
+      prisonerId = prisonerId,
+      sessionRestriction = OPEN,
+      withAppointmentsCheck = true,
+      excludedApplicationReference = null,
+      toDateOverride = toDateOverride,
+      authHttpHeaders = roleVSIPOrchestrationServiceHttpHeaders,
+    )
+
+    // Then
+    val dateRange = DateRange(
+      fromDate = LocalDate.now().plusDays(visitSchedulerPrisonDto.policyNoticeDaysMin.toLong()),
+      toDate = LocalDate.now().plusDays(toDateOverride.toLong()),
+    )
+
+    verify(visitSchedulerClient, times(1)).getAvailableVisitSessions(prisonId = prisonCode, prisonerId = prisonerId, sessionRestriction = OPEN, dateRange = dateRange, excludedApplicationReference = null)
+  }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/utils/DateUtilsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/utils/DateUtilsTest.kt
@@ -38,25 +38,25 @@ class DateUtilsTest {
   @Test
   fun `adds 1 day to from date if advance date by days is 1`() {
     // Given
-    val advanceFromDateByDays = 1
+    val pvbAdvanceFromDateByDays = 1
 
     // When
     var dateRange = dateUtils.getToDaysDateRange(prison)
-    dateRange = dateUtils.advanceFromDate(dateRange, advanceFromDateByDays)
+    dateRange = dateUtils.advanceFromDate(dateRange, pvbAdvanceFromDateByDays)
 
     // Then
-    Assertions.assertThat(dateRange.fromDate).isEqualTo(today.plusDays(prison.policyNoticeDaysMin.toLong() + advanceFromDateByDays))
+    Assertions.assertThat(dateRange.fromDate).isEqualTo(today.plusDays(prison.policyNoticeDaysMin.toLong() + pvbAdvanceFromDateByDays))
     Assertions.assertThat(dateRange.toDate).isEqualTo(today.plusDays(prison.policyNoticeDaysMax.toLong()))
   }
 
   @Test
   fun `adds no days if advance date by days is zero`() {
     // Given
-    val advanceFromDateByDays = 0
+    val pvbAdvanceFromDateByDays = 0
 
     // When
     var dateRange = dateUtils.getToDaysDateRange(prison)
-    dateRange = dateUtils.advanceFromDate(dateRange, advanceFromDateByDays)
+    dateRange = dateUtils.advanceFromDate(dateRange, pvbAdvanceFromDateByDays)
 
     // Then
     Assertions.assertThat(dateRange.fromDate).isEqualTo(today.plusDays(prison.policyNoticeDaysMin.toLong()))
@@ -66,11 +66,11 @@ class DateUtilsTest {
   @Test
   fun `adds no days if advance date by days is negative value`() {
     // Given
-    val advanceFromDateByDays = -1
+    val pvbAdvanceFromDateByDays = -1
 
     // When
     var dateRange = dateUtils.getToDaysDateRange(prison)
-    dateRange = dateUtils.advanceFromDate(dateRange, advanceFromDateByDays)
+    dateRange = dateUtils.advanceFromDate(dateRange, pvbAdvanceFromDateByDays)
 
     // Then
     Assertions.assertThat(dateRange.fromDate).isEqualTo(today.plusDays(prison.policyNoticeDaysMin.toLong()))
@@ -80,11 +80,11 @@ class DateUtilsTest {
   @Test
   fun `adds no days if number of days is more than max policy days`() {
     // Given
-    val advanceFromDateByDays = (prison.policyNoticeDaysMax - prison.policyNoticeDaysMin) + 1
+    val pvbAdvanceFromDateByDays = (prison.policyNoticeDaysMax - prison.policyNoticeDaysMin) + 1
 
     // When
     var dateRange = dateUtils.getToDaysDateRange(prison)
-    dateRange = dateUtils.advanceFromDate(dateRange, advanceFromDateByDays)
+    dateRange = dateUtils.advanceFromDate(dateRange, pvbAdvanceFromDateByDays)
 
     // Then
     Assertions.assertThat(dateRange.fromDate).isEqualTo(today.plusDays(prison.policyNoticeDaysMin.toLong()))
@@ -94,14 +94,14 @@ class DateUtilsTest {
   @Test
   fun `adds days if number of days is same as max policy days`() {
     // Given
-    val advanceFromDateByDays = (prison.policyNoticeDaysMax - prison.policyNoticeDaysMin)
+    val pvbAdvanceFromDateByDays = (prison.policyNoticeDaysMax - prison.policyNoticeDaysMin)
 
     // When
     var dateRange = dateUtils.getToDaysDateRange(prison)
-    dateRange = dateUtils.advanceFromDate(dateRange, advanceFromDateByDays)
+    dateRange = dateUtils.advanceFromDate(dateRange, pvbAdvanceFromDateByDays)
 
     // Then
-    Assertions.assertThat(dateRange.fromDate).isEqualTo(today.plusDays(prison.policyNoticeDaysMin.toLong() + advanceFromDateByDays))
+    Assertions.assertThat(dateRange.fromDate).isEqualTo(today.plusDays(prison.policyNoticeDaysMin.toLong() + pvbAdvanceFromDateByDays))
     Assertions.assertThat(dateRange.toDate).isEqualTo(today.plusDays(prison.policyNoticeDaysMax.toLong()))
     Assertions.assertThat(dateRange.fromDate).isEqualTo(dateRange.toDate)
   }
@@ -109,14 +109,14 @@ class DateUtilsTest {
   @Test
   fun `adds days if number of days is less than max policy days`() {
     // Given
-    val advanceFromDateByDays = 25
+    val pvbAdvanceFromDateByDays = 25
 
     // When
     var dateRange = dateUtils.getToDaysDateRange(prison)
-    dateRange = dateUtils.advanceFromDate(dateRange, advanceFromDateByDays)
+    dateRange = dateUtils.advanceFromDate(dateRange, pvbAdvanceFromDateByDays)
 
     // Then
-    Assertions.assertThat(dateRange.fromDate).isEqualTo(today.plusDays(prison.policyNoticeDaysMin.toLong() + advanceFromDateByDays))
+    Assertions.assertThat(dateRange.fromDate).isEqualTo(today.plusDays(prison.policyNoticeDaysMin.toLong() + pvbAdvanceFromDateByDays))
     Assertions.assertThat(dateRange.toDate).isEqualTo(today.plusDays(prison.policyNoticeDaysMax.toLong()))
   }
 }


### PR DESCRIPTION
## What does this PR do?

Add 2 parameters which allow you to manually set the opening and closing booking window.

fromDateOverride is an Int which is used to offset from todays date, the opening booking window.

toDateOverride is an Int which is used to offset from todays date, the closing booking window.

E.g.

fromDateOverride = 2 and toDateOverride = 28, would give a booking window of (Opening = today + 2, Closing = today + 28).

Note: These are optional overrides. If not passed in, the prison config min and max will be used instead.

## JIRA Link
https://dsdmoj.atlassian.net/browse/VB-4507