### PR TITLE
Fix schema warning and remove unwanted annotation

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/dto/booker/registry/RegisteredPrisonDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/dto/booker/registry/RegisteredPrisonDto.kt
@@ -12,7 +12,7 @@ data class RegisteredPrisonDto(
   val prisonName: String,
 
   @param:JsonInclude(JsonInclude.Include.NON_NULL)
-  @Schema(description = "Name of the prison in Welsh", example = "Carchar Brynbuga", required = false)
+  @param:Schema(description = "Name of the prison in Welsh", example = "Carchar Brynbuga", required = false)
   val prisonNameInWelsh: String? = null,
 ) {
   constructor(prisonDto: PrisonRegisterPrisonDto) : this(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/dto/booker/registry/RegisteredPrisonDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/dto/booker/registry/RegisteredPrisonDto.kt
@@ -1,6 +1,5 @@
 package uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.booker.registry
 
-import com.fasterxml.jackson.annotation.JsonInclude
 import io.swagger.v3.oas.annotations.media.Schema
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.prison.register.PrisonRegisterPrisonDto
 
@@ -11,7 +10,6 @@ data class RegisteredPrisonDto(
   @param:Schema(description = "prison name", example = "MDI", required = true)
   val prisonName: String,
 
-  @param:JsonInclude(JsonInclude.Include.NON_NULL)
   @param:Schema(description = "Name of the prison in Welsh", example = "Carchar Brynbuga", required = false)
   val prisonNameInWelsh: String? = null,
 ) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/dto/booker/registry/RegisteredPrisonDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/dto/booker/registry/RegisteredPrisonDto.kt
@@ -1,8 +1,10 @@
 package uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.booker.registry
 
+import com.fasterxml.jackson.annotation.JsonInclude
 import io.swagger.v3.oas.annotations.media.Schema
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.prison.register.PrisonRegisterPrisonDto
 
+@JsonInclude(JsonInclude.Include.NON_NULL)
 data class RegisteredPrisonDto(
   @param:Schema(description = "prison code", example = "MDI", required = true)
   val prisonCode: String,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/dto/booker/registry/RegisteredPrisonDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/dto/booker/registry/RegisteredPrisonDto.kt
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.annotation.JsonInclude
 import io.swagger.v3.oas.annotations.media.Schema
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.prison.register.PrisonRegisterPrisonDto
 
-@JsonInclude(JsonInclude.Include.NON_NULL)
 data class RegisteredPrisonDto(
   @param:Schema(description = "prison code", example = "MDI", required = true)
   val prisonCode: String,
@@ -12,6 +11,7 @@ data class RegisteredPrisonDto(
   @param:Schema(description = "prison name", example = "MDI", required = true)
   val prisonName: String,
 
+  @param:JsonInclude(JsonInclude.Include.NON_NULL)
   @Schema(description = "Name of the prison in Welsh", example = "Carchar Brynbuga", required = false)
   val prisonNameInWelsh: String? = null,
 ) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/dto/orchestration/PrisonDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/dto/orchestration/PrisonDto.kt
@@ -1,6 +1,5 @@
 package uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.orchestration
 
-import com.fasterxml.jackson.annotation.JsonInclude
 import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.constraints.Min
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.prison.register.PrisonRegisterContactDetailsDto
@@ -17,7 +16,6 @@ data class PrisonDto(
   @param:Schema(description = "prison name", example = "HMP Hewell", required = true)
   val prisonName: String,
 
-  @param:JsonInclude(JsonInclude.Include.NON_NULL)
   @param:Schema(description = "Name of the prison in Welsh", example = "Carchar Brynbuga", required = false)
   val prisonNameInWelsh: String? = null,
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/dto/orchestration/PrisonDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/dto/orchestration/PrisonDto.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.orchestration
 
+import com.fasterxml.jackson.annotation.JsonInclude
 import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.constraints.Min
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.prison.register.PrisonRegisterContactDetailsDto
@@ -16,6 +17,7 @@ data class PrisonDto(
   @param:Schema(description = "prison name", example = "HMP Hewell", required = true)
   val prisonName: String,
 
+  @param:JsonInclude(JsonInclude.Include.NON_NULL)
   @param:Schema(description = "Name of the prison in Welsh", example = "Carchar Brynbuga", required = false)
   val prisonNameInWelsh: String? = null,
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/dto/prison/register/PrisonNameDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/dto/prison/register/PrisonNameDto.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.prison.register
 
+import com.fasterxml.jackson.annotation.JsonInclude
 import io.swagger.v3.oas.annotations.media.Schema
 
 @Schema(description = "Prison Information")
@@ -8,6 +9,8 @@ data class PrisonNameDto(
   val prisonId: String,
   @param:Schema(description = "Name of the prison", example = "Moorland HMP", required = true)
   val prisonName: String,
+
+  @param:JsonInclude(JsonInclude.Include.NON_NULL)
   @param:Schema(description = "Name of the prison in Welsh", example = "Carchar Brynbuga", required = false)
   val prisonNameInWelsh: String? = null,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/dto/prison/register/PrisonNameDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/dto/prison/register/PrisonNameDto.kt
@@ -1,6 +1,5 @@
 package uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.prison.register
 
-import com.fasterxml.jackson.annotation.JsonInclude
 import io.swagger.v3.oas.annotations.media.Schema
 
 @Schema(description = "Prison Information")
@@ -10,7 +9,6 @@ data class PrisonNameDto(
   @param:Schema(description = "Name of the prison", example = "Moorland HMP", required = true)
   val prisonName: String,
 
-  @param:JsonInclude(JsonInclude.Include.NON_NULL)
   @param:Schema(description = "Name of the prison in Welsh", example = "Carchar Brynbuga", required = false)
   val prisonNameInWelsh: String? = null,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/dto/prison/register/PrisonRegisterPrisonDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/dto/prison/register/PrisonRegisterPrisonDto.kt
@@ -3,13 +3,14 @@ package uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.pr
 import com.fasterxml.jackson.annotation.JsonInclude
 import io.swagger.v3.oas.annotations.media.Schema
 
-@JsonInclude(JsonInclude.Include.NON_NULL)
 @Schema(description = "Prison Information")
 data class PrisonRegisterPrisonDto(
   @param:Schema(description = "Prison ID", example = "MDI", required = true)
   val prisonId: String,
   @param:Schema(description = "Name of the prison", example = "Moorland HMP", required = true)
   val prisonName: String,
+
+  @param:JsonInclude(JsonInclude.Include.NON_NULL)
   @param:Schema(description = "Name of the prison in Welsh", example = "Carchar Brynbuga", required = false)
   val prisonNameInWelsh: String? = null,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/dto/prison/register/PrisonRegisterPrisonDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/dto/prison/register/PrisonRegisterPrisonDto.kt
@@ -1,6 +1,5 @@
 package uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.prison.register
 
-import com.fasterxml.jackson.annotation.JsonInclude
 import io.swagger.v3.oas.annotations.media.Schema
 
 @Schema(description = "Prison Information")
@@ -10,7 +9,6 @@ data class PrisonRegisterPrisonDto(
   @param:Schema(description = "Name of the prison", example = "Moorland HMP", required = true)
   val prisonName: String,
 
-  @param:JsonInclude(JsonInclude.Include.NON_NULL)
   @param:Schema(description = "Name of the prison in Welsh", example = "Carchar Brynbuga", required = false)
   val prisonNameInWelsh: String? = null,
 )


### PR DESCRIPTION
## What does this PR do?
- Add param: to the Schema, as we do with all other entries.
- Remove the use of JSON include NON_NULL, this is now handled at the prisoner-register level, we don't need to handle this in orchestration anymore.