### PR TITLE
Listen to appointment updated events in visits space

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/client/VisitSchedulerClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/client/VisitSchedulerClient.kt
@@ -65,6 +65,7 @@ const val GET_VISIT_HISTORY_CONTROLLER_PATH: String = "$VISIT_CONTROLLER_PATH/{r
 const val VISIT_NOTIFICATION_CONTROLLER_PATH: String = "$VISIT_CONTROLLER_PATH/notification"
 
 const val VISIT_NOTIFICATION_COURT_VIDEO_APPOINTMENT_CREATED_PATH: String = "$VISIT_NOTIFICATION_CONTROLLER_PATH/court-video-appointment/created"
+const val VISIT_NOTIFICATION_COURT_VIDEO_APPOINTMENT_UPDATED_PATH: String = "$VISIT_NOTIFICATION_CONTROLLER_PATH/court-video-appointment/updated"
 const val VISIT_NOTIFICATION_COURT_VIDEO_APPOINTMENT_CANCELLED_DELETED_PATH: String = "$VISIT_NOTIFICATION_CONTROLLER_PATH/court-video-appointment/cancelled-or-deleted"
 
 const val VISIT_NOTIFICATION_NON_ASSOCIATION_CHANGE_PATH: String = "$VISIT_NOTIFICATION_CONTROLLER_PATH/non-association/changed"
@@ -444,6 +445,16 @@ class VisitSchedulerClient(
       .retrieve()
       .toBodilessEntity()
       .doOnError { e -> LOG.error("Could not processCourtVideoAppointmentCreated :", e) }
+      .block(apiTimeout)
+  }
+
+  fun processCourtVideoAppointmentUpdated(sendDto: CourtVideoAppointmentNotificationDto) {
+    webClient.post()
+      .uri(VISIT_NOTIFICATION_COURT_VIDEO_APPOINTMENT_UPDATED_PATH)
+      .body(BodyInserters.fromValue(sendDto))
+      .retrieve()
+      .toBodilessEntity()
+      .doOnError { e -> LOG.error("Could not processCourtVideoAppointmentUpdated :", e) }
       .block(apiTimeout)
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/service/VisitSchedulerService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/service/VisitSchedulerService.kt
@@ -153,6 +153,10 @@ class VisitSchedulerService(
     visitSchedulerClient.processCourtVideoAppointmentCreated(CourtVideoAppointmentNotificationDto(info))
   }
 
+  fun processCourtVideoAppointmentUpdated(info: CourtVideoAppointmentInfo) {
+    visitSchedulerClient.processCourtVideoAppointmentUpdated(CourtVideoAppointmentNotificationDto(info))
+  }
+
   fun processCourtVideoAppointmentCancelledDeleted(info: CourtVideoAppointmentInfo) {
     visitSchedulerClient.processCourtVideoAppointmentCancelledDeleted(CourtVideoAppointmentNotificationDto(info))
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/service/listeners/notifiers/CourtVideoAppointmentCancelledNotifier.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/service/listeners/notifiers/CourtVideoAppointmentCancelledNotifier.kt
@@ -12,9 +12,9 @@ class CourtVideoAppointmentCancelledNotifier : EventNotifier() {
     val info: CourtVideoAppointmentInfo = getAdditionalInfo(domainEvent, CourtVideoAppointmentInfo::class.java)
     LOG.debug("Enter CourtVideoAppointmentCancelledNotifier Info: {}", info)
 
-    // TODO: VB-5754 - Add the eventCode to AdditionalInformation object, and filter to only process certain event codes (see JIRA for list).
     getVisitSchedulerService().processCourtVideoAppointmentCancelledDeleted(info)
   }
 
+  // TODO: VB-5754 - Add the eventCode to AdditionalInformation object, and filter to only process certain event codes (see JIRA for list).
   override fun isProcessableEvent(domainEvent: DomainEvent): Boolean = true
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/service/listeners/notifiers/CourtVideoAppointmentCreatedNotifier.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/service/listeners/notifiers/CourtVideoAppointmentCreatedNotifier.kt
@@ -12,9 +12,9 @@ class CourtVideoAppointmentCreatedNotifier : EventNotifier() {
     val info: CourtVideoAppointmentInfo = getAdditionalInfo(domainEvent, CourtVideoAppointmentInfo::class.java)
     LOG.debug("Enter CourtVideoAppointmentCreatedNotifier Info: {}", info)
 
-    // TODO: VB-5754 - Add the eventCode to AdditionalInformation object, and filter to only process certain event codes (see JIRA for list).
     getVisitSchedulerService().processCourtVideoAppointmentCreated(info)
   }
 
+  // TODO: VB-5754 - Add the eventCode to AdditionalInformation object, and filter to only process certain event codes (see JIRA for list).
   override fun isProcessableEvent(domainEvent: DomainEvent): Boolean = true
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/service/listeners/notifiers/CourtVideoAppointmentUpdatedNotifier.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/service/listeners/notifiers/CourtVideoAppointmentUpdatedNotifier.kt
@@ -4,15 +4,15 @@ import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.service.listeners.events.DomainEvent
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.service.listeners.events.additionalinfo.CourtVideoAppointmentInfo
 
-const val COURT_VIDEO_APPOINTMENT_DELETED_EVENT_TYPE = "appointments.appointment-instance.deleted"
+const val COURT_VIDEO_APPOINTMENT_UPDATED_EVENT_TYPE = "appointments.appointment-instance.updated"
 
-@Component(value = COURT_VIDEO_APPOINTMENT_DELETED_EVENT_TYPE)
-class CourtVideoAppointmentDeletedNotifier : EventNotifier() {
+@Component(value = COURT_VIDEO_APPOINTMENT_UPDATED_EVENT_TYPE)
+class CourtVideoAppointmentUpdatedNotifier : EventNotifier() {
   override fun processEvent(domainEvent: DomainEvent) {
     val info: CourtVideoAppointmentInfo = getAdditionalInfo(domainEvent, CourtVideoAppointmentInfo::class.java)
-    LOG.debug("Enter CourtVideoAppointmentDeletedNotifier Info: {}", info)
+    LOG.debug("Enter CourtVideoAppointmentUpdatedNotifier Info: {}", info)
 
-    getVisitSchedulerService().processCourtVideoAppointmentCancelledDeleted(info)
+    getVisitSchedulerService().processCourtVideoAppointmentUpdated(info)
   }
 
   // TODO: VB-5754 - Add the eventCode to AdditionalInformation object, and filter to only process certain event codes (see JIRA for list).

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/domainevents/PrisonVisitsEventsIntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/domainevents/PrisonVisitsEventsIntegrationTestBase.kt
@@ -32,6 +32,7 @@ import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.service
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.service.listeners.notifiers.CourtVideoAppointmentCancelledNotifier
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.service.listeners.notifiers.CourtVideoAppointmentCreatedNotifier
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.service.listeners.notifiers.CourtVideoAppointmentDeletedNotifier
+import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.service.listeners.notifiers.CourtVideoAppointmentUpdatedNotifier
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.service.listeners.notifiers.PersonRestrictionUpsertedNotifier
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.service.listeners.notifiers.PrisonerAlertsUpdatedNotifier
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.service.listeners.notifiers.PrisonerIncentivesDeletedNotifier
@@ -98,6 +99,9 @@ abstract class PrisonVisitsEventsIntegrationTestBase {
 
   @MockitoSpyBean
   lateinit var courtVideoAppointmentCancelledNotifierSpy: CourtVideoAppointmentCancelledNotifier
+
+  @MockitoSpyBean
+  lateinit var courtVideoAppointmentUpdatedNotifierSpy: CourtVideoAppointmentUpdatedNotifier
 
   @MockitoSpyBean
   lateinit var courtVideoAppointmentDeletedNotifierSpy: CourtVideoAppointmentDeletedNotifier


### PR DESCRIPTION
## What does this PR do?

Will be used by visit scheduler to un-flag visits originally flagged by this appointment using the appointmentInstanceId then re-search for visits to flag with the updated appointment information