### PR TITLE
Re-enable oss indexer

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -54,5 +54,4 @@ tasks {
 
 dependencyCheck {
   nvd.datafeedUrl = "file:///opt/vulnz/cache"
-  analyzers.ossIndex.enabled = false
 }


### PR DESCRIPTION
Updates have happened to github actions v2.4 to allow the oss indexer to work correctly with a set of variables that are set org wide.

Re-enable.