### PR TITLE
VB-5053 Correctly type convictedStatus

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/dto/BookerPrisonerInfoDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/dto/BookerPrisonerInfoDto.kt
@@ -18,6 +18,6 @@ data class BookerPrisonerInfoDto(
   @Schema(description = "Current prison code for the prison that the booker registered the prisoner with", required = true)
   val registeredPrison: RegisteredPrisonDto,
 
-  @Schema(description = "Convicted status of prisoner", required = false)
+  @Schema(description = "Convicted status of prisoner", allowableValues = ["Convicted", "Remand"], required = false)
   val convictedStatus: String?,
 )


### PR DESCRIPTION
Add correct type to `convictedStatus` so it is usable by TypeScript in front-end.