### PR TITLE
VB-5552 - Skip getting alerts & restrictions if visit is in past or prisoner is out of prison

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/client/PrisonerProfileClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/client/PrisonerProfileClient.kt
@@ -47,8 +47,8 @@ class PrisonerProfileClient(
 
     return Mono.zip(prisonerMono, inmateDetailMono, visitBalancesMono, visitSchedulerMono, alertsMono, prisonerRestrictionsMono)
       .map { prisonerProfileMonos ->
-        val prisoner = prisonerProfileMonos.t1 ?: throw InvalidPrisonerProfileException("Unable to retrieve offender details from Prisoner Search API")
-        val inmateDetails = prisonerProfileMonos.t2 ?: throw InvalidPrisonerProfileException("Unable to retrieve inmate details from Prison API")
+        val prisoner = prisonerProfileMonos.t1
+        val inmateDetails = prisonerProfileMonos.t2
         val visitBalances = if (prisonerProfileMonos.t3.isEmpty) {
           null
         } else {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/client/PrisonerProfileClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/client/PrisonerProfileClient.kt
@@ -10,7 +10,6 @@ import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.ale
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.contact.registry.PrisonerContactDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.orchestration.VisitBalancesDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.visit.scheduler.VisitSummaryDto
-import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.exception.InvalidPrisonerProfileException
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.filter.VisitSearchRequestFilter
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.service.AlertsService.Companion.predicateFilterSupportedCodes
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.utils.Comparators.Companion.alertsComparatorDateUpdatedOrCreatedDateDesc

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/client/VisitAllocationApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/client/VisitAllocationApiClient.kt
@@ -103,7 +103,7 @@ class VisitAllocationApiClient(
     val visitOrderHistoryListMono = getPrisonerVisitOrderHistoryAsMono(prisonerId, fromDate)
     return Mono.zip(inmateDetailMono, visitOrderHistoryListMono)
       .map { visitOrderHistoryMonos ->
-        val inmateDetails = visitOrderHistoryMonos.t1 ?: throw InvalidPrisonerProfileException("Unable to retrieve inmate details from Prison API")
+        val inmateDetails = visitOrderHistoryMonos.t1
 
         val visitOrderHistoryList = visitOrderHistoryMonos.t2.sortedBy { it.createdTimeStamp }
         VisitOrderHistoryDetailsDto(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/client/VisitAllocationApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/client/VisitAllocationApiClient.kt
@@ -23,7 +23,6 @@ import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.vis
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.visit.allocation.VisitOrderHistoryDetailsDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.visit.allocation.VisitOrderHistoryDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.visit.allocation.VisitOrderPrisonerBalanceDto
-import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.exception.InvalidPrisonerProfileException
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.exception.NotFoundException
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.exception.PrisonerBalanceAdjustmentValidationException
 import java.time.Duration

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/client/VisitBookingDetailsClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/client/VisitBookingDetailsClient.kt
@@ -5,11 +5,14 @@ import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Component
 import reactor.core.publisher.Mono
+import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.RestPage
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.alerts.api.AlertDto
+import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.alerts.api.AlertResponseDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.contact.registry.PrisonerContactDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.orchestration.EventAuditOrchestrationDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.orchestration.VisitBookingDetailsDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.orchestration.VisitContactDto
+import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.prison.api.OffenderRestrictionsDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.prison.register.PrisonRegisterPrisonDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.exception.NotFoundException
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.service.AlertsService.Companion.predicateFilterSupportedCodes
@@ -18,6 +21,7 @@ import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.service
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.utils.Comparators.Companion.alertsComparatorDateUpdatedOrCreatedDateDesc
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.utils.Comparators.Companion.restrictionsComparatorDatCreatedDesc
 import java.time.Duration
+import java.time.LocalDateTime
 import kotlin.jvm.optionals.getOrNull
 
 @Component
@@ -39,72 +43,96 @@ class VisitBookingDetailsClient(
     visitReference: String,
   ): VisitBookingDetailsDto? {
     LOG.debug("getVisitDetails for visit reference - {}", visitReference)
+
     val visit = visitSchedulerClient.getVisitByReference(visitReference) ?: throw NotFoundException("Visit with reference - $visitReference not found")
 
     val prisonDetailsMono = prisonRegisterClient.getPrisonAsMonoEmptyIfNotFound(visit.prisonCode)
-    val prisonerDetailsMono = prisonerSearchClient.getPrisonerByIdAsMono(visit.prisonerId)
-    val prisonerAlertsMono = alertsApiClient.getPrisonerAlertsAsMono(visit.prisonerId)
-    val prisonerRestrictionsMono = prisonApiClient.getPrisonerRestrictionsAsMono(visit.prisonerId)
-    val visitorsMono = prisonerContactRegistryClient.getPrisonersSocialContactsAsMono(
-      prisonerId = visit.prisonerId,
-
-    )
+    val visitorsMono = prisonerContactRegistryClient.getPrisonersSocialContactsAsMono(prisonerId = visit.prisonerId)
     val eventsMono = visitSchedulerClient.getVisitHistoryByReferenceAsMono(visitReference)
-
     val notificationsMono = visitSchedulerClient.getNotificationEventsForBookingReferenceAsMono(visitReference)
 
-    val visitBookingDetails = Mono.zip(prisonDetailsMono, prisonerDetailsMono, prisonerAlertsMono, prisonerRestrictionsMono, visitorsMono, eventsMono, notificationsMono)
-      .map { visitBookingDetailsMono ->
-        val prison = visitBookingDetailsMono.t1.getOrNull() ?: PrisonRegisterPrisonDto(prisonId = visit.prisonCode, prisonName = visit.prisonCode)
-        val prisoner = visitBookingDetailsMono.t2
-        val prisonerAlerts = visitBookingDetailsMono.t3.content.filter {
-          predicateFilterSupportedCodes.test(it)
-        }.sortedWith(alertsComparatorDateUpdatedOrCreatedDateDesc)
-          .map { alertResponse -> AlertDto(alertResponse) }
+    val visitBookingDetails = prisonerSearchClient.getPrisonerByIdAsMono(visit.prisonerId)
+      .flatMap { prisoner ->
 
-        val prisonerRestrictions = (visitBookingDetailsMono.t4.offenderRestrictions ?: emptyList()).sortedWith(
-          restrictionsComparatorDatCreatedDesc,
-        )
-        val allVisitorsForPrisoner = visitBookingDetailsMono.t5
-        val events = visitBookingDetailsMono.t6
-        val notifications = visitBookingDetailsMono.t7
-        val visitors = mutableListOf<PrisonerContactDto>()
+        val isPastVisit = visit.startTimestamp.isBefore(LocalDateTime.now())
+        val prisonerOutOfPrison = prisoner.inOutStatus != "IN"
+        val skipAlertsAndRestrictions = isPastVisit || prisonerOutOfPrison
 
-        visit.visitors?.forEach { visitVisitor ->
-          allVisitorsForPrisoner.firstOrNull { it.personId == visitVisitor.nomisPersonId }?.let {
-            visitors.add(it)
+        // If the prisoner is out of prison OR the visit is in the past, we do NOT want to display alerts
+        val prisonerAlertsMono =
+          if (skipAlertsAndRestrictions) {
+            Mono.just(RestPage.empty<AlertResponseDto>())
+          } else {
+            alertsApiClient.getPrisonerAlertsAsMono(visit.prisonerId)
           }
-        }
 
-        val eventAuditDetails = events.map {
-          EventAuditOrchestrationDto(
-            eventAuditDto = it,
-            actionedByFullName = it.actionedBy.userName,
+        // If the prisoner is out of prison OR the visit is in the past, we do NOT want to display restrictions
+        val prisonerRestrictionsMono =
+          if (skipAlertsAndRestrictions) {
+            Mono.just(OffenderRestrictionsDto(offenderRestrictions = emptyList()))
+          } else {
+            prisonApiClient.getPrisonerRestrictionsAsMono(visit.prisonerId)
+          }
+
+        Mono.zip(
+          prisonDetailsMono,
+          prisonerAlertsMono,
+          prisonerRestrictionsMono,
+          visitorsMono,
+          eventsMono,
+          notificationsMono,
+        ).map { visitBookingDetailsMono ->
+          val prison = visitBookingDetailsMono.t1.getOrNull() ?: PrisonRegisterPrisonDto(prisonId = visit.prisonCode, prisonName = visit.prisonCode)
+
+          val prisonerAlerts = visitBookingDetailsMono.t2.content
+            .filter { predicateFilterSupportedCodes.test(it) }
+            .sortedWith(alertsComparatorDateUpdatedOrCreatedDateDesc)
+            .map { alertResponse -> AlertDto(alertResponse) }
+
+          val prisonerRestrictions = (visitBookingDetailsMono.t3.offenderRestrictions ?: emptyList())
+            .sortedWith(restrictionsComparatorDatCreatedDesc)
+
+          val allVisitorsForPrisoner = visitBookingDetailsMono.t4
+          val events = visitBookingDetailsMono.t5
+          val notifications = visitBookingDetailsMono.t6
+          val visitors = mutableListOf<PrisonerContactDto>()
+
+          visit.visitors?.forEach { visitVisitor ->
+            allVisitorsForPrisoner.firstOrNull { it.personId == visitVisitor.nomisPersonId }?.let {
+              visitors.add(it)
+            }
+          }
+
+          val eventAuditDetails = events.map {
+            EventAuditOrchestrationDto(
+              eventAuditDto = it,
+              actionedByFullName = it.actionedBy.userName,
+            )
+          }
+
+          val visitContact = visit.visitContact?.let { contact ->
+            val contactId = visit.visitors?.firstOrNull { it.visitContact == true }?.nomisPersonId
+            VisitContactDto(contact, contactId)
+          }
+
+          VisitBookingDetailsDto(
+            visit = visit,
+            prison = prison,
+            prisonerDto = prisoner,
+            prisonerAlerts = prisonerAlerts,
+            prisonerRestrictions = prisonerRestrictions,
+            visitVisitors = visitors,
+            visitContact = visitContact,
+            events = eventAuditDetails,
+            notifications = notifications,
           )
         }
-
-        val visitContact = visit.visitContact?.let { contact ->
-          val contactId = visit.visitors?.firstOrNull { it.visitContact == true }?.nomisPersonId
-          VisitContactDto(contact, contactId)
-        }
-
-        VisitBookingDetailsDto(
-          visit = visit,
-          prison = prison,
-          prisonerDto = prisoner,
-          prisonerAlerts = prisonerAlerts,
-          prisonerRestrictions = prisonerRestrictions,
-          visitVisitors = visitors,
-          visitContact = visitContact,
-          events = eventAuditDetails,
-          notifications = notifications,
-        )
       }
       .block(apiTimeout)
 
     return visitBookingDetails?.let {
       // update the full names for event audit entries
-      updateEventUserNames(visitBookingDetails)
+      updateEventUserNames(it)
     }
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/client/VisitBookingDetailsClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/client/VisitBookingDetailsClient.kt
@@ -47,54 +47,53 @@ class VisitBookingDetailsClient(
     val visit = visitSchedulerClient.getVisitByReference(visitReference) ?: throw NotFoundException("Visit with reference - $visitReference not found")
 
     val prisonDetailsMono = prisonRegisterClient.getPrisonAsMonoEmptyIfNotFound(visit.prisonCode)
+    val prisonerDetailsMono = prisonerSearchClient.getPrisonerByIdAsMono(visit.prisonerId)
     val visitorsMono = prisonerContactRegistryClient.getPrisonersSocialContactsAsMono(prisonerId = visit.prisonerId)
     val eventsMono = visitSchedulerClient.getVisitHistoryByReferenceAsMono(visitReference)
     val notificationsMono = visitSchedulerClient.getNotificationEventsForBookingReferenceAsMono(visitReference)
 
-    val visitBookingDetails = prisonerSearchClient.getPrisonerByIdAsMono(visit.prisonerId)
-      .flatMap { prisoner ->
+    val visitBookingDetails = Mono.zip(
+      prisonDetailsMono,
+      prisonerDetailsMono,
+      visitorsMono,
+      eventsMono,
+      notificationsMono,
+    ).flatMap { visitBookingDetailsCoreInfo ->
 
-        val isPastVisit = visit.startTimestamp.isBefore(LocalDateTime.now())
-        val prisonerOutOfPrison = prisoner.inOutStatus != "IN"
-        val skipAlertsAndRestrictions = isPastVisit || prisonerOutOfPrison
+      val prison = visitBookingDetailsCoreInfo.t1.getOrNull() ?: PrisonRegisterPrisonDto(prisonId = visit.prisonCode, prisonName = visit.prisonCode)
+      val prisoner = visitBookingDetailsCoreInfo.t2
+      val allVisitorsForPrisoner = visitBookingDetailsCoreInfo.t3
+      val events = visitBookingDetailsCoreInfo.t4
+      val notifications = visitBookingDetailsCoreInfo.t5
 
-        // If the prisoner is out of prison OR the visit is in the past, we do NOT want to display alerts
-        val prisonerAlertsMono =
-          if (skipAlertsAndRestrictions) {
-            Mono.just(RestPage.empty<AlertResponseDto>())
-          } else {
-            alertsApiClient.getPrisonerAlertsAsMono(visit.prisonerId)
-          }
+      val isPastVisit = visit.startTimestamp.isBefore(LocalDateTime.now())
+      val prisonerOutOfPrison = prisoner.inOutStatus != "IN"
+      val skipAlertsAndRestrictions = isPastVisit || prisonerOutOfPrison
 
-        // If the prisoner is out of prison OR the visit is in the past, we do NOT want to display restrictions
-        val prisonerRestrictionsMono =
-          if (skipAlertsAndRestrictions) {
-            Mono.just(OffenderRestrictionsDto(offenderRestrictions = emptyList()))
-          } else {
-            prisonApiClient.getPrisonerRestrictionsAsMono(visit.prisonerId)
-          }
+      val prisonerAlertsMono: Mono<RestPage<AlertResponseDto>> =
+        if (skipAlertsAndRestrictions) {
+          Mono.just(RestPage.empty())
+        } else {
+          alertsApiClient.getPrisonerAlertsAsMono(visit.prisonerId)
+        }
 
-        Mono.zip(
-          prisonDetailsMono,
-          prisonerAlertsMono,
-          prisonerRestrictionsMono,
-          visitorsMono,
-          eventsMono,
-          notificationsMono,
-        ).map { visitBookingDetailsMono ->
-          val prison = visitBookingDetailsMono.t1.getOrNull() ?: PrisonRegisterPrisonDto(prisonId = visit.prisonCode, prisonName = visit.prisonCode)
+      val prisonerRestrictionsMono: Mono<OffenderRestrictionsDto> =
+        if (skipAlertsAndRestrictions) {
+          Mono.just(OffenderRestrictionsDto(offenderRestrictions = emptyList()))
+        } else {
+          prisonApiClient.getPrisonerRestrictionsAsMono(visit.prisonerId)
+        }
 
-          val prisonerAlerts = visitBookingDetailsMono.t2.content
+      Mono.zip(prisonerAlertsMono, prisonerRestrictionsMono)
+        .map { optionalAlertsAndRestrictionsInfo ->
+          val prisonerAlerts = optionalAlertsAndRestrictionsInfo.t1.content
             .filter { predicateFilterSupportedCodes.test(it) }
             .sortedWith(alertsComparatorDateUpdatedOrCreatedDateDesc)
             .map { alertResponse -> AlertDto(alertResponse) }
 
-          val prisonerRestrictions = (visitBookingDetailsMono.t3.offenderRestrictions ?: emptyList())
+          val prisonerRestrictions = (optionalAlertsAndRestrictionsInfo.t2.offenderRestrictions ?: emptyList())
             .sortedWith(restrictionsComparatorDatCreatedDesc)
 
-          val allVisitorsForPrisoner = visitBookingDetailsMono.t4
-          val events = visitBookingDetailsMono.t5
-          val notifications = visitBookingDetailsMono.t6
           val visitors = mutableListOf<PrisonerContactDto>()
 
           visit.visitors?.forEach { visitVisitor ->
@@ -127,11 +126,10 @@ class VisitBookingDetailsClient(
             notifications = notifications,
           )
         }
-      }
+    }
       .block(apiTimeout)
 
     return visitBookingDetails?.let {
-      // update the full names for event audit entries
       updateEventUserNames(it)
     }
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/dto/RestPage.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/dto/RestPage.kt
@@ -11,4 +11,13 @@ class RestPage<T : Any>(
   @JsonProperty("number") page: Int,
   @JsonProperty("size") size: Int,
   @JsonProperty("totalElements") total: Long,
-) : PageImpl<T>(content ?: emptyList(), PageRequest.of(page, size), total)
+) : PageImpl<T>(content ?: emptyList(), PageRequest.of(page, size), total) {
+  companion object {
+    fun <T : Any> empty(): RestPage<T> = RestPage(
+      content = emptyList(),
+      page = 0,
+      size = 1, // (cannot be less than 1)
+      total = 0,
+    )
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/dto/prisoner/search/PrisonerDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/dto/prisoner/search/PrisonerDto.kt
@@ -33,4 +33,7 @@ data class PrisonerDto(
 
   @param:Schema(description = "Convicted Status", example = "Convicted", allowableValues = ["Convicted", "Remand"])
   val convictedStatus: String? = null,
+
+  @param:Schema(description = "In / Out status", example = "OUT", allowableValues = ["IN, OUT, TRN"])
+  val inOutStatus: String? = null,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/dto/prisoner/search/PrisonerDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/dto/prisoner/search/PrisonerDto.kt
@@ -34,6 +34,6 @@ data class PrisonerDto(
   @param:Schema(description = "Convicted Status", example = "Convicted", allowableValues = ["Convicted", "Remand"])
   val convictedStatus: String? = null,
 
-  @param:Schema(description = "In / Out status", example = "OUT", allowableValues = ["IN, OUT, TRN"])
+  @param:Schema(description = "In / Out status", example = "OUT", allowableValues = ["IN", "OUT", "TRN"])
   val inOutStatus: String? = null,
 )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/IntegrationTestBase.kt
@@ -289,8 +289,8 @@ abstract class IntegrationTestBase {
     visitStatus: VisitStatus = VisitStatus.BOOKED,
     visitSubStatus: VisitSubStatus = VisitSubStatus.AUTO_APPROVED,
     visitRestriction: VisitRestriction = VisitRestriction.OPEN,
-    startTimestamp: LocalDateTime = LocalDateTime.now(),
-    endTimestamp: LocalDateTime = startTimestamp.plusHours(1),
+    startTimestamp: LocalDateTime = LocalDateTime.now().plusDays(1),
+    endTimestamp: LocalDateTime = startTimestamp.plusDays(1).plusHours(1),
     outcomeStatus: OutcomeStatus? = null,
     createdTimestamp: LocalDateTime = LocalDateTime.now(),
     modifiedTimestamp: LocalDateTime = LocalDateTime.now(),
@@ -658,6 +658,7 @@ abstract class IntegrationTestBase {
     cellLocation: String? = null,
     currentIncentive: CurrentIncentive? = null,
     convictedStatus: String?,
+    inOutStatus: String = "IN",
   ): PrisonerDto = PrisonerDto(
     prisonerNumber = prisonerId,
     firstName = firstName,
@@ -668,6 +669,7 @@ abstract class IntegrationTestBase {
     cellLocation = cellLocation,
     currentIncentive = currentIncentive,
     convictedStatus = convictedStatus,
+    inOutStatus = inOutStatus,
   )
 
   final fun createContactsList(visitorDetails: List<VisitorDetails>): List<PrisonerContactDto> = visitorDetails.stream().map {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/IntegrationTestBase.kt
@@ -290,7 +290,7 @@ abstract class IntegrationTestBase {
     visitSubStatus: VisitSubStatus = VisitSubStatus.AUTO_APPROVED,
     visitRestriction: VisitRestriction = VisitRestriction.OPEN,
     startTimestamp: LocalDateTime = LocalDateTime.now().plusDays(1),
-    endTimestamp: LocalDateTime = startTimestamp.plusDays(1).plusHours(1),
+    endTimestamp: LocalDateTime = startTimestamp.plusHours(1),
     outcomeStatus: OutcomeStatus? = null,
     createdTimestamp: LocalDateTime = LocalDateTime.now(),
     modifiedTimestamp: LocalDateTime = LocalDateTime.now(),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/visit/GetVisitBookingDetailsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/visit/GetVisitBookingDetailsTest.kt
@@ -660,6 +660,8 @@ class GetVisitBookingDetailsTest : IntegrationTestBase() {
     assertVisitBookingDetails(visitBookingResponse, visit, prison, releasedPrisoner, emptyList(), OffenderRestrictionsDto(null, emptyList()), contactsList, expectedVisitContact, eventList, expectedEventActionedByFullNames, notifications)
     verify(manageUsersApiClientSpy, times(1)).getUsersByUsernames(any())
     verify(manageUsersApiClientSpy, times(1)).getUsersByUsernames(userIds.toSet())
+    verify(alertsApiClientSpy, times(0)).getPrisonerAlertsAsMono(any())
+    verify(prisonApiClientSpy, times(0)).getPrisonerRestrictionsAsMono(any())
   }
 
   @Test
@@ -700,6 +702,8 @@ class GetVisitBookingDetailsTest : IntegrationTestBase() {
     assertVisitBookingDetails(visitBookingResponse, visit, prison, prisonerDto, emptyList(), OffenderRestrictionsDto(null, emptyList()), contactsList, expectedVisitContact, eventList, expectedEventActionedByFullNames, notifications)
     verify(manageUsersApiClientSpy, times(1)).getUsersByUsernames(any())
     verify(manageUsersApiClientSpy, times(1)).getUsersByUsernames(userIds.toSet())
+    verify(alertsApiClientSpy, times(0)).getPrisonerAlertsAsMono(any())
+    verify(prisonApiClientSpy, times(0)).getPrisonerRestrictionsAsMono(any())
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/visit/GetVisitBookingDetailsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/visit/GetVisitBookingDetailsTest.kt
@@ -136,14 +136,6 @@ class GetVisitBookingDetailsTest : IntegrationTestBase() {
     notification2 = createNotificationEvent(NotificationEventType.VISITOR_RESTRICTION_UPSERTED_EVENT, additionalData = listOf(eventAttribute1, eventAttribute2, eventAttribute3))
   }
 
-  fun callGetVisitFullDetailsByReference(
-    webTestClient: WebTestClient,
-    reference: String,
-    authHttpHeaders: (HttpHeaders) -> Unit,
-  ): WebTestClient.ResponseSpec = webTestClient.get().uri("/visits/$reference/detailed")
-    .headers(authHttpHeaders)
-    .exchange()
-
   @Test
   fun `when visit exists search by reference returns the full booking details for that visit`() {
     // Given
@@ -618,6 +610,96 @@ class GetVisitBookingDetailsTest : IntegrationTestBase() {
     // Then
     responseSpec.expectStatus().isNotFound
     verify(manageUsersApiClientSpy, times(0)).getUsersByUsernames(any())
+  }
+
+  @Test
+  fun `when prisoner is not in prison then alerts and restrictions calls are skipped and empty lists are returned`() {
+    // Given
+    val userIds = listOf("test-user", "test-user1", "test-user2")
+    val userNamesMap = mapOf(
+      "test-user" to UserExtendedDetailsDto("test-user", "Test", "User"),
+    )
+
+    val releasedPrisoner = createPrisoner(
+      prisonerId = prisonerId,
+      firstName = "FirstName",
+      lastName = "LastName",
+      dateOfBirth = LocalDate.of(2000, 1, 31),
+      prisonId = prisonCode,
+      convictedStatus = "Convicted",
+      inOutStatus = "OUT",
+    )
+
+    val reference = "aa-bb-cc-dd"
+    val visitors = listOf(createVisitorDto(visitor1, false), createVisitorDto(visitor2, false), createVisitorDto(visitor3, true))
+    val visit = createVisitDto(reference = reference, prisonCode = prisonCode, prisonerId = prisonerId, visitors = visitors)
+    val contactsList = listOf(visitor1, visitor2, visitor3)
+    val eventList = listOf(eventAudit1, eventAudit2, eventAudit3, eventAudit4, eventAudit5)
+    val expectedEventActionedByFullNames = listOf("abcd", null, "Test User", "test-user1", "test-user2")
+    val notifications = listOf(notification1, notification2)
+
+    visitSchedulerMockServer.stubGetVisit(reference, visit)
+    prisonOffenderSearchMockServer.stubGetPrisonerById(prisonerId, releasedPrisoner)
+    prisonRegisterMockServer.stubGetPrison(prisonCode, prison)
+
+    prisonerContactRegistryMockServer.stubGetPrisonerContacts(prisonerId, contactsList = contactsList)
+    visitSchedulerMockServer.stubGetVisitHistory(visit.reference, eventList)
+    visitSchedulerMockServer.stubGetVisitNotificationEvents(visit.reference, notifications)
+    manageUsersApiMockServer.stubGetMultipleUserDetails(userIds, userDetails = userNamesMap)
+
+    // When
+    val responseSpec = callGetVisitFullDetailsByReference(webTestClient, reference, roleVSIPOrchestrationServiceHttpHeaders)
+
+    // Then
+    responseSpec.expectStatus().isOk
+    val visitBookingResponse = getResult(responseSpec.expectBody())
+    val expectedVisitContact = VisitContactDto(
+      contactDto = visit.visitContact!!,
+      visitContactId = visitor3.personId,
+    )
+    assertVisitBookingDetails(visitBookingResponse, visit, prison, releasedPrisoner, emptyList(), OffenderRestrictionsDto(null, emptyList()), contactsList, expectedVisitContact, eventList, expectedEventActionedByFullNames, notifications)
+    verify(manageUsersApiClientSpy, times(1)).getUsersByUsernames(any())
+    verify(manageUsersApiClientSpy, times(1)).getUsersByUsernames(userIds.toSet())
+  }
+
+  @Test
+  fun `when visit is in the past then alerts and restrictions calls are skipped and empty lists are returned`() {
+    // Given
+    val userIds = listOf("test-user", "test-user1", "test-user2")
+    val userNamesMap = mapOf(
+      "test-user" to UserExtendedDetailsDto("test-user", "Test", "User"),
+    )
+
+    val reference = "aa-bb-cc-dd"
+    val visitors = listOf(createVisitorDto(visitor1, false), createVisitorDto(visitor2, false), createVisitorDto(visitor3, true))
+    val visit = createVisitDto(reference = reference, prisonCode = prisonCode, prisonerId = prisonerId, visitors = visitors, startTimestamp = LocalDateTime.now().minusDays(1), endTimestamp = LocalDateTime.now().minusDays(1))
+    val contactsList = listOf(visitor1, visitor2, visitor3)
+    val eventList = listOf(eventAudit1, eventAudit2, eventAudit3, eventAudit4, eventAudit5)
+    val expectedEventActionedByFullNames = listOf("abcd", null, "Test User", "test-user1", "test-user2")
+    val notifications = listOf(notification1, notification2)
+
+    visitSchedulerMockServer.stubGetVisit(reference, visit)
+    prisonOffenderSearchMockServer.stubGetPrisonerById(prisonerId, prisonerDto)
+    prisonRegisterMockServer.stubGetPrison(prisonCode, prison)
+
+    prisonerContactRegistryMockServer.stubGetPrisonerContacts(prisonerId, contactsList = contactsList)
+    visitSchedulerMockServer.stubGetVisitHistory(visit.reference, eventList)
+    visitSchedulerMockServer.stubGetVisitNotificationEvents(visit.reference, notifications)
+    manageUsersApiMockServer.stubGetMultipleUserDetails(userIds, userDetails = userNamesMap)
+
+    // When
+    val responseSpec = callGetVisitFullDetailsByReference(webTestClient, reference, roleVSIPOrchestrationServiceHttpHeaders)
+
+    // Then
+    responseSpec.expectStatus().isOk
+    val visitBookingResponse = getResult(responseSpec.expectBody())
+    val expectedVisitContact = VisitContactDto(
+      contactDto = visit.visitContact!!,
+      visitContactId = visitor3.personId,
+    )
+    assertVisitBookingDetails(visitBookingResponse, visit, prison, prisonerDto, emptyList(), OffenderRestrictionsDto(null, emptyList()), contactsList, expectedVisitContact, eventList, expectedEventActionedByFullNames, notifications)
+    verify(manageUsersApiClientSpy, times(1)).getUsersByUsernames(any())
+    verify(manageUsersApiClientSpy, times(1)).getUsersByUsernames(userIds.toSet())
   }
 
   @Test
@@ -1164,4 +1246,12 @@ class GetVisitBookingDetailsTest : IntegrationTestBase() {
     assertThat(notification.createdDateTime).isEqualTo(visitNotificationEventDto.createdDateTime)
     assertThat(notification.additionalData).isEqualTo(visitNotificationEventDto.additionalData)
   }
+
+  private fun callGetVisitFullDetailsByReference(
+    webTestClient: WebTestClient,
+    reference: String,
+    authHttpHeaders: (HttpHeaders) -> Unit,
+  ): WebTestClient.ResponseSpec = webTestClient.get().uri("/visits/$reference/detailed")
+    .headers(authHttpHeaders)
+    .exchange()
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/visit/GetVisitBookingDetailsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/visit/GetVisitBookingDetailsTest.kt
@@ -674,7 +674,7 @@ class GetVisitBookingDetailsTest : IntegrationTestBase() {
 
     val reference = "aa-bb-cc-dd"
     val visitors = listOf(createVisitorDto(visitor1, false), createVisitorDto(visitor2, false), createVisitorDto(visitor3, true))
-    val visit = createVisitDto(reference = reference, prisonCode = prisonCode, prisonerId = prisonerId, visitors = visitors, startTimestamp = LocalDateTime.now().minusDays(1), endTimestamp = LocalDateTime.now().minusDays(1))
+    val visit = createVisitDto(reference = reference, prisonCode = prisonCode, prisonerId = prisonerId, visitors = visitors, startTimestamp = LocalDateTime.now().minusDays(1))
     val contactsList = listOf(visitor1, visitor2, visitor3)
     val eventList = listOf(eventAudit1, eventAudit2, eventAudit3, eventAudit4, eventAudit5)
     val expectedEventActionedByFullNames = listOf("abcd", null, "Test User", "test-user1", "test-user2")


### PR DESCRIPTION
## What does this PR do?

Because we don't capture the alerts / restrictions at the time of booking, reviewing older visits can often show incorrect information in regards to these, as they're showing the current alerts / restrictions and not the ones at the time of booking.

This change, checks if the visit is in the past, or the prisoner is out of prison and if yes, it skips getting them.

Also fixes some checkstyle issues, to remove some ?: right side operations, which are unreachable in our kotlin code.

## JIRA
https://dsdmoj.atlassian.net/browse/VB-5552