### PR TITLE
VB-4403 Fix prison web address returned with PrisonDto

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/dto/orchestration/PrisonDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/dto/orchestration/PrisonDto.kt
@@ -46,8 +46,8 @@ data class PrisonDto(
   @Schema(description = "Contact number of prison", required = false)
   val phoneNumber: String?,
 
-  @Schema(description = "Website of prison", required = false)
-  val website: String?,
+  @Schema(description = "Web address of prison", required = false)
+  val webAddress: String?,
 
   @Schema(description = "prison user client", required = false)
   val clients: List<PrisonUserClientDto> = listOf(),
@@ -66,6 +66,6 @@ data class PrisonDto(
 
     emailAddress = prisonRegisterContactDetailsDto.emailAddress,
     phoneNumber = prisonRegisterContactDetailsDto.phoneNumber,
-    website = prisonRegisterContactDetailsDto.website,
+    webAddress = prisonRegisterContactDetailsDto.webAddress,
   )
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/dto/prison/register/PrisonRegisterContactDetailsDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/dto/prison/register/PrisonRegisterContactDetailsDto.kt
@@ -4,12 +4,12 @@ import com.fasterxml.jackson.annotation.JsonInclude
 import io.swagger.v3.oas.annotations.media.Schema
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@Schema(description = "Prison Contact Details such as email address, phone number and website")
+@Schema(description = "Prison Contact Details such as email address, phone number and web address")
 data class PrisonRegisterContactDetailsDto(
   @Schema(description = "Contact email address of prison", example = "example@example.com", required = false)
   val emailAddress: String? = null,
   @Schema(description = "Contact number of prison", required = false)
   val phoneNumber: String? = null,
-  @Schema(description = "Website of prison", required = false)
-  val website: String? = null,
+  @Schema(description = "Web address of prison", required = false)
+  val webAddress: String? = null,
 )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/prisons/GetPrisonTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/prisons/GetPrisonTest.kt
@@ -28,7 +28,7 @@ class GetPrisonTest : IntegrationTestBase() {
   final val prisonCode = "HEI"
   val visitSchedulerPrisonDto = VisitSchedulerPrisonDto(prisonCode, true, 2, 28, 6, 3, 3, 18)
   val prisonRegisterPrisonDto = PrisonRegisterPrisonDto(prisonCode, "HMP Hewell", true)
-  val prisonRegisterPrisonContactDetailsDto = PrisonRegisterContactDetailsDto("example@email.com", "07777777777", "website")
+  val prisonRegisterPrisonContactDetailsDto = PrisonRegisterContactDetailsDto("example@email.com", "07777777777", "https://www.example.com")
 
   fun callGetSupportedPrisons(
     webTestClient: WebTestClient,
@@ -94,7 +94,7 @@ class GetPrisonTest : IntegrationTestBase() {
     Assertions.assertThat(result.adultAgeYears).isEqualTo(visitSchedulerPrisonDto.adultAgeYears)
     Assertions.assertThat(result.emailAddress).isNull()
     Assertions.assertThat(result.phoneNumber).isNull()
-    Assertions.assertThat(result.website).isNull()
+    Assertions.assertThat(result.webAddress).isNull()
 
     verify(prisonRegisterClientSpy, times(1)).getPrison(prisonCode)
     verify(visitSchedulerClientSpy, times(1)).getPrison(prisonCode)


### PR DESCRIPTION
Prison register returns a prison web address as `webAddress`, not `website`.

Fix this and update property name in `PrisonDto` to match.