### PR TITLE
Add restriction ID to visitor local and global restriction events

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/dto/visit/scheduler/visitnotification/PersonRestrictionUpsertedNotificationDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/dto/visit/scheduler/visitnotification/PersonRestrictionUpsertedNotificationDto.kt
@@ -19,6 +19,8 @@ data class PersonRestrictionUpsertedNotificationDto(
   val validToDate: LocalDate? = null,
   @NotBlank
   val restrictionType: String,
+  @NotBlank
+  val restrictionId: String,
 ) {
 
   constructor(info: PersonRestrictionUpsertedInfo) : this(
@@ -27,5 +29,6 @@ data class PersonRestrictionUpsertedNotificationDto(
     LocalDate.parse(info.validFromDate, DateTimeFormatter.ISO_DATE),
     info.validToDate?.let { LocalDate.parse(info.validToDate, DateTimeFormatter.ISO_DATE) },
     info.restrictionType,
+    info.restrictionId,
   )
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/dto/visit/scheduler/visitnotification/VisitorRestrictionUpsertedNotificationDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/dto/visit/scheduler/visitnotification/VisitorRestrictionUpsertedNotificationDto.kt
@@ -20,6 +20,9 @@ data class VisitorRestrictionUpsertedNotificationDto(
 
   @NotBlank
   val restrictionType: String,
+
+  @NotBlank
+  val restrictionId: String,
 ) {
 
   constructor(info: VisitorRestrictionUpsertedInfo) : this(
@@ -27,5 +30,6 @@ data class VisitorRestrictionUpsertedNotificationDto(
     LocalDate.parse(info.validFromDate, DateTimeFormatter.ISO_DATE),
     info.validToDate?.let { LocalDate.parse(info.validToDate, DateTimeFormatter.ISO_DATE) },
     info.restrictionType,
+    info.restrictionId,
   )
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/service/listeners/events/additionalinfo/PersonRestrictionUpsertedInfo.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/service/listeners/events/additionalinfo/PersonRestrictionUpsertedInfo.kt
@@ -24,4 +24,8 @@ data class PersonRestrictionUpsertedInfo(
 
   @NotBlank
   val restrictionType: String,
+
+  @NotBlank
+  @JsonProperty("offenderPersonRestrictionId")
+  val restrictionId: String,
 ) : EventInfo

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/service/listeners/events/additionalinfo/VisitorRestrictionUpsertedInfo.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/service/listeners/events/additionalinfo/VisitorRestrictionUpsertedInfo.kt
@@ -20,4 +20,8 @@ data class VisitorRestrictionUpsertedInfo(
 
   @NotBlank
   val restrictionType: String,
+
+  @NotBlank
+  @JsonProperty("visitorRestrictionId")
+  val restrictionId: String,
 ) : EventInfo

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/domainevents/PrisonVisitsEventsIntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/domainevents/PrisonVisitsEventsIntegrationTestBase.kt
@@ -247,6 +247,7 @@ abstract class PrisonVisitsEventsIntegrationTestBase {
     effectiveDate: String? = null,
     expiryDate: String? = null,
     restrictionType: String? = null,
+    offenderPersonRestrictionId: String? = null,
   ): String {
     val jsonValues = HashMap<String, Any>()
     nomsNumber?.let {
@@ -263,6 +264,36 @@ abstract class PrisonVisitsEventsIntegrationTestBase {
     }
     restrictionType?.let {
       jsonValues["restrictionType"] = restrictionType
+    }
+    offenderPersonRestrictionId?.let {
+      jsonValues["offenderPersonRestrictionId"] = offenderPersonRestrictionId
+    }
+
+    return createAdditionalInformationJson(jsonValues)
+  }
+
+  fun createVisitorRestrictionAdditionalInformationJson(
+    visitorId: String? = null,
+    effectiveDate: String? = null,
+    expiryDate: String? = null,
+    restrictionType: String? = null,
+    visitorRestrictionId: String? = null,
+  ): String {
+    val jsonValues = HashMap<String, Any>()
+    visitorId?.let {
+      jsonValues["personId"] = visitorId
+    }
+    effectiveDate?.let {
+      jsonValues["effectiveDate"] = effectiveDate
+    }
+    expiryDate?.let {
+      jsonValues["expiryDate"] = expiryDate
+    }
+    restrictionType?.let {
+      jsonValues["restrictionType"] = restrictionType
+    }
+    visitorRestrictionId?.let {
+      jsonValues["visitorRestrictionId"] = visitorRestrictionId
     }
 
     return createAdditionalInformationJson(jsonValues)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/domainevents/PrisonVisitsEventsSqsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/domainevents/PrisonVisitsEventsSqsTest.kt
@@ -97,7 +97,7 @@ class PrisonVisitsEventsSqsTest : PrisonVisitsEventsIntegrationTestBase() {
       visitorId = "12345",
       validFromDate = LocalDate.parse("2023-09-20"),
       restrictionType = "BAN",
-      restrictionId = "123"
+      restrictionId = "123",
     )
 
     val domainEvent =

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/domainevents/PrisonVisitsEventsSqsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/domainevents/PrisonVisitsEventsSqsTest.kt
@@ -97,6 +97,7 @@ class PrisonVisitsEventsSqsTest : PrisonVisitsEventsIntegrationTestBase() {
       visitorId = "12345",
       validFromDate = LocalDate.parse("2023-09-20"),
       restrictionType = "BAN",
+      restrictionId = "123"
     )
 
     val domainEvent =
@@ -107,6 +108,7 @@ class PrisonVisitsEventsSqsTest : PrisonVisitsEventsIntegrationTestBase() {
           visitorId = "12345",
           effectiveDate = "2023-09-20",
           restrictionType = "BAN",
+          offenderPersonRestrictionId = "123",
         ),
       )
 
@@ -184,15 +186,17 @@ class PrisonVisitsEventsSqsTest : PrisonVisitsEventsIntegrationTestBase() {
       visitorId = "12345",
       validFromDate = LocalDate.parse("2023-09-20"),
       restrictionType = "BAN",
+      restrictionId = "123",
     )
 
     val domainEvent =
       createDomainEventJson(
         VISITOR_RESTRICTION_UPSERTED_TYPE,
-        createPersonRestrictionAdditionalInformationJson(
+        createVisitorRestrictionAdditionalInformationJson(
           visitorId = "12345",
           effectiveDate = "2023-09-20",
           restrictionType = "BAN",
+          visitorRestrictionId = "123",
         ),
       )
     val publishRequest = createDomainEventPublishRequest(VISITOR_RESTRICTION_UPSERTED_TYPE, domainEvent)


### PR DESCRIPTION
## What does this PR do?
This will be used in the visit-scheduler to capture the restriction ID, the frontend will use it to highlight a specific restriction on booking details page.