### PR TITLE
Speed up tests by removing unwanted DirtiesContext and updating  DirtiesContext classMode

### DIFF
--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/prisons/GetPrisonExcludeDatesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/prisons/GetPrisonExcludeDatesTest.kt
@@ -9,8 +9,6 @@ import org.mockito.kotlin.verify
 import org.springframework.boot.test.mock.mockito.SpyBean
 import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpStatus
-import org.springframework.test.annotation.DirtiesContext
-import org.springframework.test.annotation.DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD
 import org.springframework.test.web.reactive.server.WebTestClient
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.client.ManageUsersApiClient
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.visit.scheduler.prisons.ExcludeDateDto
@@ -18,7 +16,6 @@ import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.integra
 import java.time.LocalDate
 
 @DisplayName("Get prison exclude dates tests")
-@DirtiesContext(classMode = BEFORE_EACH_TEST_METHOD)
 class GetPrisonExcludeDatesTest : IntegrationTestBase() {
   @SpyBean
   lateinit var manageUsersApiClientSpy: ManageUsersApiClient

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/sessions/GetSessionTemplateExcludeDatesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/sessions/GetSessionTemplateExcludeDatesTest.kt
@@ -10,7 +10,7 @@ import org.springframework.boot.test.mock.mockito.SpyBean
 import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpStatus
 import org.springframework.test.annotation.DirtiesContext
-import org.springframework.test.annotation.DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD
+import org.springframework.test.annotation.DirtiesContext.ClassMode.BEFORE_CLASS
 import org.springframework.test.web.reactive.server.WebTestClient
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.client.ManageUsersApiClient
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.visit.scheduler.prisons.ExcludeDateDto
@@ -18,7 +18,7 @@ import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.integra
 import java.time.LocalDate
 
 @DisplayName("Get session template exclude dates tests")
-@DirtiesContext(classMode = BEFORE_EACH_TEST_METHOD)
+@DirtiesContext(classMode = BEFORE_CLASS)
 class GetSessionTemplateExcludeDatesTest : IntegrationTestBase() {
   @SpyBean
   lateinit var manageUsersApiClientSpy: ManageUsersApiClient


### PR DESCRIPTION
Remove DirtiesContext from GetPrisonExcludeDatesTest but leave it on GetSessionTemplateExcludeDatesTest with classMode as BEFORE_CLASS to speed up tests.