### PR TITLE
remove pinning, not needed anymore

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -132,5 +132,3 @@ api:
   timeout: 10s
   health:
     timeout: 2s
-
-springdoc.swagger-ui.version: 5.32.1


### PR DESCRIPTION
After lib updates, this is no longer needed.