### PR TITLE
Fix retryDlq failing

### DIFF
--- a/helm_deploy/hmpps-manage-prison-visits-orchestration/values.yaml
+++ b/helm_deploy/hmpps-manage-prison-visits-orchestration/values.yaml
@@ -13,6 +13,13 @@ generic-service:
     enabled: true
     host: app-hostname.local # override per environment
     tlsSecretName: hmpps-manage-prison-visits-orchestration-cert
+    annotations:
+      nginx.ingress.kubernetes.io/server-snippet: |
+        server_tokens off;
+        location /queue-admin/retry-all-dlqs {
+          deny all;
+          return 401;
+        }
 
   # Environment variables to load into the deployment
   env:

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/config/ResourceServerConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/config/ResourceServerConfiguration.kt
@@ -39,7 +39,7 @@ class ResourceServerConfiguration {
           "/swagger-resources/configuration/ui",
           "/swagger-resources/configuration/security",
           "/queue-admin/retry-all-dlqs",
-          ).forEach { authorize(it, permitAll) }
+        ).forEach { authorize(it, permitAll) }
         authorize(anyRequest, authenticated)
       }
       oauth2ResourceServer { jwt { jwtAuthenticationConverter = AuthAwareTokenConverter() } }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/config/ResourceServerConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/config/ResourceServerConfiguration.kt
@@ -38,7 +38,8 @@ class ResourceServerConfiguration {
           "/swagger-resources",
           "/swagger-resources/configuration/ui",
           "/swagger-resources/configuration/security",
-        ).forEach { authorize(it, permitAll) }
+          "/queue-admin/retry-all-dlqs",
+          ).forEach { authorize(it, permitAll) }
         authorize(anyRequest, authenticated)
       }
       oauth2ResourceServer { jwt { jwtAuthenticationConverter = AuthAwareTokenConverter() } }


### PR DESCRIPTION
Needed to allow the endpoint to be called from within k8s without requiring auth