### PR TITLE
VB-4411 - Feature - Visit booking details page rework

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/dto/orchestration/OrchestrationPrisonerVisitsNotificationDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/dto/orchestration/OrchestrationPrisonerVisitsNotificationDto.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.or
 
 import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.constraints.NotBlank
+import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.visit.scheduler.visitnotification.VisitNotificationEventAttributeDto
 import java.time.LocalDate
 
 class OrchestrationPrisonerVisitsNotificationDto(
@@ -19,4 +20,6 @@ class OrchestrationPrisonerVisitsNotificationDto(
   @Schema(description = "Booked by name", example = "John Smith", required = true)
   @field:NotBlank
   val bookedByName: String,
+  @Schema(description = "A list of all notification attributes for a given visit", required = false)
+  val notificationEventAttributes: List<VisitNotificationEventAttributeDto>,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/dto/visit/scheduler/enums/NotificationEventAttributeType.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/dto/visit/scheduler/enums/NotificationEventAttributeType.kt
@@ -1,0 +1,7 @@
+package uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.visit.scheduler.enums
+
+@Suppress("unused")
+enum class NotificationEventAttributeType {
+  VISITOR_RESTRICTION,
+  VISITOR_ID,
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/dto/visit/scheduler/visitnotification/PrisonerVisitsNotificationDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/dto/visit/scheduler/visitnotification/PrisonerVisitsNotificationDto.kt
@@ -3,7 +3,6 @@ package uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.vi
 import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.constraints.NotBlank
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.visit.scheduler.ActionedByDto
-import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.visit.scheduler.enums.VisitorSupportedRestrictionType
 import java.time.LocalDate
 
 class PrisonerVisitsNotificationDto(
@@ -18,11 +17,6 @@ class PrisonerVisitsNotificationDto(
   val visitDate: LocalDate,
   @Schema(description = "Visit Booking Reference", example = "v9-d7-ed-7u", required = true)
   val bookingReference: String,
-  @Schema(description = "Description of the flagged event", example = "Visitor with id <id> has had restriction <restriction> added", required = false)
-  @field:NotBlank
-  val description: String? = null,
-  @Schema(description = "For visitor specific events, the id of the affected visitor", example = "1234567", required = false)
-  val visitorId: Long? = null,
-  @Schema(description = "For visitor specific events, the restriction type of the affected visitor", example = "BAN", required = false)
-  val visitorRestrictionType: VisitorSupportedRestrictionType? = null,
+  @Schema(description = "A list of all notification attributes for a given visit", required = false)
+  val notificationEventAttributes: List<VisitNotificationEventAttributeDto>,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/dto/visit/scheduler/visitnotification/VisitNotificationEventAttributeDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/dto/visit/scheduler/visitnotification/VisitNotificationEventAttributeDto.kt
@@ -1,0 +1,15 @@
+package uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.visit.scheduler.visitnotification
+
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.NotNull
+import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.visit.scheduler.enums.NotificationEventAttributeType
+
+class VisitNotificationEventAttributeDto(
+  @Schema(description = "Name of the attribute associated with the notification event", example = "VISITOR_RESTRICTION", required = true)
+  @field:NotNull
+  val attributeName: NotificationEventAttributeType,
+
+  @Schema(description = "Value of the attribute associated with the notification event", example = "BAN", required = true)
+  @field:NotNull
+  val attributeValue: String,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/service/VisitSchedulerService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/service/VisitSchedulerService.kt
@@ -212,6 +212,7 @@ class VisitSchedulerService(
           it.visitDate,
           it.bookingReference,
           manageUsersService.getFullNameFromActionedBy(it.lastActionedBy),
+          it.notificationEventAttributes,
         )
       }
       OrchestrationNotificationGroupDto(group.reference, group.type, affectedVisits)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/mock/VisitSchedulerMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/mock/VisitSchedulerMockServer.kt
@@ -25,15 +25,18 @@ import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.vis
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.visit.scheduler.VisitSchedulerPrisonDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.visit.scheduler.VisitSessionDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.visit.scheduler.application.ApplicationDto
+import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.visit.scheduler.enums.NotificationEventAttributeType
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.visit.scheduler.enums.SessionRestriction
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.visit.scheduler.enums.UserType
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.visit.scheduler.enums.VisitRestriction
+import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.visit.scheduler.enums.VisitorSupportedRestrictionType
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.visit.scheduler.prisons.ExcludeDateDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.visit.scheduler.visitnotification.NotificationCountDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.visit.scheduler.visitnotification.NotificationEventType
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.visit.scheduler.visitnotification.NotificationEventType.NON_ASSOCIATION_EVENT
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.visit.scheduler.visitnotification.NotificationGroupDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.visit.scheduler.visitnotification.PrisonerVisitsNotificationDto
+import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.visit.scheduler.visitnotification.VisitNotificationEventAttributeDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.integration.IntegrationTestBase.Companion.getVisitsQueryParams
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.integration.mock.MockUtils.Companion.createJsonResponseBuilder
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.integration.mock.MockUtils.Companion.getJsonString
@@ -408,8 +411,8 @@ class VisitSchedulerMockServer : WireMockServer(8092) {
       "v7*d7*ed*7u",
       NON_ASSOCIATION_EVENT,
       listOf(
-        PrisonerVisitsNotificationDto("AF34567G", ActionedByDto(bookerReference = null, userName = "Username1", userType = UserType.STAFF), now, "v1-d7-ed-7u"),
-        PrisonerVisitsNotificationDto("BF34567G", ActionedByDto(bookerReference = null, userName = "Username2", userType = UserType.STAFF), now.plusDays(1), "v2-d7-ed-7u"),
+        PrisonerVisitsNotificationDto("AF34567G", ActionedByDto(bookerReference = null, userName = "Username1", userType = UserType.STAFF), now, "v1-d7-ed-7u", listOf(VisitNotificationEventAttributeDto(NotificationEventAttributeType.VISITOR_RESTRICTION, VisitorSupportedRestrictionType.BAN.name))),
+        PrisonerVisitsNotificationDto("BF34567G", ActionedByDto(bookerReference = null, userName = "Username2", userType = UserType.STAFF), now.plusDays(1), "v2-d7-ed-7u", listOf(VisitNotificationEventAttributeDto(NotificationEventAttributeType.VISITOR_ID, "AA12345"))),
       ),
     )
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/visit/FutureNotificationVisitGroupsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/visit/FutureNotificationVisitGroupsTest.kt
@@ -38,6 +38,7 @@ class FutureNotificationVisitGroupsTest : IntegrationTestBase() {
         Assertions.assertThat(bookedByName).isEqualTo("Aled")
         Assertions.assertThat(visitDate).isEqualTo(dtoStub.affectedVisits[0].visitDate)
         Assertions.assertThat(bookingReference).isEqualTo("v1-d7-ed-7u")
+        Assertions.assertThat(notificationEventAttributes.size).isEqualTo(1)
       }
       with(affectedVisits[1]) {
         Assertions.assertThat(prisonerNumber).isEqualTo("BF34567G")
@@ -45,6 +46,7 @@ class FutureNotificationVisitGroupsTest : IntegrationTestBase() {
         Assertions.assertThat(bookedByName).isEqualTo("Gwyn")
         Assertions.assertThat(visitDate).isEqualTo(dtoStub.affectedVisits[1].visitDate)
         Assertions.assertThat(bookingReference).isEqualTo("v2-d7-ed-7u")
+        Assertions.assertThat(notificationEventAttributes.size).isEqualTo(1)
       }
     }
   }


### PR DESCRIPTION
## What does this PR do?
This PR introduces "attributes" to the visit event notifications. These attributes allow for extra information to be captured for specific event types. Currently only 3 events (VISITOR_RESTRICTION_UPSERTED_EVENT, PERSON_RESTRICTION_UPSERTED_EVENT, VISITOR_UNAPPROVED_EVENT) have extra fields, but this new design allows new fields (attributes) to be added dynamically to the new attributes table with little changes required to the code itself.

## JIRA Link
https://dsdmoj.atlassian.net/browse/VB-4411

## Extra reading (Original SPIKE)
https://dsdmoj.atlassian.net/browse/VB-5040
