### PR TITLE
VB-5215 Add contact ID for visit's main contact

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/client/VisitBookingDetailsClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/client/VisitBookingDetailsClient.kt
@@ -9,6 +9,7 @@ import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.ale
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.contact.registry.PrisonerContactDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.orchestration.EventAuditOrchestrationDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.orchestration.VisitBookingDetailsDto
+import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.orchestration.VisitContactDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.prison.register.PrisonRegisterPrisonDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.exception.NotFoundException
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.service.AlertsService.Companion.predicateFilterSupportedCodes
@@ -75,6 +76,11 @@ class VisitBookingDetailsClient(
           )
         }
 
+        val visitContact = visit.visitContact?.let { contact ->
+          val contactId = visit.visitors?.firstOrNull { it.visitContact == true }?.nomisPersonId
+          VisitContactDto(contact, contactId)
+        }
+
         VisitBookingDetailsDto(
           visit = visit,
           prison = prison,
@@ -82,6 +88,7 @@ class VisitBookingDetailsClient(
           prisonerAlerts = prisonerAlerts,
           prisonerRestrictions = prisonerRestrictions,
           visitVisitors = visitors,
+          visitContact = visitContact,
           events = eventAuditDetails,
           notifications = notifications,
         )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/dto/orchestration/VisitBookingDetailsDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/dto/orchestration/VisitBookingDetailsDto.kt
@@ -44,6 +44,8 @@ data class VisitBookingDetailsDto internal constructor(
   val visitNotes: List<VisitNoteDto>? = listOf(),
   @Schema(description = "Contact associated with the visit", required = false)
   val visitContact: ContactDto? = null,
+  @Schema(description = "Main contact ID associated with the visit", example = "1234", required = false)
+  val visitContactId: Long?,
   @Schema(description = "Additional support associated with the visit", required = false)
   val visitorSupport: VisitorSupportDto? = null,
   @Schema(description = "Prison code and name", required = true)
@@ -74,6 +76,7 @@ data class VisitBookingDetailsDto internal constructor(
     endTimestamp = visit.endTimestamp,
     visitNotes = visit.visitNotes,
     visitContact = visit.visitContact,
+    visitContactId = visit.visitors?.firstOrNull { it.visitContact == true }?.nomisPersonId,
     visitorSupport = visit.visitorSupport,
     prison = prison,
     prisoner = PrisonerDetailsDto(visit.prisonerId, prisonerDto, prisonerAlerts, prisonerRestrictions),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/dto/orchestration/VisitBookingDetailsDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/dto/orchestration/VisitBookingDetailsDto.kt
@@ -43,9 +43,7 @@ data class VisitBookingDetailsDto internal constructor(
   @Schema(description = "Visit Notes", required = false)
   val visitNotes: List<VisitNoteDto>? = listOf(),
   @Schema(description = "Contact associated with the visit", required = false)
-  val visitContact: ContactDto? = null,
-  @Schema(description = "Main contact ID associated with the visit", example = "1234", required = false)
-  val visitContactId: Long?,
+  val visitContact: VisitContactDto? = null,
   @Schema(description = "Additional support associated with the visit", required = false)
   val visitorSupport: VisitorSupportDto? = null,
   @Schema(description = "Prison code and name", required = true)
@@ -64,6 +62,7 @@ data class VisitBookingDetailsDto internal constructor(
     prisonerAlerts: List<AlertDto>,
     prisonerRestrictions: List<OffenderRestrictionDto>,
     visitVisitors: List<PrisonerContactDto>,
+    visitContact: VisitContactDto?,
     events: List<EventAuditOrchestrationDto>,
     notifications: List<VisitNotificationEventDto>,
   ) : this(
@@ -75,8 +74,7 @@ data class VisitBookingDetailsDto internal constructor(
     startTimestamp = visit.startTimestamp,
     endTimestamp = visit.endTimestamp,
     visitNotes = visit.visitNotes,
-    visitContact = visit.visitContact,
-    visitContactId = visit.visitors?.firstOrNull { it.visitContact == true }?.nomisPersonId,
+    visitContact = visitContact,
     visitorSupport = visit.visitorSupport,
     prison = prison,
     prisoner = PrisonerDetailsDto(visit.prisonerId, prisonerDto, prisonerAlerts, prisonerRestrictions),
@@ -174,5 +172,24 @@ data class VisitNotificationDto internal constructor(
     type = visitNotificationEventDto.type,
     createdDateTime = visitNotificationEventDto.createdDateTime,
     additionalData = visitNotificationEventDto.additionalData,
+  )
+}
+
+@Schema(description = "Visit notification details")
+data class VisitContactDto internal constructor(
+  @Schema(description = "Main contact ID associated with the visit", example = "1234", required = false)
+  val visitContactId: Long?,
+  @Schema(description = "Contact Name", example = "John Smith", required = true)
+  override val name: String,
+  @Schema(description = "Contact Phone Number", example = "01234 567890", required = false)
+  override val telephone: String? = null,
+  @Schema(description = "Contact Email Address", example = "email@example.com", required = false)
+  override val email: String? = null,
+) : ContactDto(name = name, telephone = telephone, email = email) {
+  constructor(contactDto: ContactDto, visitContactId: Long?) : this(
+    visitContactId = visitContactId,
+    name = contactDto.name,
+    telephone = contactDto.telephone,
+    email = contactDto.email,
   )
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/dto/visit/scheduler/ContactDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/dto/visit/scheduler/ContactDto.kt
@@ -5,11 +5,33 @@ import io.swagger.v3.oas.annotations.media.Schema
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @Schema(description = "Contact")
-data class ContactDto(
+open class ContactDto(
   @Schema(description = "Contact Name", example = "John Smith", required = true)
-  val name: String,
+  open val name: String,
   @Schema(description = "Contact Phone Number", example = "01234 567890", required = false)
-  val telephone: String? = null,
+  open val telephone: String? = null,
   @Schema(description = "Contact Email Address", example = "email@example.com", required = false)
-  val email: String? = null,
-)
+  open val email: String? = null,
+) {
+  override fun equals(other: Any?): Boolean {
+    if (this === other) return true
+    if (javaClass != other?.javaClass) return false
+
+    other as ContactDto
+
+    if (name != other.name) return false
+    if (telephone != other.telephone) return false
+    if (email != other.email) return false
+
+    return true
+  }
+
+  override fun hashCode(): Int {
+    var result = name.hashCode()
+    result = 31 * result + (telephone?.hashCode() ?: 0)
+    result = 31 * result + (email?.hashCode() ?: 0)
+    return result
+  }
+
+  override fun toString(): String = "ContactDto(name='$name', telephone=$telephone, email=$email)"
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/IntegrationTestBase.kt
@@ -223,7 +223,7 @@ abstract class IntegrationTestBase {
     modifiedTimestamp: LocalDateTime = LocalDateTime.now(),
     sessionTemplateReference: String? = "ref.ref.ref",
     visitors: List<VisitorDto>? = null,
-    contact: ContactDto = ContactDto("Jane Doe", "01234567890", "email@example.com"),
+    contact: ContactDto? = ContactDto("Jane Doe", "01234567890", "email@example.com"),
     firstBookedDate: LocalDateTime? = null,
   ): VisitDto = VisitDto(
     applicationReference = applicationReference,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/visit/GetVisitBookingDetailsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/visit/GetVisitBookingDetailsTest.kt
@@ -15,6 +15,7 @@ import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.con
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.orchestration.EventAuditOrchestrationDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.orchestration.PrisonerDetailsDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.orchestration.VisitBookingDetailsDto
+import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.orchestration.VisitContactDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.orchestration.VisitNotificationDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.orchestration.VisitorDetailsDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.prison.api.OffenderRestrictionDto
@@ -22,6 +23,7 @@ import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.pri
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.prison.register.PrisonRegisterPrisonDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.prisoner.search.PrisonerDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.visit.scheduler.ActionedByDto
+import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.visit.scheduler.ContactDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.visit.scheduler.EventAuditDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.visit.scheduler.VisitDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.visit.scheduler.enums.ApplicationMethodType.EMAIL
@@ -166,7 +168,11 @@ class GetVisitBookingDetailsTest : IntegrationTestBase() {
     // Then
     responseSpec.expectStatus().isOk
     val visitBookingResponse = getResult(responseSpec.expectBody())
-    assertVisitBookingDetails(visitBookingResponse, visit, prison, prisonerDto, listOf(alert1, alert2), offenderRestrictions, contactsList, visitor3.personId, eventList, expectedEventActionedByFullNames, notifications)
+    val expectedVisitContact = VisitContactDto(
+      contactDto = visit.visitContact!!,
+      visitContactId = visitor3.personId,
+    )
+    assertVisitBookingDetails(visitBookingResponse, visit, prison, prisonerDto, listOf(alert1, alert2), offenderRestrictions, contactsList, expectedVisitContact, eventList, expectedEventActionedByFullNames, notifications)
   }
 
   @Test
@@ -200,7 +206,90 @@ class GetVisitBookingDetailsTest : IntegrationTestBase() {
     // Then
     responseSpec.expectStatus().isOk
     val visitBookingResponse = getResult(responseSpec.expectBody())
-    assertVisitBookingDetails(visitBookingResponse, visit, prison, prisonerDto, listOf(alert1, alert2), offenderRestrictions, contactsList, visitor3.personId, eventList, expectedEventActionedByFullNames, notifications)
+    val expectedVisitContact = VisitContactDto(
+      contactDto = visit.visitContact!!,
+      visitContactId = visitor3.personId,
+    )
+
+    assertVisitBookingDetails(visitBookingResponse, visit, prison, prisonerDto, listOf(alert1, alert2), offenderRestrictions, contactsList, expectedVisitContact, eventList, expectedEventActionedByFullNames, notifications)
+  }
+
+  @Test
+  fun `when a visit's contact details are null then visitContactDetails are also returned as null for that visit`() {
+    // Given
+    val reference = "aa-bb-cc-dd"
+    val prisonerId = "prisoner-id"
+    val visitors = listOf(createVisitorDto(visitor1, false), createVisitorDto(visitor2, false), createVisitorDto(visitor3, true))
+
+    // contact for the visit is null
+    val visit = createVisitDto(reference = reference, prisonCode = prisonCode, prisonerId = prisonerId, visitors = visitors, contact = null)
+    val contactsList = listOf(visitor1, visitor2, visitor3)
+    val eventList = mutableListOf(eventAudit1, eventAudit2, eventAudit3)
+    val expectedEventActionedByFullNames = listOf("abcd", null, "Test User A")
+
+    val notifications = emptyList<VisitNotificationEventDto>()
+
+    visitSchedulerMockServer.stubGetVisit(reference, visit)
+    prisonOffenderSearchMockServer.stubGetPrisonerById(prisonerId, prisonerDto)
+    prisonRegisterMockServer.stubGetPrison(prisonCode, prison)
+    // alert 3's alert code is not relevant for visits so should be ignored
+    alertApiMockServer.stubGetPrisonerAlertsMono(prisonerId, listOf(alert1, alert2, alert3))
+    prisonApiMockServer.stubGetPrisonerRestrictions(prisonerId, offenderRestrictions)
+    prisonerContactRegistryMockServer.stubGetPrisonerContacts(prisonerId = prisonerId, withAddress = true, approvedVisitorsOnly = false, personId = null, hasDateOfBirth = null, contactsList = contactsList)
+    visitSchedulerMockServer.stubGetVisitHistory(visit.reference, eventList)
+    visitSchedulerMockServer.stubGetVisitNotificationEvents(visit.reference, notifications)
+    manageUsersApiMockServer.stubGetUserDetails("test-user", "Test User A")
+
+    // When
+    val responseSpec = callGetVisitFullDetailsByReference(webTestClient, reference, roleVSIPOrchestrationServiceHttpHeaders)
+
+    // Then
+    responseSpec.expectStatus().isOk
+    val visitBookingResponse = getResult(responseSpec.expectBody())
+    assertVisitBookingDetails(visitBookingResponse, visit, prison, prisonerDto, listOf(alert1, alert2), offenderRestrictions, contactsList, expectedVisitContact = null, eventList, expectedEventActionedByFullNames, notifications)
+  }
+
+  @Test
+  fun `when a visit's contact is not from the contact list then visitContactDetails are populated without contactId for that visit`() {
+    // Given
+    val reference = "aa-bb-cc-dd"
+    val prisonerId = "prisoner-id"
+
+    // none of the 3 visitors are main contacts
+    val visitors = listOf(createVisitorDto(visitor1, false), createVisitorDto(visitor2, false), createVisitorDto(visitor3, false))
+
+    // main contact details
+    val contact = ContactDto("Johnny Doe", "01234567890", "email@example.com")
+    val visit = createVisitDto(reference = reference, prisonCode = prisonCode, prisonerId = prisonerId, visitors = visitors, contact = contact)
+    // contacts returned does not have visitor 3
+    val contactsList = listOf(visitor1, visitor2)
+    val eventList = mutableListOf(eventAudit1, eventAudit2, eventAudit3)
+    val expectedEventActionedByFullNames = listOf("abcd", null, "Test User A")
+
+    val notifications = emptyList<VisitNotificationEventDto>()
+
+    visitSchedulerMockServer.stubGetVisit(reference, visit)
+    prisonOffenderSearchMockServer.stubGetPrisonerById(prisonerId, prisonerDto)
+    prisonRegisterMockServer.stubGetPrison(prisonCode, prison)
+    // alert 3's alert code is not relevant for visits so should be ignored
+    alertApiMockServer.stubGetPrisonerAlertsMono(prisonerId, listOf(alert1, alert2, alert3))
+    prisonApiMockServer.stubGetPrisonerRestrictions(prisonerId, offenderRestrictions)
+    prisonerContactRegistryMockServer.stubGetPrisonerContacts(prisonerId = prisonerId, withAddress = true, approvedVisitorsOnly = false, personId = null, hasDateOfBirth = null, contactsList = contactsList)
+    visitSchedulerMockServer.stubGetVisitHistory(visit.reference, eventList)
+    visitSchedulerMockServer.stubGetVisitNotificationEvents(visit.reference, notifications)
+    manageUsersApiMockServer.stubGetUserDetails("test-user", "Test User A")
+
+    // When
+    val responseSpec = callGetVisitFullDetailsByReference(webTestClient, reference, roleVSIPOrchestrationServiceHttpHeaders)
+
+    // Then
+    responseSpec.expectStatus().isOk
+    val visitBookingResponse = getResult(responseSpec.expectBody())
+    val expectedVisitContact = VisitContactDto(
+      contactDto = visit.visitContact!!,
+      visitContactId = null,
+    )
+    assertVisitBookingDetails(visitBookingResponse, visit, prison, prisonerDto, listOf(alert1, alert2), offenderRestrictions, contactsList, expectedVisitContact, eventList, expectedEventActionedByFullNames, notifications)
   }
 
   @Test
@@ -291,7 +380,12 @@ class GetVisitBookingDetailsTest : IntegrationTestBase() {
 
     // as prison register search returned a 404 we expect both prison code and name to have the same value of prison code
     val expectedPrison = PrisonRegisterPrisonDto(prisonCode, prisonCode, true)
-    assertVisitBookingDetails(visitBookingResponse, visit, expectedPrison, prisonerDto, listOf(alert1, alert2), offenderRestrictions, contactsList, visitor3.personId, eventList, expectedEventActionedByFullNames, notifications)
+    val expectedVisitContact = VisitContactDto(
+      contactDto = visit.visitContact!!,
+      visitContactId = visitor3.personId,
+    )
+
+    assertVisitBookingDetails(visitBookingResponse, visit, expectedPrison, prisonerDto, listOf(alert1, alert2), offenderRestrictions, contactsList, expectedVisitContact, eventList, expectedEventActionedByFullNames, notifications)
   }
 
   @Test
@@ -587,7 +681,12 @@ class GetVisitBookingDetailsTest : IntegrationTestBase() {
     // Then
     responseSpec.expectStatus().isOk
     val visitBookingResponse = getResult(responseSpec.expectBody())
-    assertVisitBookingDetails(visitBookingResponse, visit, prison, prisonerDto, listOf(alert1, alert2), offenderRestrictions, contactsList, visitor3.personId, eventList, expectedEventActionedByFullNames, notifications)
+    val expectedVisitContact = VisitContactDto(
+      contactDto = visit.visitContact!!,
+      visitContactId = visitor3.personId,
+    )
+
+    assertVisitBookingDetails(visitBookingResponse, visit, prison, prisonerDto, listOf(alert1, alert2), offenderRestrictions, contactsList, expectedVisitContact, eventList, expectedEventActionedByFullNames, notifications)
   }
 
   @Test
@@ -620,7 +719,12 @@ class GetVisitBookingDetailsTest : IntegrationTestBase() {
     // Then
     responseSpec.expectStatus().isOk
     val visitBookingResponse = getResult(responseSpec.expectBody())
-    assertVisitBookingDetails(visitBookingResponse, visit, prison, prisonerDto, listOf(alert1, alert2), offenderRestrictions, contactsList, visitor3.personId, eventList, expectedEventActionedByFullNames, notifications)
+    val expectedVisitContact = VisitContactDto(
+      contactDto = visit.visitContact!!,
+      visitContactId = visitor3.personId,
+    )
+
+    assertVisitBookingDetails(visitBookingResponse, visit, prison, prisonerDto, listOf(alert1, alert2), offenderRestrictions, contactsList, expectedVisitContact, eventList, expectedEventActionedByFullNames, notifications)
   }
 
   private fun getResult(bodyContentSpec: WebTestClient.BodyContentSpec): VisitBookingDetailsDto = objectMapper.readValue(bodyContentSpec.returnResult().responseBody, VisitBookingDetailsDto::class.java)
@@ -633,12 +737,12 @@ class GetVisitBookingDetailsTest : IntegrationTestBase() {
     relevantPrisonerAlerts: List<AlertResponseDto>,
     prisonerRestrictions: OffenderRestrictionsDto,
     visitors: List<PrisonerContactDto>,
-    visitContactId: Long?,
+    expectedVisitContact: VisitContactDto?,
     events: List<EventAuditDto>,
     expectedEventActionedByFullNames: List<String?>,
     notifications: List<VisitNotificationEventDto>,
   ) {
-    assertVisitDetails(visitBookingDetailsDto, visitDto, visitContactId)
+    assertVisitDetails(visitBookingDetailsDto, visitDto, expectedVisitContact)
     assertPrisonDetails(visitBookingDetailsDto, prisonDto)
     assertPrisonerDetails(visitBookingDetailsDto, visitDto, prisonerDto, relevantPrisonerAlerts, prisonerRestrictions.offenderRestrictions)
     assertVisitors(visitBookingDetailsDto, visitors)
@@ -649,19 +753,18 @@ class GetVisitBookingDetailsTest : IntegrationTestBase() {
   private fun assertVisitDetails(
     visitBookingDetailsDto: VisitBookingDetailsDto,
     visitDto: VisitDto,
-    visitContactId: Long?,
+    visitContact: VisitContactDto?,
   ) {
     assertThat(visitBookingDetailsDto.reference).isEqualTo(visitDto.reference)
     assertThat(visitBookingDetailsDto.visitRoom).isEqualTo(visitDto.visitRoom)
     assertThat(visitBookingDetailsDto.visitStatus).isEqualTo(visitDto.visitStatus)
     assertThat(visitBookingDetailsDto.outcomeStatus).isEqualTo(visitDto.outcomeStatus)
     assertThat(visitBookingDetailsDto.visitRestriction).isEqualTo(visitDto.visitRestriction)
-    assertThat(visitBookingDetailsDto.visitContact).isEqualTo(visitDto.visitContact)
-    assertThat(visitBookingDetailsDto.visitContactId).isEqualTo(visitContactId)
     assertThat(visitBookingDetailsDto.endTimestamp).isEqualTo(visitDto.endTimestamp)
     assertThat(visitBookingDetailsDto.startTimestamp).isEqualTo(visitDto.startTimestamp)
     assertThat(visitBookingDetailsDto.visitorSupport).isEqualTo(visitDto.visitorSupport)
     assertThat(visitBookingDetailsDto.visitNotes).isEqualTo(visitDto.visitNotes)
+    assertThat(visitBookingDetailsDto.visitContact).isEqualTo(visitContact)
   }
 
   private fun assertPrisonDetails(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/visit/GetVisitBookingDetailsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/visit/GetVisitBookingDetailsTest.kt
@@ -142,7 +142,7 @@ class GetVisitBookingDetailsTest : IntegrationTestBase() {
   fun `when visit exists search by reference returns the full booking details for that visit`() {
     // Given
     val reference = "aa-bb-cc-dd"
-    val visitors = listOf(createVisitorDto(visitor1, true), createVisitorDto(visitor2, false), createVisitorDto(visitor3, true))
+    val visitors = listOf(createVisitorDto(visitor1, false), createVisitorDto(visitor2, false), createVisitorDto(visitor3, true))
     val visit = createVisitDto(reference = reference, prisonCode = prisonCode, prisonerId = prisonerId, visitors = visitors)
     val contactsList = listOf(visitor1, visitor2, visitor3)
     val eventList = listOf(eventAudit1, eventAudit2, eventAudit3, eventAudit4, eventAudit5)
@@ -166,7 +166,7 @@ class GetVisitBookingDetailsTest : IntegrationTestBase() {
     // Then
     responseSpec.expectStatus().isOk
     val visitBookingResponse = getResult(responseSpec.expectBody())
-    assertVisitBookingDetails(visitBookingResponse, visit, prison, prisonerDto, listOf(alert1, alert2), offenderRestrictions, contactsList, eventList, expectedEventActionedByFullNames, notifications)
+    assertVisitBookingDetails(visitBookingResponse, visit, prison, prisonerDto, listOf(alert1, alert2), offenderRestrictions, contactsList, visitor3.personId, eventList, expectedEventActionedByFullNames, notifications)
   }
 
   @Test
@@ -174,7 +174,7 @@ class GetVisitBookingDetailsTest : IntegrationTestBase() {
     // Given
     val reference = "aa-bb-cc-dd"
     val prisonerId = "prisoner-id"
-    val visitors = listOf(createVisitorDto(visitor1, true), createVisitorDto(visitor2, false), createVisitorDto(visitor3, true))
+    val visitors = listOf(createVisitorDto(visitor1, false), createVisitorDto(visitor2, false), createVisitorDto(visitor3, true))
     val visit = createVisitDto(reference = reference, prisonCode = prisonCode, prisonerId = prisonerId, visitors = visitors)
     // contacts returned does not have visitor 3
     val contactsList = listOf(visitor1, visitor2)
@@ -200,7 +200,7 @@ class GetVisitBookingDetailsTest : IntegrationTestBase() {
     // Then
     responseSpec.expectStatus().isOk
     val visitBookingResponse = getResult(responseSpec.expectBody())
-    assertVisitBookingDetails(visitBookingResponse, visit, prison, prisonerDto, listOf(alert1, alert2), offenderRestrictions, contactsList, eventList, expectedEventActionedByFullNames, notifications)
+    assertVisitBookingDetails(visitBookingResponse, visit, prison, prisonerDto, listOf(alert1, alert2), offenderRestrictions, contactsList, visitor3.personId, eventList, expectedEventActionedByFullNames, notifications)
   }
 
   @Test
@@ -208,7 +208,7 @@ class GetVisitBookingDetailsTest : IntegrationTestBase() {
     // Given
     val reference = "aa-bb-cc-dd"
     val prisonerId = "prisoner-id"
-    val visitors = listOf(createVisitorDto(visitor1, true), createVisitorDto(visitor2, false), createVisitorDto(visitor3, true))
+    val visitors = listOf(createVisitorDto(visitor1, false), createVisitorDto(visitor2, false), createVisitorDto(visitor3, true))
     val visit = createVisitDto(reference = reference, prisonCode = prisonCode, prisonerId = prisonerId, visitors = visitors)
     val contactsList = listOf(visitor1, visitor2, visitor3)
     val eventList = mutableListOf(eventAudit3)
@@ -237,7 +237,7 @@ class GetVisitBookingDetailsTest : IntegrationTestBase() {
     // Given
     val reference = "aa-bb-cc-dd"
     val prisonerId = "prisoner-id"
-    val visitors = listOf(createVisitorDto(visitor1, true), createVisitorDto(visitor2, false), createVisitorDto(visitor3, true))
+    val visitors = listOf(createVisitorDto(visitor1, false), createVisitorDto(visitor2, false), createVisitorDto(visitor3, true))
     val visit = createVisitDto(reference = reference, prisonCode = prisonCode, prisonerId = prisonerId, visitors = visitors)
     val contactsList = listOf(visitor1, visitor2, visitor3)
     val eventList = mutableListOf(eventAudit1)
@@ -265,7 +265,7 @@ class GetVisitBookingDetailsTest : IntegrationTestBase() {
     // Given
     val reference = "aa-bb-cc-dd"
     val prisonerId = "prisoner-id"
-    val visitors = listOf(createVisitorDto(visitor1, true), createVisitorDto(visitor2, false), createVisitorDto(visitor3, true))
+    val visitors = listOf(createVisitorDto(visitor1, false), createVisitorDto(visitor2, false), createVisitorDto(visitor3, true))
     val visit = createVisitDto(reference = reference, prisonCode = prisonCode, prisonerId = prisonerId, visitors = visitors)
     val contactsList = listOf(visitor1, visitor2, visitor3)
     val eventList = mutableListOf(eventAudit1)
@@ -291,14 +291,14 @@ class GetVisitBookingDetailsTest : IntegrationTestBase() {
 
     // as prison register search returned a 404 we expect both prison code and name to have the same value of prison code
     val expectedPrison = PrisonRegisterPrisonDto(prisonCode, prisonCode, true)
-    assertVisitBookingDetails(visitBookingResponse, visit, expectedPrison, prisonerDto, listOf(alert1, alert2), offenderRestrictions, contactsList, eventList, expectedEventActionedByFullNames, notifications)
+    assertVisitBookingDetails(visitBookingResponse, visit, expectedPrison, prisonerDto, listOf(alert1, alert2), offenderRestrictions, contactsList, visitor3.personId, eventList, expectedEventActionedByFullNames, notifications)
   }
 
   @Test
   fun `when prison register search returns a 500 an exception is thrown and a 500 is returned as response`() {
     // Given
     val reference = "aa-bb-cc-dd"
-    val visitors = listOf(createVisitorDto(visitor1, true), createVisitorDto(visitor2, false), createVisitorDto(visitor3, true))
+    val visitors = listOf(createVisitorDto(visitor1, false), createVisitorDto(visitor2, false), createVisitorDto(visitor3, true))
     val visit = createVisitDto(reference = reference, prisonCode = prisonCode, prisonerId = prisonerId, visitors = visitors)
     val contactsList = listOf(visitor1, visitor2, visitor3)
     val eventList = mutableListOf(eventAudit1)
@@ -324,7 +324,7 @@ class GetVisitBookingDetailsTest : IntegrationTestBase() {
   fun `when alert API returns returns a 500 an exception is thrown and a 500 is returned as response`() {
     // Given
     val reference = "aa-bb-cc-dd"
-    val visitors = listOf(createVisitorDto(visitor1, true), createVisitorDto(visitor2, false), createVisitorDto(visitor3, true))
+    val visitors = listOf(createVisitorDto(visitor1, false), createVisitorDto(visitor2, false), createVisitorDto(visitor3, true))
     val visit = createVisitDto(reference = reference, prisonCode = prisonCode, prisonerId = prisonerId, visitors = visitors)
     val contactsList = listOf(visitor1, visitor2, visitor3)
     val eventList = mutableListOf(eventAudit1)
@@ -351,7 +351,7 @@ class GetVisitBookingDetailsTest : IntegrationTestBase() {
   fun `when prison API get restrictions call returns returns a 404 an exception is thrown and a 404 is returned as response`() {
     // Given
     val reference = "aa-bb-cc-dd"
-    val visitors = listOf(createVisitorDto(visitor1, true), createVisitorDto(visitor2, false), createVisitorDto(visitor3, true))
+    val visitors = listOf(createVisitorDto(visitor1, false), createVisitorDto(visitor2, false), createVisitorDto(visitor3, true))
     val visit = createVisitDto(reference = reference, prisonCode = prisonCode, prisonerId = prisonerId, visitors = visitors)
     val contactsList = listOf(visitor1, visitor2, visitor3)
     val eventList = mutableListOf(eventAudit1)
@@ -378,7 +378,7 @@ class GetVisitBookingDetailsTest : IntegrationTestBase() {
   fun `when prison API get restrictions call returns returns a 500 an exception is thrown and a 500 is returned as response`() {
     // Given
     val reference = "aa-bb-cc-dd"
-    val visitors = listOf(createVisitorDto(visitor1, true), createVisitorDto(visitor2, false), createVisitorDto(visitor3, true))
+    val visitors = listOf(createVisitorDto(visitor1, false), createVisitorDto(visitor2, false), createVisitorDto(visitor3, true))
     val visit = createVisitDto(reference = reference, prisonCode = prisonCode, prisonerId = prisonerId, visitors = visitors)
     val contactsList = listOf(visitor1, visitor2, visitor3)
     val eventList = mutableListOf(eventAudit1)
@@ -405,7 +405,7 @@ class GetVisitBookingDetailsTest : IntegrationTestBase() {
   fun `when prisoner contact registry API call returns returns a 404 an exception is thrown and a 404 is returned as response`() {
     // Given
     val reference = "aa-bb-cc-dd"
-    val visitors = listOf(createVisitorDto(visitor1, true), createVisitorDto(visitor2, false), createVisitorDto(visitor3, true))
+    val visitors = listOf(createVisitorDto(visitor1, false), createVisitorDto(visitor2, false), createVisitorDto(visitor3, true))
     val visit = createVisitDto(reference = reference, prisonCode = prisonCode, prisonerId = prisonerId, visitors = visitors)
     val eventList = mutableListOf(eventAudit1)
     val notifications = listOf(notification1, notification2)
@@ -431,7 +431,7 @@ class GetVisitBookingDetailsTest : IntegrationTestBase() {
   fun `when prisoner contact registry API call returns returns a 500 an exception is thrown and a 500 is returned as response`() {
     // Given
     val reference = "aa-bb-cc-dd"
-    val visitors = listOf(createVisitorDto(visitor1, true), createVisitorDto(visitor2, false), createVisitorDto(visitor3, true))
+    val visitors = listOf(createVisitorDto(visitor1, false), createVisitorDto(visitor2, false), createVisitorDto(visitor3, true))
     val visit = createVisitDto(reference = reference, prisonCode = prisonCode, prisonerId = prisonerId, visitors = visitors)
     val eventList = mutableListOf(eventAudit1)
     val notifications = listOf(notification1, notification2)
@@ -457,7 +457,7 @@ class GetVisitBookingDetailsTest : IntegrationTestBase() {
   fun `when visit history API call returns returns a 404 an exception is thrown and a 404 is returned as response`() {
     // Given
     val reference = "aa-bb-cc-dd"
-    val visitors = listOf(createVisitorDto(visitor1, true), createVisitorDto(visitor2, false), createVisitorDto(visitor3, true))
+    val visitors = listOf(createVisitorDto(visitor1, false), createVisitorDto(visitor2, false), createVisitorDto(visitor3, true))
     val visit = createVisitDto(reference = reference, prisonCode = prisonCode, prisonerId = prisonerId, visitors = visitors)
     val contactsList = listOf(visitor1, visitor2, visitor3)
     val notifications = listOf(notification1, notification2)
@@ -483,7 +483,7 @@ class GetVisitBookingDetailsTest : IntegrationTestBase() {
   fun `when visit history API call returns returns a 500 an exception is thrown and a 500 is returned as response`() {
     // Given
     val reference = "aa-bb-cc-dd"
-    val visitors = listOf(createVisitorDto(visitor1, true), createVisitorDto(visitor2, false), createVisitorDto(visitor3, true))
+    val visitors = listOf(createVisitorDto(visitor1, false), createVisitorDto(visitor2, false), createVisitorDto(visitor3, true))
     val visit = createVisitDto(reference = reference, prisonCode = prisonCode, prisonerId = prisonerId, visitors = visitors)
     val contactsList = listOf(visitor1, visitor2, visitor3)
     val notifications = listOf(notification1, notification2)
@@ -509,7 +509,7 @@ class GetVisitBookingDetailsTest : IntegrationTestBase() {
   fun `when visit notifications API call returns returns a 404 an exception is thrown and a 404 is returned as response`() {
     // Given
     val reference = "aa-bb-cc-dd"
-    val visitors = listOf(createVisitorDto(visitor1, true), createVisitorDto(visitor2, false), createVisitorDto(visitor3, true))
+    val visitors = listOf(createVisitorDto(visitor1, false), createVisitorDto(visitor2, false), createVisitorDto(visitor3, true))
     val visit = createVisitDto(reference = reference, prisonCode = prisonCode, prisonerId = prisonerId, visitors = visitors)
     val contactsList = listOf(visitor1, visitor2, visitor3)
     val eventList = mutableListOf(eventAudit1)
@@ -535,7 +535,7 @@ class GetVisitBookingDetailsTest : IntegrationTestBase() {
   fun `when visit notifications API call returns returns a 500 an exception is thrown and a 500 is returned as response`() {
     // Given
     val reference = "aa-bb-cc-dd"
-    val visitors = listOf(createVisitorDto(visitor1, true), createVisitorDto(visitor2, false), createVisitorDto(visitor3, true))
+    val visitors = listOf(createVisitorDto(visitor1, false), createVisitorDto(visitor2, false), createVisitorDto(visitor3, true))
     val visit = createVisitDto(reference = reference, prisonCode = prisonCode, prisonerId = prisonerId, visitors = visitors)
     val contactsList = listOf(visitor1, visitor2, visitor3)
     val eventList = mutableListOf(eventAudit1)
@@ -561,7 +561,7 @@ class GetVisitBookingDetailsTest : IntegrationTestBase() {
   fun `when visit exists by reference but manage user search returns a 404 the full booking details for that visit is still returned`() {
     // Given
     val reference = "aa-bb-cc-dd"
-    val visitors = listOf(createVisitorDto(visitor1, true), createVisitorDto(visitor2, false), createVisitorDto(visitor3, true))
+    val visitors = listOf(createVisitorDto(visitor1, false), createVisitorDto(visitor2, false), createVisitorDto(visitor3, true))
     val visit = createVisitDto(reference = reference, prisonCode = prisonCode, prisonerId = prisonerId, visitors = visitors)
     val contactsList = listOf(visitor1, visitor2, visitor3)
     val eventList = listOf(eventAudit1, eventAudit2, eventAudit3, eventAudit4, eventAudit5)
@@ -587,14 +587,14 @@ class GetVisitBookingDetailsTest : IntegrationTestBase() {
     // Then
     responseSpec.expectStatus().isOk
     val visitBookingResponse = getResult(responseSpec.expectBody())
-    assertVisitBookingDetails(visitBookingResponse, visit, prison, prisonerDto, listOf(alert1, alert2), offenderRestrictions, contactsList, eventList, expectedEventActionedByFullNames, notifications)
+    assertVisitBookingDetails(visitBookingResponse, visit, prison, prisonerDto, listOf(alert1, alert2), offenderRestrictions, contactsList, visitor3.personId, eventList, expectedEventActionedByFullNames, notifications)
   }
 
   @Test
   fun `when visit exists by reference but manage user search returns a 500 the full booking details for that visit is still returned`() {
     // Given
     val reference = "aa-bb-cc-dd"
-    val visitors = listOf(createVisitorDto(visitor1, true), createVisitorDto(visitor2, false), createVisitorDto(visitor3, true))
+    val visitors = listOf(createVisitorDto(visitor1, false), createVisitorDto(visitor2, false), createVisitorDto(visitor3, true))
     val visit = createVisitDto(reference = reference, prisonCode = prisonCode, prisonerId = prisonerId, visitors = visitors)
     val contactsList = listOf(visitor1, visitor2, visitor3)
     val eventList = listOf(eventAudit1, eventAudit2, eventAudit3, eventAudit4, eventAudit5)
@@ -620,7 +620,7 @@ class GetVisitBookingDetailsTest : IntegrationTestBase() {
     // Then
     responseSpec.expectStatus().isOk
     val visitBookingResponse = getResult(responseSpec.expectBody())
-    assertVisitBookingDetails(visitBookingResponse, visit, prison, prisonerDto, listOf(alert1, alert2), offenderRestrictions, contactsList, eventList, expectedEventActionedByFullNames, notifications)
+    assertVisitBookingDetails(visitBookingResponse, visit, prison, prisonerDto, listOf(alert1, alert2), offenderRestrictions, contactsList, visitor3.personId, eventList, expectedEventActionedByFullNames, notifications)
   }
 
   private fun getResult(bodyContentSpec: WebTestClient.BodyContentSpec): VisitBookingDetailsDto = objectMapper.readValue(bodyContentSpec.returnResult().responseBody, VisitBookingDetailsDto::class.java)
@@ -633,11 +633,12 @@ class GetVisitBookingDetailsTest : IntegrationTestBase() {
     relevantPrisonerAlerts: List<AlertResponseDto>,
     prisonerRestrictions: OffenderRestrictionsDto,
     visitors: List<PrisonerContactDto>,
+    visitContactId: Long?,
     events: List<EventAuditDto>,
     expectedEventActionedByFullNames: List<String?>,
     notifications: List<VisitNotificationEventDto>,
   ) {
-    assertVisitDetails(visitBookingDetailsDto, visitDto)
+    assertVisitDetails(visitBookingDetailsDto, visitDto, visitContactId)
     assertPrisonDetails(visitBookingDetailsDto, prisonDto)
     assertPrisonerDetails(visitBookingDetailsDto, visitDto, prisonerDto, relevantPrisonerAlerts, prisonerRestrictions.offenderRestrictions)
     assertVisitors(visitBookingDetailsDto, visitors)
@@ -648,6 +649,7 @@ class GetVisitBookingDetailsTest : IntegrationTestBase() {
   private fun assertVisitDetails(
     visitBookingDetailsDto: VisitBookingDetailsDto,
     visitDto: VisitDto,
+    visitContactId: Long?,
   ) {
     assertThat(visitBookingDetailsDto.reference).isEqualTo(visitDto.reference)
     assertThat(visitBookingDetailsDto.visitRoom).isEqualTo(visitDto.visitRoom)
@@ -655,6 +657,7 @@ class GetVisitBookingDetailsTest : IntegrationTestBase() {
     assertThat(visitBookingDetailsDto.outcomeStatus).isEqualTo(visitDto.outcomeStatus)
     assertThat(visitBookingDetailsDto.visitRestriction).isEqualTo(visitDto.visitRestriction)
     assertThat(visitBookingDetailsDto.visitContact).isEqualTo(visitDto.visitContact)
+    assertThat(visitBookingDetailsDto.visitContactId).isEqualTo(visitContactId)
     assertThat(visitBookingDetailsDto.endTimestamp).isEqualTo(visitDto.endTimestamp)
     assertThat(visitBookingDetailsDto.startTimestamp).isEqualTo(visitDto.startTimestamp)
     assertThat(visitBookingDetailsDto.visitorSupport).isEqualTo(visitDto.visitorSupport)


### PR DESCRIPTION
Add `visitContactId` to `visitContact` in `VisitBookingDetailsDto`. This is the `nomisPersonId` of the visitor set as the `visitContact` (i.e. main contact).

This is needed so that `VisitBookingDetailsDto` has all the required information to initiate an update visit journey.