### PR TITLE
VB-5607 - Use prison config when fromDateOverride and toDateOverride are below / above prison config limits.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/utils/DateUtils.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/utils/DateUtils.kt
@@ -14,8 +14,17 @@ class DateUtils {
   ): DateRange {
     val today = LocalDate.now()
 
-    val min = minOverride ?: prison.policyNoticeDaysMin
-    val max = maxOverride ?: prison.policyNoticeDaysMax
+    val min = if (minOverride == null || minOverride < prison.policyNoticeDaysMin) {
+      prison.policyNoticeDaysMin
+    } else {
+      minOverride
+    }
+
+    val max = if (maxOverride == null || maxOverride > prison.policyNoticeDaysMax) {
+      prison.policyNoticeDaysMax
+    } else {
+      maxOverride
+    }
 
     val bookableStartDate = today.plusDays(min.toLong())
     val bookableEndDate = today.plusDays(max.toLong())

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/sessions/AvailableVisitSessionsDateRangeTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/sessions/AvailableVisitSessionsDateRangeTest.kt
@@ -299,6 +299,127 @@ class AvailableVisitSessionsDateRangeTest : IntegrationTestBase() {
   }
 
   @Test
+  fun `when fromDateOverride is less than the prison configured min the first date offered is today + prison configured min days`() {
+    // Given
+    // the fromDateOverride passed is less than the allowed prison config days
+    val fromDateOverride = 1
+    visitSchedulerMockServer.stubGetAvailableVisitSessions(visitSchedulerPrisonDto, prisonerId, OPEN, mutableListOf(visitSession1, visitSession2, visitSession3), userType = PUBLIC)
+
+    // When
+    callGetAvailableVisitSessions(
+      webTestClient,
+      prisonCode = prisonCode,
+      prisonerId = prisonerId,
+      sessionRestriction = OPEN,
+      withAppointmentsCheck = true,
+      excludedApplicationReference = null,
+      fromDateOverride = fromDateOverride,
+      userType = PUBLIC,
+      authHttpHeaders = roleVSIPOrchestrationServiceHttpHeaders,
+    )
+
+    // Then
+    // date range should ignore the fromDateOverride as it is less than the prison configured min value
+    val dateRange = DateRange(
+      fromDate = LocalDate.now().plusDays(visitSchedulerPrisonDto.policyNoticeDaysMin.toLong()),
+      toDate = LocalDate.now().plusDays(visitSchedulerPrisonDto.policyNoticeDaysMax.toLong()),
+    )
+
+    verify(visitSchedulerClient, times(1)).getAvailableVisitSessions(prisonId = prisonCode, prisonerId = prisonerId, sessionRestriction = OPEN, dateRange = dateRange, userType = PUBLIC, excludedApplicationReference = null)
+  }
+
+  @Test
+  fun `when fromDateOverride is more than the prison configured min the first date offered is today + fromDateOverride`() {
+    // Given
+    // the fromDateOverride passed is more than the allowed prison config days
+    val fromDateOverride = 15
+    visitSchedulerMockServer.stubGetAvailableVisitSessions(visitSchedulerPrisonDto, prisonerId, OPEN, mutableListOf(visitSession1, visitSession2, visitSession3), userType = PUBLIC)
+
+    // When
+    callGetAvailableVisitSessions(
+      webTestClient,
+      prisonCode = prisonCode,
+      prisonerId = prisonerId,
+      sessionRestriction = OPEN,
+      withAppointmentsCheck = true,
+      excludedApplicationReference = null,
+      fromDateOverride = fromDateOverride,
+      userType = PUBLIC,
+      authHttpHeaders = roleVSIPOrchestrationServiceHttpHeaders,
+    )
+
+    // Then
+    // date range should use the fromDateOverride as it is more than the prison configured min value
+    val dateRange = DateRange(
+      fromDate = LocalDate.now().plusDays(fromDateOverride.toLong()),
+      toDate = LocalDate.now().plusDays(visitSchedulerPrisonDto.policyNoticeDaysMax.toLong()),
+    )
+
+    verify(visitSchedulerClient, times(1)).getAvailableVisitSessions(prisonId = prisonCode, prisonerId = prisonerId, sessionRestriction = OPEN, dateRange = dateRange, userType = PUBLIC, excludedApplicationReference = null)
+  }
+
+  @Test
+  fun `when toDateOverride is less than the prison configured max the first date offered is today + toDateOverride`() {
+    // Given
+    // the toDateOverride passed is less than the allowed prison config days
+    val toDateOverride = 15
+    visitSchedulerMockServer.stubGetAvailableVisitSessions(visitSchedulerPrisonDto, prisonerId, OPEN, mutableListOf(visitSession1, visitSession2, visitSession3), userType = PUBLIC)
+
+    // When
+    callGetAvailableVisitSessions(
+      webTestClient,
+      prisonCode = prisonCode,
+      prisonerId = prisonerId,
+      sessionRestriction = OPEN,
+      withAppointmentsCheck = true,
+      excludedApplicationReference = null,
+      toDateOverride = toDateOverride,
+      userType = PUBLIC,
+      authHttpHeaders = roleVSIPOrchestrationServiceHttpHeaders,
+    )
+
+    // Then
+    // date range should use the toDateOverride as it is more than the prison configured max value
+    val dateRange = DateRange(
+      fromDate = LocalDate.now().plusDays(visitSchedulerPrisonDto.policyNoticeDaysMin.toLong()),
+      toDate = LocalDate.now().plusDays(toDateOverride.toLong()),
+    )
+
+    verify(visitSchedulerClient, times(1)).getAvailableVisitSessions(prisonId = prisonCode, prisonerId = prisonerId, sessionRestriction = OPEN, dateRange = dateRange, userType = PUBLIC, excludedApplicationReference = null)
+  }
+
+  @Test
+  fun `when toDateOverride is more than the prison configured max the first date offered is today + prison configured max days`() {
+    // Given
+    // the toDateOverride passed is more than the allowed prison config days
+
+    val toDateOverride = 56
+    visitSchedulerMockServer.stubGetAvailableVisitSessions(visitSchedulerPrisonDto, prisonerId, OPEN, mutableListOf(visitSession1, visitSession2, visitSession3), userType = PUBLIC)
+
+    // When
+    callGetAvailableVisitSessions(
+      webTestClient,
+      prisonCode = prisonCode,
+      prisonerId = prisonerId,
+      sessionRestriction = OPEN,
+      withAppointmentsCheck = true,
+      excludedApplicationReference = null,
+      toDateOverride = toDateOverride,
+      userType = PUBLIC,
+      authHttpHeaders = roleVSIPOrchestrationServiceHttpHeaders,
+    )
+
+    // Then
+    // date range should ignore the toDateOverride as it is more than the prison configured max value
+    val dateRange = DateRange(
+      fromDate = LocalDate.now().plusDays(visitSchedulerPrisonDto.policyNoticeDaysMin.toLong()),
+      toDate = LocalDate.now().plusDays(visitSchedulerPrisonDto.policyNoticeDaysMax.toLong()),
+    )
+
+    verify(visitSchedulerClient, times(1)).getAvailableVisitSessions(prisonId = prisonCode, prisonerId = prisonerId, sessionRestriction = OPEN, dateRange = dateRange, userType = PUBLIC, excludedApplicationReference = null)
+  }
+
+  @Test
   fun `when usertype not passed to get visit sessions usertype defaults to PUBLIC when visit scheduler client is called`() {
     // Given
     visitSchedulerMockServer.stubGetAvailableVisitSessions(visitSchedulerPrisonDto, prisonerId, OPEN, mutableListOf(visitSession1, visitSession2, visitSession3), userType = PUBLIC)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/utils/DateUtilsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/utils/DateUtilsTest.kt
@@ -119,4 +119,32 @@ class DateUtilsTest {
     Assertions.assertThat(dateRange.fromDate).isEqualTo(today.plusDays(prison.policyNoticeDaysMin.toLong() + pvbAdvanceFromDateByDays))
     Assertions.assertThat(dateRange.toDate).isEqualTo(today.plusDays(prison.policyNoticeDaysMax.toLong()))
   }
+
+  @Test
+  fun `when min override passed is less than the prison allows the prison days configured needs to be considered`() {
+    // Given
+    val minOverrideDays = 1
+
+    // When
+    // minOverride is less than allowed prison configuration - ignore this parameter
+    val dateRange = dateUtils.getToDaysDateRange(prison, minOverride = minOverrideDays)
+
+    // Then
+    Assertions.assertThat(dateRange.fromDate).isEqualTo(today.plusDays(prison.policyNoticeDaysMin.toLong()))
+    Assertions.assertThat(dateRange.toDate).isEqualTo(today.plusDays(prison.policyNoticeDaysMax.toLong()))
+  }
+
+  @Test
+  fun `when max override passed is more than the prison allows the prison days configured needs to be considered`() {
+    // Given
+    // maxOverride is more than allowed prison configuration - ignore this parameter
+    val maxOverrideDays = 56
+
+    // When
+    val dateRange = dateUtils.getToDaysDateRange(prison, maxOverride = maxOverrideDays)
+
+    // Then
+    Assertions.assertThat(dateRange.fromDate).isEqualTo(today.plusDays(prison.policyNoticeDaysMin.toLong()))
+    Assertions.assertThat(dateRange.toDate).isEqualTo(today.plusDays(prison.policyNoticeDaysMax.toLong()))
+  }
 }


### PR DESCRIPTION
VB-5607 - use prison config if fromDateOverride and toDateOverride passed is less than or more than configured limit.