### PR TITLE
VB-5315 Tweak visit session and schedule DTOs

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/dto/visit/scheduler/sessions/PrisonerScheduledEventDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/dto/visit/scheduler/sessions/PrisonerScheduledEventDto.kt
@@ -9,11 +9,11 @@ data class PrisonerScheduledEventDto(
   @Schema(required = false, description = "Type of scheduled event (as a code)")
   val eventType: String?,
 
-  @Schema(required = true, description = "Description of scheduled event type")
-  val eventTypeDesc: String? = null,
-
   @Schema(required = false, description = "Description of scheduled event sub type")
   val eventSubTypeDesc: String?,
+
+  @Schema(required = false, description = "Source-specific description for type or nature of the event")
+  val eventSourceDesc: String?,
 
   @Schema(required = false, description = "Date on which event occurs")
   val eventDate: LocalDate?,
@@ -26,8 +26,8 @@ data class PrisonerScheduledEventDto(
 ) {
   constructor(scheduledEventDto: ScheduledEventDto) : this (
     eventType = scheduledEventDto.eventType,
-    eventTypeDesc = scheduledEventDto.eventTypeDesc,
     eventSubTypeDesc = scheduledEventDto.eventSubTypeDesc,
+    eventSourceDesc = scheduledEventDto.eventSourceDesc,
     eventDate = scheduledEventDto.eventDate,
     startTime = scheduledEventDto.startTime?.toLocalTime(),
     endTime = scheduledEventDto.endTime?.toLocalTime(),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/dto/visit/scheduler/sessions/PrisonerScheduledEventDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/dto/visit/scheduler/sessions/PrisonerScheduledEventDto.kt
@@ -2,7 +2,6 @@ package uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.vi
 
 import io.swagger.v3.oas.annotations.media.Schema
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.whereabouts.ScheduledEventDto
-import java.time.LocalDate
 import java.time.LocalTime
 
 data class PrisonerScheduledEventDto(
@@ -15,9 +14,6 @@ data class PrisonerScheduledEventDto(
   @Schema(required = false, description = "Source-specific description for type or nature of the event")
   val eventSourceDesc: String?,
 
-  @Schema(required = false, description = "Date on which event occurs")
-  val eventDate: LocalDate?,
-
   @Schema(required = false, description = "Date and time at which event starts")
   val startTime: LocalTime?,
 
@@ -28,7 +24,6 @@ data class PrisonerScheduledEventDto(
     eventType = scheduledEventDto.eventType,
     eventSubTypeDesc = scheduledEventDto.eventSubTypeDesc,
     eventSourceDesc = scheduledEventDto.eventSourceDesc,
-    eventDate = scheduledEventDto.eventDate,
     startTime = scheduledEventDto.startTime?.toLocalTime(),
     endTime = scheduledEventDto.endTime?.toLocalTime(),
   )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/dto/visit/scheduler/sessions/VisitSessionV2Dto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/dto/visit/scheduler/sessions/VisitSessionV2Dto.kt
@@ -1,12 +1,13 @@
 package uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.visit.scheduler.sessions
 
+import com.fasterxml.jackson.annotation.JsonFormat
 import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.Valid
 import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.NotNull
-import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.visit.scheduler.SessionTimeSlotDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.visit.scheduler.VisitSessionDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.visit.scheduler.enums.SessionConflict
+import java.time.LocalTime
 
 data class VisitSessionV2Dto(
   @Schema(description = "Session Template Reference", example = "v9d.7ed.7u", required = true)
@@ -31,9 +32,13 @@ data class VisitSessionV2Dto(
   @Schema(description = "The count of closed visit bookings already reserved or booked for this session", example = "1", required = false)
   var closedVisitBookedCount: Int? = 0,
 
-  @Schema(description = "The timeslot for the session", required = true)
-  @field:NotNull
-  val sessionTimeSlot: SessionTimeSlotDto,
+  @JsonFormat(pattern = "HH:mm", shape = JsonFormat.Shape.STRING)
+  @Schema(description = "The start time of the visit session", example = "10:30", required = true)
+  val startTime: LocalTime,
+
+  @JsonFormat(pattern = "HH:mm", shape = JsonFormat.Shape.STRING)
+  @Schema(description = "The end time of the visit session", example = "11:30", required = true)
+  val endTime: LocalTime,
 
   @Schema(description = "Session conflicts", required = false)
   val sessionConflicts: MutableSet<@Valid SessionConflict>? = mutableSetOf(),
@@ -45,7 +50,8 @@ data class VisitSessionV2Dto(
     openVisitBookedCount = visitSessionDto.openVisitBookedCount,
     closedVisitCapacity = visitSessionDto.closedVisitCapacity,
     closedVisitBookedCount = visitSessionDto.closedVisitBookedCount,
-    sessionTimeSlot = SessionTimeSlotDto(visitSessionDto.startTimestamp.toLocalTime(), visitSessionDto.endTimestamp.toLocalTime()),
+    startTime = visitSessionDto.startTimestamp.toLocalTime(),
+    endTime = visitSessionDto.endTimestamp.toLocalTime(),
     sessionConflicts = visitSessionDto.sessionConflicts,
   )
 }


### PR DESCRIPTION
* PrisonerScheduledEventDto
  * swap one of the properties returned
  * remove eventDate - redundant as it is contained in SessionsAndScheduleDto, which has the date
* VisitSessionV2Dto
  * flatten structure so startTime / endTime are at top level