### PR TITLE
VB-4331 - Public booker can provide email address for main contact

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/dto/visit/scheduler/ContactDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/dto/visit/scheduler/ContactDto.kt
@@ -10,4 +10,6 @@ class ContactDto(
   val name: String,
   @Schema(description = "Contact Phone Number", example = "01234 567890", required = false)
   val telephone: String? = null,
+  @Schema(description = "Contact Email Address", example = "email@example.com", required = false)
+  val email: String? = null,
 )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/IntegrationTestBase.kt
@@ -206,7 +206,7 @@ abstract class IntegrationTestBase {
     visitors: List<VisitorDto>? = null,
     contact: ContactDto = ContactDto("Jane Doe", "01234567890", "email@example.com"),
     firstBookedDate: LocalDateTime? = null,
-    ): VisitDto {
+  ): VisitDto {
     return VisitDto(
       applicationReference = applicationReference,
       sessionTemplateReference = sessionTemplateReference,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/IntegrationTestBase.kt
@@ -204,7 +204,7 @@ abstract class IntegrationTestBase {
     modifiedTimestamp: LocalDateTime = LocalDateTime.now(),
     sessionTemplateReference: String? = "ref.ref.ref",
     visitors: List<VisitorDto>? = null,
-    contact: ContactDto = ContactDto("Jane Doe", "01234567890"),
+    contact: ContactDto = ContactDto("Jane Doe", "01234567890", "email@example.com"),
   ): VisitDto {
     return VisitDto(
       applicationReference = applicationReference,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/visit/VisitByReferenceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/visit/VisitByReferenceTest.kt
@@ -38,10 +38,10 @@ class VisitByReferenceTest : IntegrationTestBase() {
   }
 
   @Test
-  fun `when visit exists without a phone number for contact search by reference still returns that visit`() {
+  fun `when visit exists without a phone number or email for contact search by reference still returns that visit`() {
     // Given
     val reference = "aa-bb-cc-dd"
-    val visitDto = createVisitDto(reference = reference, contact = ContactDto("Jane Doe", null))
+    val visitDto = createVisitDto(reference = reference, contact = ContactDto("Jane Doe", null, null))
     visitSchedulerMockServer.stubGetVisit(reference, visitDto)
 
     // When
@@ -52,6 +52,7 @@ class VisitByReferenceTest : IntegrationTestBase() {
     val visitDtoResponse = objectMapper.readValue(responseSpec.expectBody().returnResult().responseBody, VisitDto::class.java)
     Assertions.assertThat(visitDtoResponse.reference).isEqualTo(visitDto.reference)
     Assertions.assertThat(visitDtoResponse.visitContact!!.telephone).isNull()
+    Assertions.assertThat(visitDtoResponse.visitContact!!.email).isNull()
     Assertions.assertThat(visitDtoResponse.visitContact!!.name).isEqualTo("Jane Doe")
   }
 


### PR DESCRIPTION
## What does this PR do?
Introduce the ability for a public booker to provide an email address for the visit main contact.