### PR TITLE
VB-5053 - Add convicted status to the booker prisoner info

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/dto/BookerPrisonerInfoDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/dto/BookerPrisonerInfoDto.kt
@@ -17,4 +17,7 @@ data class BookerPrisonerInfoDto(
 
   @Schema(description = "Current prison code for the prison that the booker registered the prisoner with", required = true)
   val registeredPrison: RegisteredPrisonDto,
+
+  @Schema(description = "Convicted status of prisoner", required = false)
+  val convictedStatus: String?,
 )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/booker/GetPermittedPrisonersForBookerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/booker/GetPermittedPrisonersForBookerTest.kt
@@ -19,6 +19,7 @@ import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.Boo
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.booker.registry.PermittedPrisonerForBookerDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.booker.registry.PermittedVisitorsForPermittedPrisonerBookerDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.booker.registry.RegisteredPrisonDto
+import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.prison.api.PrisonerBookingSummaryDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.prison.api.VisitBalancesDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.prison.register.PrisonRegisterPrisonDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.prisoner.search.CurrentIncentive
@@ -99,6 +100,20 @@ class GetPermittedPrisonersForBookerTest : IntegrationTestBase() {
     prisonApiMockServer.stubGetVisitBalances(prisoner1Dto.prisonerNumber, visitBalance1)
     prisonApiMockServer.stubGetVisitBalances(prisoner2Dto.prisonerNumber, visitBalance2)
     prisonRegisterMockServer.stubGetPrison(PRISON_CODE, prisonDto)
+    prisonApiMockServer.stubGetBookings(
+      prisoner1Dto.prisonId!!,
+      prisoner1Dto.prisonerNumber,
+      listOf(
+        PrisonerBookingSummaryDto(prisoner1Dto.prisonerNumber, "Convicted"),
+      ),
+    )
+    prisonApiMockServer.stubGetBookings(
+      prisoner2Dto.prisonId!!,
+      prisoner2Dto.prisonerNumber,
+      listOf(
+        PrisonerBookingSummaryDto(prisoner2Dto.prisonerNumber, "Remand"),
+      ),
+    )
 
     // When
     val responseSpec = callGetPrisonersByBooker(webTestClient, roleVSIPOrchestrationServiceHttpHeaders, BOOKER_REFERENCE)
@@ -108,14 +123,15 @@ class GetPermittedPrisonersForBookerTest : IntegrationTestBase() {
     val prisonerDetailsList = getResults(returnResult)
 
     Assertions.assertThat(prisonerDetailsList.size).isEqualTo(2)
-    assertPrisonerBasicDetails(prisonerBasicInfo = prisonerDetailsList[0], prisonerDto = prisoner1Dto, availableVOs = 7, registeredPrisonDto)
-    assertPrisonerBasicDetails(prisonerBasicInfo = prisonerDetailsList[1], prisonerDto = prisoner2Dto, availableVOs = 5, registeredPrisonDto)
+    assertPrisonerBasicDetails(prisonerBasicInfo = prisonerDetailsList[0], prisonerDto = prisoner1Dto, availableVOs = 7, registeredPrisonDto, "Convicted")
+    assertPrisonerBasicDetails(prisonerBasicInfo = prisonerDetailsList[1], prisonerDto = prisoner2Dto, availableVOs = 5, registeredPrisonDto, "Remand")
 
     verify(prisonVisitBookerRegistryClientSpy, times(1)).getPermittedPrisonersForBooker(BOOKER_REFERENCE)
     verify(prisonerSearchClientSpy, times(2)).getPrisonerByIdAsMono(any())
     verify(prisonApiClientSpy, times(1)).getVisitBalancesAsMono(prisoner1Dto.prisonerNumber)
     verify(prisonApiClientSpy, times(1)).getVisitBalancesAsMono(prisoner2Dto.prisonerNumber)
     verify(prisonRegisterClientSpy, times(2)).getPrisonAsMonoEmptyIfNotFound(PRISON_CODE)
+    verify(prisonApiClientSpy, times(2)).getBookingsAsMono(any(), any())
   }
 
   @Test
@@ -130,6 +146,20 @@ class GetPermittedPrisonersForBookerTest : IntegrationTestBase() {
     prisonApiMockServer.stubGetVisitBalances(prisoner1Dto.prisonerNumber, visitBalance1)
     prisonApiMockServer.stubGetVisitBalances(prisoner2Dto.prisonerNumber, visitBalance2)
     prisonRegisterMockServer.stubGetPrison(PRISON_CODE, prisonDto)
+    prisonApiMockServer.stubGetBookings(
+      prisoner1Dto.prisonId!!,
+      prisoner1Dto.prisonerNumber,
+      listOf(
+        PrisonerBookingSummaryDto(prisoner1Dto.prisonerNumber, "Convicted"),
+      ),
+    )
+    prisonApiMockServer.stubGetBookings(
+      prisoner2Dto.prisonId!!,
+      prisoner2Dto.prisonerNumber,
+      listOf(
+        PrisonerBookingSummaryDto(prisoner2Dto.prisonerNumber, "Remand"),
+      ),
+    )
 
     // When
     val responseSpec = callGetPrisonersByBooker(webTestClient, roleVSIPOrchestrationServiceHttpHeaders, BOOKER_REFERENCE)
@@ -145,6 +175,7 @@ class GetPermittedPrisonersForBookerTest : IntegrationTestBase() {
     verify(prisonApiClientSpy, times(0)).getVisitBalancesAsMono(prisoner1Dto.prisonerNumber)
     verify(prisonApiClientSpy, times(0)).getVisitBalancesAsMono(prisoner2Dto.prisonerNumber)
     verify(prisonRegisterClientSpy, times(0)).getPrisonAsMonoEmptyIfNotFound(any())
+    verify(prisonApiClientSpy, times(0)).getBookingsAsMono(any(), any())
   }
 
   @Test
@@ -163,6 +194,20 @@ class GetPermittedPrisonersForBookerTest : IntegrationTestBase() {
     prisonApiMockServer.stubGetVisitBalances(prisoner2Dto.prisonerNumber, visitBalance2)
     prisonRegisterMockServer.stubGetPrison(PRISON_CODE, PrisonRegisterPrisonDto(PRISON_CODE, "MDI", active = true))
     prisonRegisterMockServer.stubGetPrison(PRISON_CODE, prisonDto)
+    prisonApiMockServer.stubGetBookings(
+      prisoner1Dto.prisonId!!,
+      prisoner1Dto.prisonerNumber,
+      listOf(
+        PrisonerBookingSummaryDto(prisoner1Dto.prisonerNumber, "Convicted"),
+      ),
+    )
+    prisonApiMockServer.stubGetBookings(
+      prisoner2Dto.prisonId!!,
+      prisoner2Dto.prisonerNumber,
+      listOf(
+        PrisonerBookingSummaryDto(prisoner2Dto.prisonerNumber, "Remand"),
+      ),
+    )
 
     // When
     val responseSpec = callGetPrisonersByBooker(webTestClient, roleVSIPOrchestrationServiceHttpHeaders, BOOKER_REFERENCE)
@@ -172,7 +217,7 @@ class GetPermittedPrisonersForBookerTest : IntegrationTestBase() {
     val prisonerDetailsList = getResults(returnResult)
 
     Assertions.assertThat(prisonerDetailsList.size).isEqualTo(1)
-    assertPrisonerBasicDetails(prisonerBasicInfo = prisonerDetailsList[0], prisonerDto = prisoner1Dto, availableVOs = 7, registeredPrisonDto)
+    assertPrisonerBasicDetails(prisonerBasicInfo = prisonerDetailsList[0], prisonerDto = prisoner1Dto, availableVOs = 7, registeredPrisonDto, "Convicted")
 
     verify(prisonVisitBookerRegistryClientSpy, times(1)).getPermittedPrisonersForBooker(BOOKER_REFERENCE)
     verify(prisonerSearchClientSpy, times(2)).getPrisonerByIdAsMono(any())
@@ -181,41 +226,7 @@ class GetPermittedPrisonersForBookerTest : IntegrationTestBase() {
     verify(prisonApiClientSpy, times(1)).getVisitBalancesAsMono(prisoner1Dto.prisonerNumber)
     verify(prisonApiClientSpy, times(1)).getVisitBalancesAsMono(prisoner2Dto.prisonerNumber)
     verify(prisonRegisterClientSpy, times(2)).getPrisonAsMonoEmptyIfNotFound(PRISON_CODE)
-  }
-
-  @Test
-  fun `when booker has valid prisoners but 1 of them has prison code as null then that prisoner is not returned`() {
-    // Given
-    prisonOffenderSearchMockServer.stubGetPrisonerById(prisoner1Dto.prisonerNumber, prisoner1Dto)
-    prisonOffenderSearchMockServer.stubGetPrisonerById(prisoner3Dto.prisonerNumber, prisoner3Dto)
-    prisonVisitBookerRegistryMockServer.stubGetBookersPrisoners(
-      BOOKER_REFERENCE,
-      listOf(
-        PermittedPrisonerForBookerDto(prisoner1Dto.prisonerNumber, true, PRISON_CODE, listOf()),
-        PermittedPrisonerForBookerDto(prisoner3Dto.prisonerNumber, true, PRISON_CODE, listOf()),
-      ),
-    )
-    prisonApiMockServer.stubGetVisitBalances(prisoner1Dto.prisonerNumber, visitBalance1)
-    prisonRegisterMockServer.stubGetPrison(PRISON_CODE, prisonDto)
-
-    // When
-    val responseSpec = callGetPrisonersByBooker(webTestClient, roleVSIPOrchestrationServiceHttpHeaders, BOOKER_REFERENCE)
-
-    // Then
-    val returnResult = responseSpec.expectStatus().isOk.expectBody()
-    val prisonerDetailsList = getResults(returnResult)
-
-    Assertions.assertThat(prisonerDetailsList.size).isEqualTo(2)
-    assertPrisonerBasicDetails(prisonerBasicInfo = prisonerDetailsList[0], prisonerDto = prisoner1Dto, availableVOs = 7, registeredPrisonDto)
-    assertPrisonerBasicDetails(prisonerBasicInfo = prisonerDetailsList[1], prisonerDto = prisoner3Dto, availableVOs = 0, registeredPrisonDto)
-
-    verify(prisonVisitBookerRegistryClientSpy, times(1)).getPermittedPrisonersForBooker(BOOKER_REFERENCE)
-    verify(prisonerSearchClientSpy, times(2)).getPrisonerByIdAsMono(any())
-    verify(prisonerSearchClientSpy, times(1)).getPrisonerByIdAsMono(prisoner1Dto.prisonerNumber)
-    verify(prisonerSearchClientSpy, times(1)).getPrisonerByIdAsMono(prisoner3Dto.prisonerNumber)
-    verify(prisonApiClientSpy, times(1)).getVisitBalancesAsMono(prisoner1Dto.prisonerNumber)
-    verify(prisonApiClientSpy, times(1)).getVisitBalancesAsMono(prisoner3Dto.prisonerNumber)
-    verify(prisonRegisterClientSpy, times(2)).getPrisonAsMonoEmptyIfNotFound(PRISON_CODE)
+    verify(prisonApiClientSpy, times(2)).getBookingsAsMono(any(), any())
   }
 
   @Test
@@ -231,6 +242,20 @@ class GetPermittedPrisonersForBookerTest : IntegrationTestBase() {
     prisonOffenderSearchMockServer.stubGetPrisonerById(prisoner1Dto.prisonerNumber, null)
     prisonOffenderSearchMockServer.stubGetPrisonerById(prisoner2Dto.prisonerNumber, null)
     prisonRegisterMockServer.stubGetPrison(PRISON_CODE, prisonDto)
+    prisonApiMockServer.stubGetBookings(
+      prisoner1Dto.prisonId!!,
+      prisoner1Dto.prisonerNumber,
+      listOf(
+        PrisonerBookingSummaryDto(prisoner1Dto.prisonerNumber, "Convicted"),
+      ),
+    )
+    prisonApiMockServer.stubGetBookings(
+      prisoner2Dto.prisonId!!,
+      prisoner2Dto.prisonerNumber,
+      listOf(
+        PrisonerBookingSummaryDto(prisoner2Dto.prisonerNumber, "Remand"),
+      ),
+    )
 
     // When
     val responseSpec = callGetPrisonersByBooker(webTestClient, roleVSIPOrchestrationServiceHttpHeaders, BOOKER_REFERENCE)
@@ -248,6 +273,7 @@ class GetPermittedPrisonersForBookerTest : IntegrationTestBase() {
     verify(prisonApiClientSpy, times(1)).getVisitBalancesAsMono(prisoner1Dto.prisonerNumber)
     verify(prisonApiClientSpy, times(1)).getVisitBalancesAsMono(prisoner2Dto.prisonerNumber)
     verify(prisonRegisterClientSpy, times(2)).getPrisonAsMonoEmptyIfNotFound(PRISON_CODE)
+    verify(prisonApiClientSpy, times(2)).getBookingsAsMono(any(), any())
   }
 
   @Test
@@ -272,6 +298,7 @@ class GetPermittedPrisonersForBookerTest : IntegrationTestBase() {
     verify(prisonApiClientSpy, times(0)).getVisitBalancesAsMono(prisoner1Dto.prisonerNumber)
     verify(prisonApiClientSpy, times(0)).getVisitBalancesAsMono(prisoner2Dto.prisonerNumber)
     verify(prisonRegisterClientSpy, times(0)).getPrisonAsMonoEmptyIfNotFound(any())
+    verify(prisonApiClientSpy, times(0)).getBookingsAsMono(any(), any())
   }
 
   @Test
@@ -296,6 +323,7 @@ class GetPermittedPrisonersForBookerTest : IntegrationTestBase() {
     verify(prisonApiClientSpy, times(0)).getVisitBalancesAsMono(prisoner1Dto.prisonerNumber)
     verify(prisonApiClientSpy, times(0)).getVisitBalancesAsMono(prisoner2Dto.prisonerNumber)
     verify(prisonRegisterClientSpy, times(0)).getPrisonAsMonoEmptyIfNotFound(any())
+    verify(prisonApiClientSpy, times(0)).getBookingsAsMono(any(), any())
   }
 
   @Test
@@ -327,6 +355,7 @@ class GetPermittedPrisonersForBookerTest : IntegrationTestBase() {
     verify(prisonApiClientSpy, times(1)).getVisitBalancesAsMono(prisoner1Dto.prisonerNumber)
     verify(prisonApiClientSpy, times(1)).getVisitBalancesAsMono(prisoner2Dto.prisonerNumber)
     verify(prisonRegisterClientSpy, times(2)).getPrisonAsMonoEmptyIfNotFound(PRISON_CODE)
+    verify(prisonApiClientSpy, times(2)).getBookingsAsMono(any(), any())
   }
 
   @Test
@@ -364,6 +393,20 @@ class GetPermittedPrisonersForBookerTest : IntegrationTestBase() {
     prisonApiMockServer.stubGetVisitBalances(prisoner1Dto.prisonerNumber, null)
     prisonApiMockServer.stubGetVisitBalances(prisoner2Dto.prisonerNumber, null)
     prisonRegisterMockServer.stubGetPrison(PRISON_CODE, prisonDto)
+    prisonApiMockServer.stubGetBookings(
+      prisoner1Dto.prisonId!!,
+      prisoner1Dto.prisonerNumber,
+      listOf(
+        PrisonerBookingSummaryDto(prisoner1Dto.prisonerNumber, "Convicted"),
+      ),
+    )
+    prisonApiMockServer.stubGetBookings(
+      prisoner2Dto.prisonId!!,
+      prisoner2Dto.prisonerNumber,
+      listOf(
+        PrisonerBookingSummaryDto(prisoner2Dto.prisonerNumber, "Remand"),
+      ),
+    )
 
     // When
     val responseSpec = callGetPrisonersByBooker(webTestClient, roleVSIPOrchestrationServiceHttpHeaders, BOOKER_REFERENCE)
@@ -380,6 +423,7 @@ class GetPermittedPrisonersForBookerTest : IntegrationTestBase() {
     verify(prisonApiClientSpy, times(1)).getVisitBalancesAsMono(prisoner1Dto.prisonerNumber)
     verify(prisonApiClientSpy, times(1)).getVisitBalancesAsMono(prisoner2Dto.prisonerNumber)
     verify(prisonRegisterClientSpy, times(2)).getPrisonAsMonoEmptyIfNotFound(PRISON_CODE)
+    verify(prisonApiClientSpy, times(2)).getBookingsAsMono(any(), any())
   }
 
   @Test
@@ -397,6 +441,20 @@ class GetPermittedPrisonersForBookerTest : IntegrationTestBase() {
     prisonRegisterMockServer.stubGetPrison(PRISON_CODE, null, HttpStatus.NOT_FOUND)
     prisonApiMockServer.stubGetVisitBalances(prisoner1Dto.prisonerNumber, visitBalance1)
     prisonApiMockServer.stubGetVisitBalances(prisoner2Dto.prisonerNumber, visitBalance2)
+    prisonApiMockServer.stubGetBookings(
+      prisoner1Dto.prisonId!!,
+      prisoner1Dto.prisonerNumber,
+      listOf(
+        PrisonerBookingSummaryDto(prisoner1Dto.prisonerNumber, "Convicted"),
+      ),
+    )
+    prisonApiMockServer.stubGetBookings(
+      prisoner2Dto.prisonId!!,
+      prisoner2Dto.prisonerNumber,
+      listOf(
+        PrisonerBookingSummaryDto(prisoner2Dto.prisonerNumber, "Remand"),
+      ),
+    )
 
     // expect both code and name to be same as PRISON_CODE when prison registry returns 404
     val registeredPrisonDtoWhenNotReturned = RegisteredPrisonDto(PRISON_CODE, PRISON_CODE)
@@ -407,8 +465,8 @@ class GetPermittedPrisonersForBookerTest : IntegrationTestBase() {
     val returnResult = responseSpec.expectStatus().isOk.expectBody()
     val prisonerDetailsList = getResults(returnResult)
     Assertions.assertThat(prisonerDetailsList.size).isEqualTo(2)
-    assertPrisonerBasicDetails(prisonerBasicInfo = prisonerDetailsList[0], prisonerDto = prisoner1Dto, availableVOs = 7, registeredPrisonDtoWhenNotReturned)
-    assertPrisonerBasicDetails(prisonerBasicInfo = prisonerDetailsList[1], prisonerDto = prisoner2Dto, availableVOs = 5, registeredPrisonDtoWhenNotReturned)
+    assertPrisonerBasicDetails(prisonerBasicInfo = prisonerDetailsList[0], prisonerDto = prisoner1Dto, availableVOs = 7, registeredPrisonDtoWhenNotReturned, "Convicted")
+    assertPrisonerBasicDetails(prisonerBasicInfo = prisonerDetailsList[1], prisonerDto = prisoner2Dto, availableVOs = 5, registeredPrisonDtoWhenNotReturned, "Remand")
 
     verify(prisonVisitBookerRegistryClientSpy, times(1)).getPermittedPrisonersForBooker(BOOKER_REFERENCE)
     verify(prisonerSearchClientSpy, times(2)).getPrisonerByIdAsMono(any())
@@ -417,6 +475,7 @@ class GetPermittedPrisonersForBookerTest : IntegrationTestBase() {
     verify(prisonApiClientSpy, times(1)).getVisitBalancesAsMono(prisoner1Dto.prisonerNumber)
     verify(prisonApiClientSpy, times(1)).getVisitBalancesAsMono(prisoner2Dto.prisonerNumber)
     verify(prisonRegisterClientSpy, times(2)).getPrisonAsMonoEmptyIfNotFound(PRISON_CODE)
+    verify(prisonApiClientSpy, times(2)).getBookingsAsMono(any(), any())
   }
 
   @Test
@@ -434,6 +493,20 @@ class GetPermittedPrisonersForBookerTest : IntegrationTestBase() {
     prisonRegisterMockServer.stubGetPrison(PRISON_CODE, null, HttpStatus.INTERNAL_SERVER_ERROR)
     prisonApiMockServer.stubGetVisitBalances(prisoner1Dto.prisonerNumber, visitBalance1)
     prisonApiMockServer.stubGetVisitBalances(prisoner2Dto.prisonerNumber, visitBalance2)
+    prisonApiMockServer.stubGetBookings(
+      prisoner1Dto.prisonId!!,
+      prisoner1Dto.prisonerNumber,
+      listOf(
+        PrisonerBookingSummaryDto(prisoner1Dto.prisonerNumber, "Convicted"),
+      ),
+    )
+    prisonApiMockServer.stubGetBookings(
+      prisoner2Dto.prisonId!!,
+      prisoner2Dto.prisonerNumber,
+      listOf(
+        PrisonerBookingSummaryDto(prisoner2Dto.prisonerNumber, "Remand"),
+      ),
+    )
 
     // When
     val responseSpec = callGetPrisonersByBooker(webTestClient, roleVSIPOrchestrationServiceHttpHeaders, BOOKER_REFERENCE)
@@ -442,6 +515,54 @@ class GetPermittedPrisonersForBookerTest : IntegrationTestBase() {
     responseSpec.expectStatus().is5xxServerError
 
     verify(prisonVisitBookerRegistryClientSpy, times(1)).getPermittedPrisonersForBooker(BOOKER_REFERENCE)
+  }
+
+  @Test
+  fun `when no convicted status is returned from get bookings then prisoners are still returned`() {
+    // Given
+    prisonVisitBookerRegistryMockServer.stubGetBookersPrisoners(
+      BOOKER_REFERENCE,
+      listOf(
+        PermittedPrisonerForBookerDto(prisoner1Dto.prisonerNumber, true, PRISON_CODE, listOf()),
+        PermittedPrisonerForBookerDto(prisoner2Dto.prisonerNumber, true, PRISON_CODE, listOf()),
+      ),
+    )
+    prisonOffenderSearchMockServer.stubGetPrisonerById(prisoner1Dto.prisonerNumber, prisoner1Dto)
+    prisonOffenderSearchMockServer.stubGetPrisonerById(prisoner2Dto.prisonerNumber, prisoner2Dto)
+    prisonApiMockServer.stubGetVisitBalances(prisoner1Dto.prisonerNumber, visitBalance1)
+    prisonApiMockServer.stubGetVisitBalances(prisoner2Dto.prisonerNumber, visitBalance2)
+    prisonRegisterMockServer.stubGetPrison(PRISON_CODE, prisonDto)
+    prisonApiMockServer.stubGetBookings(
+      prisoner1Dto.prisonId!!,
+      prisoner1Dto.prisonerNumber,
+      listOf(
+        PrisonerBookingSummaryDto(prisoner1Dto.prisonerNumber, null),
+      ),
+    )
+    prisonApiMockServer.stubGetBookings(
+      prisoner2Dto.prisonId!!,
+      prisoner2Dto.prisonerNumber,
+      listOf(
+        PrisonerBookingSummaryDto(prisoner2Dto.prisonerNumber, null),
+      ),
+    )
+
+    // When
+    val responseSpec = callGetPrisonersByBooker(webTestClient, roleVSIPOrchestrationServiceHttpHeaders, BOOKER_REFERENCE)
+
+    // Then
+    val returnResult = responseSpec.expectStatus().isOk.expectBody()
+    val prisonerDetailsList = getResults(returnResult)
+    Assertions.assertThat(prisonerDetailsList.size).isEqualTo(2)
+
+    verify(prisonVisitBookerRegistryClientSpy, times(1)).getPermittedPrisonersForBooker(BOOKER_REFERENCE)
+    verify(prisonerSearchClientSpy, times(2)).getPrisonerByIdAsMono(any())
+    verify(prisonerSearchClientSpy, times(1)).getPrisonerByIdAsMono(prisoner1Dto.prisonerNumber)
+    verify(prisonerSearchClientSpy, times(1)).getPrisonerByIdAsMono(prisoner2Dto.prisonerNumber)
+    verify(prisonApiClientSpy, times(1)).getVisitBalancesAsMono(prisoner1Dto.prisonerNumber)
+    verify(prisonApiClientSpy, times(1)).getVisitBalancesAsMono(prisoner2Dto.prisonerNumber)
+    verify(prisonRegisterClientSpy, times(2)).getPrisonAsMonoEmptyIfNotFound(PRISON_CODE)
+    verify(prisonApiClientSpy, times(2)).getBookingsAsMono(any(), any())
   }
 
   @Test
@@ -460,6 +581,7 @@ class GetPermittedPrisonersForBookerTest : IntegrationTestBase() {
     verify(prisonApiClientSpy, times(0)).getVisitBalancesAsMono(prisoner1Dto.prisonerNumber)
     verify(prisonApiClientSpy, times(0)).getVisitBalancesAsMono(prisoner2Dto.prisonerNumber)
     verify(prisonRegisterClientSpy, times(0)).getPrison(any())
+    verify(prisonApiClientSpy, times(0)).getBookingsAsMono(any(), any())
   }
 
   @Test
@@ -475,15 +597,17 @@ class GetPermittedPrisonersForBookerTest : IntegrationTestBase() {
     verify(prisonVisitBookerRegistryClientSpy, times(0)).getPermittedPrisonersForBooker(any())
     verify(prisonerSearchClientSpy, times(0)).getPrisonerByIdAsMono(any())
     verify(prisonRegisterClientSpy, times(0)).getPrisonAsMonoEmptyIfNotFound(any())
+    verify(prisonApiClientSpy, times(0)).getBookingsAsMono(any(), any())
   }
 
-  private fun assertPrisonerBasicDetails(prisonerBasicInfo: BookerPrisonerInfoDto, prisonerDto: PrisonerDto, availableVOs: Int, registeredPrisonDto: RegisteredPrisonDto) {
+  private fun assertPrisonerBasicDetails(prisonerBasicInfo: BookerPrisonerInfoDto, prisonerDto: PrisonerDto, availableVOs: Int, registeredPrisonDto: RegisteredPrisonDto, convictedStatus: String?) {
     Assertions.assertThat(prisonerBasicInfo.prisoner.prisonerNumber).isEqualTo(prisonerDto.prisonerNumber)
     Assertions.assertThat(prisonerBasicInfo.prisoner.firstName).isEqualTo(prisonerDto.firstName)
     Assertions.assertThat(prisonerBasicInfo.prisoner.lastName).isEqualTo(prisonerDto.lastName)
     Assertions.assertThat(prisonerBasicInfo.availableVos).isEqualTo(availableVOs)
     Assertions.assertThat(prisonerBasicInfo.nextAvailableVoDate).isAfter(LocalDate.now())
     Assertions.assertThat(prisonerBasicInfo.registeredPrison).isEqualTo(registeredPrisonDto)
+    Assertions.assertThat(prisonerBasicInfo.convictedStatus).isEqualTo(convictedStatus)
   }
 
   private fun createCurrentIncentive(): CurrentIncentive {


### PR DESCRIPTION
## What does this PR do?

This will be used by the frontend to determine if the service should allow Remand prisoners with no VO balance to book freely (as remand prisoners don't require VOs, they're not convicted).

## JIRA Link
https://dsdmoj.atlassian.net/browse/VB-5053