### PR TITLE
revert webmvc-ui to 2.7.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -26,9 +26,7 @@ dependencies {
   implementation("io.opentelemetry.instrumentation:opentelemetry-instrumentation-annotations:2.11.0")
 
   implementation("org.springframework.data:spring-data-commons:3.4.1")
-  implementation("org.springdoc:springdoc-openapi-starter-webmvc-api:2.8.1")
-  implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.1")
-  implementation("org.springdoc:springdoc-openapi-starter-common:2.8.1")
+  implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0")
 
   annotationProcessor("org.springframework.boot:spring-boot-configuration-processor")
 


### PR DESCRIPTION
Remove springdoc-openapi-starter-webmvc-api and springdoc-openapi-starter-webmvc-common as they are not needed - refer - https://github.com/springdoc/springdoc-openapi/ and revert webmvc-ui to 2.7.0