### PR TITLE
VB-4757 - Add prisoner name to orchestration visit dto

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/dto/builder/OrchestrationVisitDtoBuilder.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/dto/builder/OrchestrationVisitDtoBuilder.kt
@@ -3,16 +3,19 @@ package uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.bu
 import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.contact.registry.PrisonerContactDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.orchestration.OrchestrationVisitDto
+import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.prisoner.search.PrisonerDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.visit.scheduler.VisitDto
 
 @Component
 class OrchestrationVisitDtoBuilder(
   private val orchestrationVisitorDtoBuilder: OrchestrationVisitorDtoBuilder,
 ) {
-  fun build(visitDto: VisitDto, prisonerContacts: List<PrisonerContactDto>): OrchestrationVisitDto {
+  fun build(visitDto: VisitDto, prisonerContacts: List<PrisonerContactDto>, prisoner: PrisonerDto? = null): OrchestrationVisitDto {
     return OrchestrationVisitDto(
       reference = visitDto.reference,
       prisonerId = visitDto.prisonerId,
+      prisonerFirstName = prisoner?.firstName,
+      prisonerLastName = prisoner?.lastName,
       prisonCode = visitDto.prisonCode,
       visitStatus = visitDto.visitStatus,
       outcomeStatus = visitDto.outcomeStatus,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/dto/orchestration/OrchestrationVisitDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/dto/orchestration/OrchestrationVisitDto.kt
@@ -15,6 +15,10 @@ data class OrchestrationVisitDto(
   val reference: String,
   @Schema(description = "Prisoner Id", example = "AF34567G", required = true)
   val prisonerId: String,
+  @Schema(description = "Prisoner first name", example = "James", required = false)
+  val prisonerFirstName: String?,
+  @Schema(description = "Prisoner last name", example = "Smith", required = false)
+  val prisonerLastName: String?,
   @JsonProperty("prisonId")
   @Schema(description = "Prison Id", example = "MDI", required = true)
   val prisonCode: String,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/service/PrisonerSearchService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/service/PrisonerSearchService.kt
@@ -5,6 +5,8 @@ import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.client.PrisonerSearchClient
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.prisoner.search.PrisonerDto
+import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.exception.NotFoundException
+import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.service.PrisonerContactService.Companion.LOG
 
 @Service
 class PrisonerSearchService(
@@ -16,5 +18,20 @@ class PrisonerSearchService(
 
   fun getPrisoner(prisonerNumber: String): PrisonerDto {
     return prisonerSearchClient.getPrisonerById(prisonerNumber)
+  }
+
+  fun getPrisoners(prisonerIds: Set<String>): Map<String, PrisonerDto?> {
+    val prisonerInfoMap = mutableMapOf<String, PrisonerDto?>()
+    prisonerIds.forEach { prisonerId ->
+      val prisoner = try {
+        getPrisoner(prisonerId)
+      } catch (e: NotFoundException) {
+        LOG.info("No prisoner found for prisoner id - $prisonerId")
+        null
+      }
+      prisonerInfoMap[prisonerId] = prisoner
+    }
+
+    return prisonerInfoMap
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/service/VisitSchedulerService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/service/VisitSchedulerService.kt
@@ -32,6 +32,7 @@ import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.vis
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.visit.scheduler.visitnotification.PrisonerRestrictionChangeNotificationDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.visit.scheduler.visitnotification.VisitorApprovedUnapprovedNotificationDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.visit.scheduler.visitnotification.VisitorRestrictionUpsertedNotificationDto
+import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.exception.NotFoundException
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.filter.VisitSearchRequestFilter
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.service.listeners.events.additionalinfo.NonAssociationChangedInfo
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.service.listeners.events.additionalinfo.PersonRestrictionUpsertedInfo
@@ -50,6 +51,7 @@ class VisitSchedulerService(
   private val manageUsersService: ManageUsersService,
   private val alertService: AlertsService,
   private val orchestrationVisitDtoBuilder: OrchestrationVisitDtoBuilder,
+  private val prisonerSearchService: PrisonerSearchService,
 ) {
   companion object {
     val LOG: Logger = LoggerFactory.getLogger(this::class.java)
@@ -222,9 +224,15 @@ class VisitSchedulerService(
   private fun mapVisitDtoToOrchestrationVisitDto(visits: List<VisitDto>?): List<OrchestrationVisitDto> {
     val prisonerIds = visits?.map { it.prisonerId }?.toSet() ?: emptySet()
     val prisonerContactsMap = prisonerContactService.getPrisonersContacts(prisonerIds)
-    return visits?.map {
-      val contacts = prisonerContactsMap[it.prisonerId] ?: emptyList()
-      orchestrationVisitDtoBuilder.build(it, contacts)
+    return visits?.map { visit ->
+      val contacts = prisonerContactsMap[visit.prisonerId] ?: emptyList()
+      try {
+        val prisoner = prisonerSearchService.getPrisoner(visit.prisonerId)
+        orchestrationVisitDtoBuilder.build(visit, contacts, prisoner)
+      } catch (e: NotFoundException) {
+        LOG.error("prisoner search failed to find prisoner, skipping populating prisoner details")
+        orchestrationVisitDtoBuilder.build(visit, contacts)
+      }
     }?.toList() ?: emptyList()
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/visit/PublicCancelledVisitsByBookerReferenceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/visit/PublicCancelledVisitsByBookerReferenceTest.kt
@@ -9,8 +9,10 @@ import org.mockito.kotlin.times
 import org.springframework.boot.test.mock.mockito.SpyBean
 import org.springframework.test.web.reactive.server.WebTestClient
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.client.PrisonerContactRegistryClient
+import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.client.PrisonerSearchClient
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.contact.registry.PrisonerContactDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.orchestration.OrchestrationVisitDto
+import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.prisoner.search.PrisonerDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.visit.scheduler.VisitDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.visit.scheduler.enums.VisitStatus.CANCELLED
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.integration.IntegrationTestBase
@@ -22,16 +24,23 @@ class PublicCancelledVisitsByBookerReferenceTest : IntegrationTestBase() {
   @SpyBean
   private lateinit var prisonerContactRegistryClient: PrisonerContactRegistryClient
 
+  @SpyBean
+  private lateinit var prisonerSearchClient: PrisonerSearchClient
+
   private lateinit var visitDto: VisitDto
   private lateinit var visitDto2: VisitDto
+  private lateinit var prisoner: PrisonerDto
   private lateinit var contact1: PrisonerContactDto
   private lateinit var contact2: PrisonerContactDto
   private lateinit var contact3: PrisonerContactDto
   private lateinit var contacts: List<PrisonerContactDto>
   private final val prisonerId = "ABC"
+  private final val prisonId = "MDI"
 
   @BeforeEach
   fun setup() {
+    prisoner = createPrisoner(prisonerId, "james", "smith", LocalDate.of(1965, 12, 12), prisonId)
+
     contact1 = createContactDto(firstName = "First", lastName = "Smith", dateOfBirth = LocalDate.of(2000, 1, 1))
     contact2 = createContactDto(firstName = "Second", lastName = "Smith", dateOfBirth = LocalDate.of(2000, 1, 1))
     contact3 = createContactDto(firstName = "Third", lastName = "Smith", dateOfBirth = LocalDate.of(2000, 1, 1))
@@ -60,6 +69,7 @@ class PublicCancelledVisitsByBookerReferenceTest : IntegrationTestBase() {
     // Given
     val visitsList = mutableListOf(visitDto, visitDto2)
     visitSchedulerMockServer.stubPublicCancelledVisitsByBookerReference(prisonerId, visitsList)
+    prisonOffenderSearchMockServer.stubGetPrisonerById(prisonerId, prisoner)
     prisonerContactRegistryMockServer.stubGetPrisonerContacts(prisonerId = prisonerId, withAddress = false, approvedVisitorsOnly = false, contactsList = listOf(contact1, contact2, contact3))
 
     // When
@@ -74,11 +84,13 @@ class PublicCancelledVisitsByBookerReferenceTest : IntegrationTestBase() {
   }
 
   @Test
-  fun `when cancelled visits for booker exists then the visitors names are populated`() {
+  fun `when cancelled visits for booker exists then the visitors names and prisoner info are also populated`() {
     // Given
     val visitsList = mutableListOf(visitDto, visitDto2)
     visitSchedulerMockServer.stubPublicCancelledVisitsByBookerReference(prisonerId, visitsList)
+    prisonOffenderSearchMockServer.stubGetPrisonerById(prisonerId, prisoner)
     prisonerContactRegistryMockServer.stubGetPrisonerContacts(prisonerId = prisonerId, withAddress = false, approvedVisitorsOnly = false, contactsList = listOf(contact1, contact2, contact3))
+
     // When
     val responseSpec = callPublicCancelledVisits(webTestClient, prisonerId, roleVSIPOrchestrationServiceHttpHeaders)
 
@@ -89,9 +101,13 @@ class PublicCancelledVisitsByBookerReferenceTest : IntegrationTestBase() {
     val visits = getResults(returnResult)
     Assertions.assertThat(visits.size).isEqualTo(2)
     Assertions.assertThat(visits[0].visitors.size).isEqualTo(2)
+    Assertions.assertThat(visits[0].prisonerFirstName).isEqualTo(prisoner.firstName)
+    Assertions.assertThat(visits[0].prisonerLastName).isEqualTo(prisoner.lastName)
     assertVisitorDetails(visits[0].visitors, contacts)
     assertVisitorDetails(visits[1].visitors, contacts)
+
     Mockito.verify(prisonerContactRegistryClient, times(1)).getPrisonersSocialContacts(prisonerId, withAddress = false, false, null, null)
+    Mockito.verify(prisonerSearchClient, times(visits.size)).getPrisonerById(prisonerId)
   }
 
   @Test
@@ -116,7 +132,9 @@ class PublicCancelledVisitsByBookerReferenceTest : IntegrationTestBase() {
     // Given
     val visitsList = mutableListOf(visitDto, visitDto2)
     visitSchedulerMockServer.stubPublicCancelledVisitsByBookerReference(prisonerId, visitsList)
+    prisonOffenderSearchMockServer.stubGetPrisonerById(prisonerId, prisoner)
     prisonerContactRegistryMockServer.stubGetPrisonerContacts(prisonerId = prisonerId, withAddress = false, approvedVisitorsOnly = false, contactsList = null)
+
     // When
     val responseSpec = callPublicCancelledVisits(webTestClient, prisonerId, roleVSIPOrchestrationServiceHttpHeaders)
 
@@ -127,7 +145,11 @@ class PublicCancelledVisitsByBookerReferenceTest : IntegrationTestBase() {
     val visits = getResults(returnResult)
     Assertions.assertThat(visits.size).isEqualTo(2)
     Assertions.assertThat(visits[0].visitors.size).isEqualTo(2)
+    Assertions.assertThat(visits[0].prisonerFirstName).isEqualTo(prisoner.firstName)
+    Assertions.assertThat(visits[0].prisonerLastName).isEqualTo(prisoner.lastName)
     Assertions.assertThat(visits[1].visitors.size).isEqualTo(2)
+    Assertions.assertThat(visits[1].prisonerFirstName).isEqualTo(prisoner.firstName)
+    Assertions.assertThat(visits[1].prisonerLastName).isEqualTo(prisoner.lastName)
 
     val allVisitors = visits.flatMap { it.visitors }
     for (visitor in allVisitors) {
@@ -137,6 +159,34 @@ class PublicCancelledVisitsByBookerReferenceTest : IntegrationTestBase() {
     }
 
     Mockito.verify(prisonerContactRegistryClient, times(1)).getPrisonersSocialContacts(prisonerId, withAddress = false, approvedVisitorsOnly = false, null, null)
+    Mockito.verify(prisonerSearchClient, times(visits.size)).getPrisonerById(prisonerId)
+  }
+
+  @Test
+  fun `when cancelled visits for booker exists but prisoner search returns a 404 then visits are returned without prisoner info`() {
+    // Given
+    val visitsList = mutableListOf(visitDto, visitDto2)
+    visitSchedulerMockServer.stubPublicCancelledVisitsByBookerReference(prisonerId, visitsList)
+    prisonOffenderSearchMockServer.stubGetPrisonerById(prisonerId, null)
+    prisonerContactRegistryMockServer.stubGetPrisonerContacts(prisonerId = prisonerId, withAddress = false, approvedVisitorsOnly = false, contactsList = listOf(contact1, contact2, contact3))
+
+    // When
+    val responseSpec = callPublicCancelledVisits(webTestClient, prisonerId, roleVSIPOrchestrationServiceHttpHeaders)
+
+    // Then
+    val returnResult = responseSpec.expectStatus().isOk
+      .expectBody()
+
+    val visits = getResults(returnResult)
+    Assertions.assertThat(visits.size).isEqualTo(2)
+    Assertions.assertThat(visits[0].visitors.size).isEqualTo(2)
+    Assertions.assertThat(visits[0].prisonerFirstName).isEqualTo(null)
+    Assertions.assertThat(visits[0].prisonerLastName).isEqualTo(null)
+    assertVisitorDetails(visits[0].visitors, contacts)
+    assertVisitorDetails(visits[1].visitors, contacts)
+
+    Mockito.verify(prisonerContactRegistryClient, times(1)).getPrisonersSocialContacts(prisonerId, withAddress = false, false, null, null)
+    Mockito.verify(prisonerSearchClient, times(visits.size)).getPrisonerById(prisonerId)
   }
 
   private fun getResults(returnResult: WebTestClient.BodyContentSpec): Array<OrchestrationVisitDto> {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/visit/PublicCancelledVisitsByBookerReferenceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/visit/PublicCancelledVisitsByBookerReferenceTest.kt
@@ -107,7 +107,7 @@ class PublicCancelledVisitsByBookerReferenceTest : IntegrationTestBase() {
     assertVisitorDetails(visits[1].visitors, contacts)
 
     Mockito.verify(prisonerContactRegistryClient, times(1)).getPrisonersSocialContacts(prisonerId, withAddress = false, false, null, null)
-    Mockito.verify(prisonerSearchClient, times(visits.size)).getPrisonerById(prisonerId)
+    Mockito.verify(prisonerSearchClient, times(1)).getPrisonerById(prisonerId)
   }
 
   @Test
@@ -159,7 +159,7 @@ class PublicCancelledVisitsByBookerReferenceTest : IntegrationTestBase() {
     }
 
     Mockito.verify(prisonerContactRegistryClient, times(1)).getPrisonersSocialContacts(prisonerId, withAddress = false, approvedVisitorsOnly = false, null, null)
-    Mockito.verify(prisonerSearchClient, times(visits.size)).getPrisonerById(prisonerId)
+    Mockito.verify(prisonerSearchClient, times(1)).getPrisonerById(prisonerId)
   }
 
   @Test
@@ -186,7 +186,7 @@ class PublicCancelledVisitsByBookerReferenceTest : IntegrationTestBase() {
     assertVisitorDetails(visits[1].visitors, contacts)
 
     Mockito.verify(prisonerContactRegistryClient, times(1)).getPrisonersSocialContacts(prisonerId, withAddress = false, false, null, null)
-    Mockito.verify(prisonerSearchClient, times(visits.size)).getPrisonerById(prisonerId)
+    Mockito.verify(prisonerSearchClient, times(1)).getPrisonerById(prisonerId)
   }
 
   private fun getResults(returnResult: WebTestClient.BodyContentSpec): Array<OrchestrationVisitDto> {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/visit/PublicFutureVisitsByBookerReferenceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/visit/PublicFutureVisitsByBookerReferenceTest.kt
@@ -103,7 +103,7 @@ class PublicFutureVisitsByBookerReferenceTest : IntegrationTestBase() {
     assertVisitorDetails(visits[1].visitors, contacts)
 
     Mockito.verify(prisonerContactRegistryClient, times(1)).getPrisonersSocialContacts(prisonerId, withAddress = false, false, null, null)
-    Mockito.verify(prisonerSearchClient, times(visits.size)).getPrisonerById(prisonerId)
+    Mockito.verify(prisonerSearchClient, times(1)).getPrisonerById(prisonerId)
   }
 
   @Test
@@ -155,7 +155,7 @@ class PublicFutureVisitsByBookerReferenceTest : IntegrationTestBase() {
     }
 
     Mockito.verify(prisonerContactRegistryClient, times(1)).getPrisonersSocialContacts(prisonerId, withAddress = false, approvedVisitorsOnly = false, null, null)
-    Mockito.verify(prisonerSearchClient, times(visits.size)).getPrisonerById(prisonerId)
+    Mockito.verify(prisonerSearchClient, times(1)).getPrisonerById(prisonerId)
   }
 
   @Test
@@ -183,7 +183,7 @@ class PublicFutureVisitsByBookerReferenceTest : IntegrationTestBase() {
     assertVisitorDetails(visits[1].visitors, contacts)
 
     Mockito.verify(prisonerContactRegistryClient, times(1)).getPrisonersSocialContacts(prisonerId, withAddress = false, false, null, null)
-    Mockito.verify(prisonerSearchClient, times(visits.size)).getPrisonerById(prisonerId)
+    Mockito.verify(prisonerSearchClient, times(1)).getPrisonerById(prisonerId)
   }
 
   private fun getResults(returnResult: WebTestClient.BodyContentSpec): Array<OrchestrationVisitDto> {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/visit/PublicFutureVisitsByBookerReferenceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/visit/PublicFutureVisitsByBookerReferenceTest.kt
@@ -9,8 +9,10 @@ import org.mockito.kotlin.times
 import org.springframework.boot.test.mock.mockito.SpyBean
 import org.springframework.test.web.reactive.server.WebTestClient
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.client.PrisonerContactRegistryClient
+import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.client.PrisonerSearchClient
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.contact.registry.PrisonerContactDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.orchestration.OrchestrationVisitDto
+import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.prisoner.search.PrisonerDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.visit.scheduler.VisitDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.integration.IntegrationTestBase
 import java.time.LocalDate
@@ -21,16 +23,23 @@ class PublicFutureVisitsByBookerReferenceTest : IntegrationTestBase() {
   @SpyBean
   private lateinit var prisonerContactRegistryClient: PrisonerContactRegistryClient
 
+  @SpyBean
+  private lateinit var prisonerSearchClient: PrisonerSearchClient
+
   private lateinit var visitDto: VisitDto
   private lateinit var visitDto2: VisitDto
+  private lateinit var prisoner: PrisonerDto
   private lateinit var contact1: PrisonerContactDto
   private lateinit var contact2: PrisonerContactDto
   private lateinit var contact3: PrisonerContactDto
   private lateinit var contacts: List<PrisonerContactDto>
   private final val prisonerId = "ABC"
+  private final val prisonId = "MDI"
 
   @BeforeEach
   fun setup() {
+    prisoner = createPrisoner(prisonerId, "james", "smith", LocalDate.of(1965, 12, 12), prisonId)
+
     contact1 = createContactDto(firstName = "First", lastName = "Smith", dateOfBirth = LocalDate.of(2000, 1, 1))
     contact2 = createContactDto(firstName = "Second", lastName = "Smith", dateOfBirth = LocalDate.of(2000, 1, 1))
     contact3 = createContactDto(firstName = "Third", lastName = "Smith", dateOfBirth = LocalDate.of(2000, 1, 1))
@@ -57,6 +66,7 @@ class PublicFutureVisitsByBookerReferenceTest : IntegrationTestBase() {
     // Given
     val visitsList = mutableListOf(visitDto, visitDto2)
     visitSchedulerMockServer.stubPublicFutureVisitsByBookerReference(prisonerId, visitsList)
+    prisonOffenderSearchMockServer.stubGetPrisonerById(prisonerId, prisoner)
     prisonerContactRegistryMockServer.stubGetPrisonerContacts(prisonerId = prisonerId, withAddress = false, approvedVisitorsOnly = false, contactsList = emptyList())
 
     // When
@@ -71,11 +81,13 @@ class PublicFutureVisitsByBookerReferenceTest : IntegrationTestBase() {
   }
 
   @Test
-  fun `when future visits for booker exists then the visitors names are populated`() {
+  fun `when future visits for booker exists then the visitors names and prisoner info are also populated`() {
     // Given
     val visitsList = mutableListOf(visitDto, visitDto2)
     visitSchedulerMockServer.stubPublicFutureVisitsByBookerReference(prisonerId, visitsList)
+    prisonOffenderSearchMockServer.stubGetPrisonerById(prisonerId, prisoner)
     prisonerContactRegistryMockServer.stubGetPrisonerContacts(prisonerId = prisonerId, withAddress = false, approvedVisitorsOnly = false, contactsList = listOf(contact1, contact2, contact3))
+
     // When
     val responseSpec = callPublicFutureVisits(webTestClient, prisonerId, roleVSIPOrchestrationServiceHttpHeaders)
 
@@ -85,9 +97,13 @@ class PublicFutureVisitsByBookerReferenceTest : IntegrationTestBase() {
     val visits = getResults(returnResult)
     Assertions.assertThat(visits.size).isEqualTo(2)
     Assertions.assertThat(visits[0].visitors.size).isEqualTo(2)
+    Assertions.assertThat(visits[0].prisonerFirstName).isEqualTo(prisoner.firstName)
+    Assertions.assertThat(visits[0].prisonerLastName).isEqualTo(prisoner.lastName)
     assertVisitorDetails(visits[0].visitors, contacts)
     assertVisitorDetails(visits[1].visitors, contacts)
+
     Mockito.verify(prisonerContactRegistryClient, times(1)).getPrisonersSocialContacts(prisonerId, withAddress = false, false, null, null)
+    Mockito.verify(prisonerSearchClient, times(visits.size)).getPrisonerById(prisonerId)
   }
 
   @Test
@@ -112,7 +128,9 @@ class PublicFutureVisitsByBookerReferenceTest : IntegrationTestBase() {
     // Given
     val visitsList = mutableListOf(visitDto, visitDto2)
     visitSchedulerMockServer.stubPublicFutureVisitsByBookerReference(prisonerId, visitsList)
+    prisonOffenderSearchMockServer.stubGetPrisonerById(prisonerId, prisoner)
     prisonerContactRegistryMockServer.stubGetPrisonerContacts(prisonerId = prisonerId, withAddress = false, approvedVisitorsOnly = false, contactsList = null)
+
     // When
     val responseSpec = callPublicFutureVisits(webTestClient, prisonerId, roleVSIPOrchestrationServiceHttpHeaders)
 
@@ -123,7 +141,11 @@ class PublicFutureVisitsByBookerReferenceTest : IntegrationTestBase() {
     val visits = getResults(returnResult)
     Assertions.assertThat(visits.size).isEqualTo(2)
     Assertions.assertThat(visits[0].visitors.size).isEqualTo(2)
+    Assertions.assertThat(visits[0].prisonerFirstName).isEqualTo(prisoner.firstName)
+    Assertions.assertThat(visits[0].prisonerLastName).isEqualTo(prisoner.lastName)
     Assertions.assertThat(visits[1].visitors.size).isEqualTo(2)
+    Assertions.assertThat(visits[1].prisonerFirstName).isEqualTo(prisoner.firstName)
+    Assertions.assertThat(visits[1].prisonerLastName).isEqualTo(prisoner.lastName)
 
     val allVisitors = visits.flatMap { it.visitors }
     for (visitor in allVisitors) {
@@ -133,6 +155,35 @@ class PublicFutureVisitsByBookerReferenceTest : IntegrationTestBase() {
     }
 
     Mockito.verify(prisonerContactRegistryClient, times(1)).getPrisonersSocialContacts(prisonerId, withAddress = false, approvedVisitorsOnly = false, null, null)
+    Mockito.verify(prisonerSearchClient, times(visits.size)).getPrisonerById(prisonerId)
+  }
+
+  @Test
+  fun `when future visits for booker exists but prisoner search returns a 404 then visits are returned without prisoner info`() {
+    // Given
+    val visitsList = mutableListOf(visitDto, visitDto2)
+    visitSchedulerMockServer.stubPublicFutureVisitsByBookerReference(prisonerId, visitsList)
+    prisonOffenderSearchMockServer.stubGetPrisonerById(prisonerId, null)
+    prisonerContactRegistryMockServer.stubGetPrisonerContacts(prisonerId = prisonerId, withAddress = false, approvedVisitorsOnly = false, contactsList = listOf(contact1, contact2, contact3))
+
+    // When
+    val responseSpec = callPublicFutureVisits(webTestClient, prisonerId, roleVSIPOrchestrationServiceHttpHeaders)
+
+    // Then
+    val returnResult = responseSpec.expectStatus().isOk.expectBody()
+
+    val visits = getResults(returnResult)
+    Assertions.assertThat(visits.size).isEqualTo(2)
+    Assertions.assertThat(visits[0].visitors.size).isEqualTo(2)
+    Assertions.assertThat(visits[0].prisonerFirstName).isEqualTo(null)
+    Assertions.assertThat(visits[0].prisonerLastName).isEqualTo(null)
+    assertVisitorDetails(visits[0].visitors, contacts)
+    Assertions.assertThat(visits[1].prisonerFirstName).isEqualTo(null)
+    Assertions.assertThat(visits[1].prisonerLastName).isEqualTo(null)
+    assertVisitorDetails(visits[1].visitors, contacts)
+
+    Mockito.verify(prisonerContactRegistryClient, times(1)).getPrisonersSocialContacts(prisonerId, withAddress = false, false, null, null)
+    Mockito.verify(prisonerSearchClient, times(visits.size)).getPrisonerById(prisonerId)
   }
 
   private fun getResults(returnResult: WebTestClient.BodyContentSpec): Array<OrchestrationVisitDto> {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/visit/PublicPastVisitsByBookerReferenceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/visit/PublicPastVisitsByBookerReferenceTest.kt
@@ -104,7 +104,7 @@ class PublicPastVisitsByBookerReferenceTest : IntegrationTestBase() {
     assertVisitorDetails(visits[1].visitors, contacts)
 
     Mockito.verify(prisonerContactRegistryClient, times(1)).getPrisonersSocialContacts(prisonerId, withAddress = false, approvedVisitorsOnly = false, null, null)
-    Mockito.verify(prisonerSearchClient, times(visits.size)).getPrisonerById(prisonerId)
+    Mockito.verify(prisonerSearchClient, times(1)).getPrisonerById(prisonerId)
   }
 
   @Test
@@ -139,7 +139,7 @@ class PublicPastVisitsByBookerReferenceTest : IntegrationTestBase() {
     }
 
     Mockito.verify(prisonerContactRegistryClient, times(1)).getPrisonersSocialContacts(prisonerId, withAddress = false, approvedVisitorsOnly = false, null, null)
-    Mockito.verify(prisonerSearchClient, times(visits.size)).getPrisonerById(prisonerId)
+    Mockito.verify(prisonerSearchClient, times(1)).getPrisonerById(prisonerId)
   }
 
   @Test
@@ -168,7 +168,7 @@ class PublicPastVisitsByBookerReferenceTest : IntegrationTestBase() {
     Assertions.assertThat(visits[0].prisonerLastName).isEqualTo(null)
 
     Mockito.verify(prisonerContactRegistryClient, times(1)).getPrisonersSocialContacts(prisonerId, withAddress = false, approvedVisitorsOnly = false, null, null)
-    Mockito.verify(prisonerSearchClient, times(visits.size)).getPrisonerById(prisonerId)
+    Mockito.verify(prisonerSearchClient, times(1)).getPrisonerById(prisonerId)
   }
 
   @Test


### PR DESCRIPTION
## What does this PR do?
As requested by frontend, we need to display the prisoner name for each visit. Adding call to get prisoner details and capturing the name on the returned dto.

Updated integration tests to cover new call to prisoner search.