### PR TITLE
Fix issue where VisitCreated and VisitUpdated errors would not end up the DLQ

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/client/VisitSchedulerClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/client/VisitSchedulerClient.kt
@@ -200,7 +200,10 @@ class VisitSchedulerClient(
     .accept(MediaType.APPLICATION_JSON)
     .retrieve()
     .bodyToMono<VisitDto>()
-    .doOnError { e -> LOG.error("Could not update visit from external system :", e) }
+    .onErrorResume { e ->
+      LOG.error("Could not update visit from external system :", e)
+      Mono.error(e)
+    }
     .block(apiTimeout)
 
   fun getBookedVisitByApplicationReference(applicationReference: String): VisitDto? = webClient.get()
@@ -515,7 +518,10 @@ class VisitSchedulerClient(
     .body(BodyInserters.fromValue(createVisitFromExternalSystemDto))
     .retrieve()
     .bodyToMono<VisitDto>()
-    .doOnError { e -> LOG.error("Could not create visit from external system :", e) }
+    .onErrorResume { e ->
+      LOG.error("Could not create visit from external system :", e)
+      Mono.error(e)
+    }
     .block(apiTimeout)
 
   private fun visitSearchUriBuilder(visitSearchRequestFilter: VisitSearchRequestFilter, uriBuilder: UriBuilder): UriBuilder {


### PR DESCRIPTION
Errors were being caught and logged but not then rethrown so I think this was resulting in the tasks not ending up on the DLQ