### PR TITLE
VB-5817 - Use new prisoner contact registry endpoint to search for specific visitors, given their contactIds

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.8"
-
 services:
   local-stack-aws:
     image: localstack/localstack:community-archive

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/client/PrisonerContactRegistryClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/client/PrisonerContactRegistryClient.kt
@@ -12,6 +12,7 @@ import org.springframework.web.reactive.function.client.bodyToMono
 import org.springframework.web.util.UriBuilder
 import reactor.core.publisher.Mono
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.client.ClientUtils.Companion.isNotFoundError
+import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.contact.registry.ContactWithOptionalPrisonerRelationshipDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.contact.registry.PrisonerContactDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.prison.api.HasClosedRestrictionDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.visit.scheduler.DateRange
@@ -31,6 +32,7 @@ class PrisonerContactRegistryClient(
   companion object {
     val LOG: Logger = LoggerFactory.getLogger(this::class.java)
     const val CONTACT_REGISTRY_CONTACTS_PATH: String = "/v2/prisoners/{prisonerId}/contacts"
+    const val CONTACT_REGISTRY_SEARCH_CONTACTS_PATH: String = "$CONTACT_REGISTRY_CONTACTS_PATH/search"
     const val CONTACT_REGISTRY_APPROVED_SOCIAL_CONTACTS_PATH: String = "$CONTACT_REGISTRY_CONTACTS_PATH/social/approved"
     const val CONTACT_REGISTRY_SOCIAL_CONTACTS_PATH: String = "$CONTACT_REGISTRY_CONTACTS_PATH/social"
     const val CONTACT_REGISTRY_APPROVED_SOCIAL_CONTACTS_RESTRICTIONS_PATH: String = "$CONTACT_REGISTRY_APPROVED_SOCIAL_CONTACTS_PATH/restrictions"
@@ -133,6 +135,21 @@ class PrisonerContactRegistryClient(
         }
         Mono.error(e)
       }.block(apiTimeout)
+  }
+
+  fun searchPrisonerContacts(prisonerId: String, contactIds: List<Long>, withRestrictions: Boolean = true): Mono<List<ContactWithOptionalPrisonerRelationshipDto>> {
+    val uri = CONTACT_REGISTRY_SEARCH_CONTACTS_PATH.replace("{prisonerId}", prisonerId)
+    return webClient.get().uri(uri) {
+      getSearchPrisonerContactsUriBuilder(contactIds, withRestrictions, it).build()
+    }
+      .retrieve()
+      .bodyToMono<List<ContactWithOptionalPrisonerRelationshipDto>>()
+  }
+
+  private fun getSearchPrisonerContactsUriBuilder(contactIds: List<Long>, withRestrictions: Boolean = true, uriBuilder: UriBuilder): UriBuilder {
+    uriBuilder.queryParam("contactIds", contactIds.joinToString(","))
+    uriBuilder.queryParam("withRestrictions", withRestrictions)
+    return uriBuilder
   }
 
   private fun getVisitorsHaveClosedRestrictionsParams(visitorIds: List<Long>, uriBuilder: UriBuilder): URI {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/client/VisitBookingDetailsClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/client/VisitBookingDetailsClient.kt
@@ -8,7 +8,7 @@ import reactor.core.publisher.Mono
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.RestPage
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.alerts.api.AlertDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.alerts.api.AlertResponseDto
-import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.contact.registry.PrisonerContactDto
+import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.contact.registry.ContactWithOptionalPrisonerRelationshipDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.orchestration.EventAuditOrchestrationDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.orchestration.VisitBookingDetailsDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.orchestration.VisitContactDto
@@ -81,26 +81,27 @@ class VisitBookingDetailsClient(
           prisonApiClient.getPrisonerRestrictionsAsMono(visit.prisonerId)
         }
 
-      val visitorsMono = prisonerContactRegistryClient.getPrisonersSocialContactsAsMono(
+      val visitorsMono = prisonerContactRegistryClient.searchPrisonerContacts(
         prisonerId = visit.prisonerId,
+        contactIds = visit.visitors!!.map { it.nomisPersonId },
         withRestrictions = !skipAlertsAndRestrictions,
       )
 
       Mono.zip(prisonerAlertsMono, prisonerRestrictionsMono, visitorsMono)
-        .map { optionalAlertsAndRestrictionsInfo ->
-          val prisonerAlerts = optionalAlertsAndRestrictionsInfo.t1.content
+        .map { alertsRestrictionsAndVisitors ->
+          val prisonerAlerts = alertsRestrictionsAndVisitors.t1.content
             .filter { predicateFilterSupportedCodes.test(it) }
             .sortedWith(alertsComparatorDateUpdatedOrCreatedDateDesc)
             .map { alertResponse -> AlertDto(alertResponse) }
 
-          val prisonerRestrictions = (optionalAlertsAndRestrictionsInfo.t2.offenderRestrictions ?: emptyList())
+          val prisonerRestrictions = (alertsRestrictionsAndVisitors.t2.offenderRestrictions ?: emptyList())
             .sortedWith(restrictionsComparatorDatCreatedDesc)
 
-          val allVisitorsForPrisoner = optionalAlertsAndRestrictionsInfo.t3
+          val allVisitorsForPrisoner = alertsRestrictionsAndVisitors.t3
 
-          val visitors = mutableListOf<PrisonerContactDto>()
-          visit.visitors?.forEach { visitVisitor ->
-            allVisitorsForPrisoner.firstOrNull { it.personId == visitVisitor.nomisPersonId }?.let {
+          val visitors = mutableListOf<ContactWithOptionalPrisonerRelationshipDto>()
+          visit.visitors.forEach { visitVisitor ->
+            allVisitorsForPrisoner.firstOrNull { it.contactId == visitVisitor.nomisPersonId }?.let {
               visitors.add(it)
             }
           }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/dto/contact/registry/ContactWithOptionalPrisonerRelationshipDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/dto/contact/registry/ContactWithOptionalPrisonerRelationshipDto.kt
@@ -1,0 +1,40 @@
+package uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.contact.registry
+
+import io.swagger.v3.oas.annotations.media.Schema
+import java.time.LocalDate
+
+@Schema(description = "A contact with an optional prisoner relationship")
+data class ContactWithOptionalPrisonerRelationshipDto(
+  @param:Schema(description = "Identifier for this contact (Person in NOMIS)", example = "5871791")
+  val contactId: Long,
+
+  @param:Schema(description = "First name", example = "John", required = true)
+  val firstName: String,
+
+  @param:Schema(description = "Middle name", example = "Mark", required = false)
+  val middleName: String? = null,
+
+  @param:Schema(description = "Last name", example = "Smith", required = true)
+  val lastName: String,
+
+  @param:Schema(description = "Date of birth", example = "1980-01-28", required = false)
+  val dateOfBirth: LocalDate? = null,
+
+  @param:Schema(description = "Code for relationship to Prisoner", example = "RO", required = false)
+  val relationshipCode: String? = null,
+
+  @param:Schema(description = "Description of relationship to Prisoner", example = "Responsible Officer", required = false)
+  val relationshipDescription: String? = null,
+
+  @param:Schema(description = "Type of Contact", example = "O", required = false)
+  val contactType: String? = null,
+
+  @param:Schema(description = "Description of Contact Type", example = "Official", required = false)
+  val contactTypeDescription: String? = null,
+
+  @param:Schema(description = "List of restrictions associated with the contact", required = false)
+  val restrictions: List<RestrictionDto> = listOf(),
+
+  @param:Schema(description = "Address associated with the contact", required = false)
+  var address: AddressDto? = null,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/dto/orchestration/VisitBookingDetailsDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/dto/orchestration/VisitBookingDetailsDto.kt
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.constraints.NotBlank
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.alerts.api.AlertDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.contact.registry.AddressDto
+import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.contact.registry.ContactWithOptionalPrisonerRelationshipDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.contact.registry.PrisonerContactDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.contact.registry.RestrictionDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.prison.api.OffenderRestrictionDto
@@ -55,12 +56,13 @@ data class VisitBookingDetailsDto(
   val prison: PrisonRegisterPrisonDto,
   @param:Schema(description = "Prisoner details", required = true)
   val prisoner: PrisonerDetailsDto,
-  @param:Schema(description = "Prisoner details", required = true)
+  @param:Schema(description = "Visitor details", required = true)
   val visitors: List<VisitorDetailsDto>,
+  @param:Schema(description = "Events tied to visit booking", required = true)
   val events: List<EventAuditOrchestrationDto>,
+  @param:Schema(description = "Notifications tied to visit booking", required = true)
   val notifications: List<VisitNotificationDto>,
-
-  @param:Schema(description = "Prisoner details", required = true)
+  @param:Schema(description = "Boolean to signify if alerts and restrictions retrieval was intentionally skipped", required = true)
   val skipAlertsAndRestrictions: Boolean,
 ) {
   constructor(
@@ -69,7 +71,7 @@ data class VisitBookingDetailsDto(
     prisonerDto: PrisonerDto,
     prisonerAlerts: List<AlertDto>,
     prisonerRestrictions: List<OffenderRestrictionDto>,
-    visitVisitors: List<PrisonerContactDto>,
+    visitVisitors: List<ContactWithOptionalPrisonerRelationshipDto>,
     visitContact: VisitContactDto?,
     events: List<EventAuditOrchestrationDto>,
     notifications: List<VisitNotificationEventDto>,
@@ -171,6 +173,16 @@ data class VisitorDetailsDto(
     restrictions = prisonerContactDto.restrictions,
     // Address (primary if address.primary is true)
     primaryAddress = prisonerContactDto.address,
+  )
+
+  constructor(contactWithOptionalPrisonerRelationshipDto: ContactWithOptionalPrisonerRelationshipDto) : this(
+    personId = contactWithOptionalPrisonerRelationshipDto.contactId,
+    firstName = contactWithOptionalPrisonerRelationshipDto.firstName,
+    lastName = contactWithOptionalPrisonerRelationshipDto.lastName,
+    dateOfBirth = contactWithOptionalPrisonerRelationshipDto.dateOfBirth,
+    relationshipDescription = contactWithOptionalPrisonerRelationshipDto.relationshipDescription,
+    restrictions = contactWithOptionalPrisonerRelationshipDto.restrictions,
+    primaryAddress = contactWithOptionalPrisonerRelationshipDto.address,
   )
 }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/IntegrationTestBase.kt
@@ -31,6 +31,7 @@ import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.control
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.alerts.api.AlertCodeSummaryDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.alerts.api.AlertResponseDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.contact.registry.AddressDto
+import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.contact.registry.ContactWithOptionalPrisonerRelationshipDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.contact.registry.PrisonerContactDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.contact.registry.RestrictionDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.orchestration.OrchestrationVisitorDto
@@ -648,6 +649,32 @@ abstract class IntegrationTestBase {
     address = address,
   )
 
+  final fun createContactWithOptionalPrisonerRelationshipDto(
+    personId: Long = ThreadLocalRandom.current().nextLong(),
+    firstName: String = "John",
+    middleName: String? = null,
+    lastName: String = "Smith",
+    dateOfBirth: LocalDate? = null,
+    relationshipCode: String? = "OTH",
+    relationshipDescription: String? = "Other",
+    contactType: String? = "S",
+    contactTypeDescription: String? = "Social",
+    restrictions: List<RestrictionDto> = emptyList(),
+    address: AddressDto? = null,
+  ): ContactWithOptionalPrisonerRelationshipDto = ContactWithOptionalPrisonerRelationshipDto(
+    contactId = personId,
+    firstName = firstName,
+    middleName = middleName,
+    lastName = lastName,
+    dateOfBirth = dateOfBirth,
+    relationshipCode = relationshipCode,
+    relationshipDescription = relationshipDescription,
+    contactType = contactType,
+    contactTypeDescription = contactTypeDescription,
+    restrictions = restrictions,
+    address = address,
+  )
+
   final fun createPrisoner(
     prisonerId: String,
     firstName: String,
@@ -690,6 +717,14 @@ abstract class IntegrationTestBase {
     visitContact: Boolean = false,
   ): VisitorDto = VisitorDto(
     nomisPersonId = contact.personId!!,
+    visitContact = visitContact,
+  )
+
+  final fun createVisitorDto(
+    contact: ContactWithOptionalPrisonerRelationshipDto,
+    visitContact: Boolean = false,
+  ): VisitorDto = VisitorDto(
+    nomisPersonId = contact.contactId,
     visitContact = visitContact,
   )
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/mock/PrisonerContactRegistryMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/mock/PrisonerContactRegistryMockServer.kt
@@ -7,6 +7,7 @@ import com.github.tomakehurst.wiremock.client.WireMock.post
 import org.springframework.http.HttpStatus
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.client.PrisonerContactRegistryClient
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.client.PrisonerContactRegistryClient.Companion.CONTACT_REGISTRY_REVIEW_RESTRICTIONS_DATE_RANGES_PATH
+import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.contact.registry.ContactWithOptionalPrisonerRelationshipDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.contact.registry.PrisonerContactDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.prison.api.HasClosedRestrictionDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.visit.scheduler.DateRange
@@ -28,6 +29,32 @@ class PrisonerContactRegistryMockServer : WireMockServer(8095) {
     } else {
       "/v2/prisoners/$prisonerId/contacts/social?withRestrictions=$withRestrictions"
     }
+
+    stubFor(
+      get(uri)
+        .willReturn(
+          if (contactsList == null) {
+            responseBuilder
+              .withStatus(httpStatus.value())
+          } else {
+            responseBuilder
+              .withStatus(HttpStatus.OK.value())
+              .withBody(getJsonString(contactsList))
+          },
+        ),
+    )
+  }
+
+  fun stubSearchPrisonerContacts(
+    prisonerId: String,
+    contactIds: List<Long>,
+    withRestrictions: Boolean = true,
+    contactsList: List<ContactWithOptionalPrisonerRelationshipDto>?,
+    httpStatus: HttpStatus = HttpStatus.NOT_FOUND,
+  ) {
+    val responseBuilder = createJsonResponseBuilder()
+
+    val uri = "/v2/prisoners/$prisonerId/contacts/search?contactIds=${contactIds.joinToString(",")}&withRestrictions=$withRestrictions"
 
     stubFor(
       get(uri)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/visit/GetVisitBookingDetailsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/visit/GetVisitBookingDetailsTest.kt
@@ -14,7 +14,7 @@ import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.control
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.alerts.api.AlertDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.alerts.api.AlertResponseDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.contact.registry.AddressDto
-import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.contact.registry.PrisonerContactDto
+import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.contact.registry.ContactWithOptionalPrisonerRelationshipDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.manage.users.UserExtendedDetailsDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.orchestration.EventAuditOrchestrationDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.orchestration.PrisonerDetailsDto
@@ -57,9 +57,9 @@ class GetVisitBookingDetailsTest : IntegrationTestBase() {
 
   private lateinit var offenderRestrictions: OffenderRestrictionsDto
 
-  private lateinit var visitor1: PrisonerContactDto
-  private lateinit var visitor2: PrisonerContactDto
-  private lateinit var visitor3: PrisonerContactDto
+  private lateinit var visitor1: ContactWithOptionalPrisonerRelationshipDto
+  private lateinit var visitor2: ContactWithOptionalPrisonerRelationshipDto
+  private lateinit var visitor3: ContactWithOptionalPrisonerRelationshipDto
 
   private lateinit var prison: PrisonRegisterPrisonDto
   private lateinit var alert1: AlertResponseDto
@@ -98,13 +98,28 @@ class GetVisitBookingDetailsTest : IntegrationTestBase() {
     )
 
     // visitor 1 has a primary address
-    visitor1 = createContactDto(1, "First", "VisitorA", address = createAddressDto(street = "ABC Street", primary = true))
+    visitor1 = createContactWithOptionalPrisonerRelationshipDto(
+      personId = 1,
+      firstName = "First",
+      lastName = "VisitorA",
+      address = createAddressDto(street = "ABC Street", primary = true),
+    )
 
     // visitor2 has only a secondary address
-    visitor2 = createContactDto(2, "Second", "VisitorB", address = createAddressDto(street = "ABC Street", primary = false))
+    visitor2 = createContactWithOptionalPrisonerRelationshipDto(
+      personId = 2,
+      firstName = "Second",
+      lastName = "VisitorB",
+      address = createAddressDto(street = "ABC Street", primary = false),
+    )
 
     // visitor 3 has no address
-    visitor3 = createContactDto(3, "Third", "VisitorC", address = null)
+    visitor3 = createContactWithOptionalPrisonerRelationshipDto(
+      personId = 3,
+      firstName = "Third",
+      lastName = "VisitorC",
+      address = null,
+    )
 
     prison = PrisonRegisterPrisonDto(prisonCode, "Prison-MDI")
 
@@ -158,7 +173,11 @@ class GetVisitBookingDetailsTest : IntegrationTestBase() {
     // alert 3's alert code is not relevant for visits so should be ignored
     alertApiMockServer.stubGetPrisonerAlertsMono(prisonerId, listOf(alert1, alert2, alert3))
     prisonApiMockServer.stubGetPrisonerRestrictions(prisonerId, offenderRestrictions)
-    prisonerContactRegistryMockServer.stubGetPrisonerContacts(prisonerId, contactsList = contactsList)
+    prisonerContactRegistryMockServer.stubSearchPrisonerContacts(
+      prisonerId = prisonerId,
+      contactIds = contactsList.map { it.contactId },
+      contactsList = contactsList,
+    )
     visitSchedulerMockServer.stubGetVisitHistory(visit.reference, eventList)
     visitSchedulerMockServer.stubGetVisitNotificationEvents(visit.reference, notifications)
     manageUsersApiMockServer.stubGetMultipleUserDetails(userIds, userDetails = userNamesMap)
@@ -171,54 +190,8 @@ class GetVisitBookingDetailsTest : IntegrationTestBase() {
     val visitBookingResponse = getResult(responseSpec.expectBody())
     val expectedVisitContact = VisitContactDto(
       contactDto = visit.visitContact!!,
-      visitContactId = visitor3.personId,
+      visitContactId = visitor3.contactId,
     )
-    assertVisitBookingDetails(visitBookingResponse, visit, prison, prisonerDto, listOf(alert1, alert2), offenderRestrictions, contactsList, expectedVisitContact, eventList, expectedEventActionedByFullNames, notifications)
-    verify(manageUsersApiClientSpy, times(1)).getUsersByUsernames(any())
-    verify(manageUsersApiClientSpy, times(1)).getUsersByUsernames(userIds.toSet())
-  }
-
-  @Test
-  fun `when a visit's visitor is no longer in contact list that visitor is not returned for that visit`() {
-    // Given
-    val userIds = listOf("test-user")
-    val userNamesMap = mapOf(
-      "test-user" to UserExtendedDetailsDto("test-user", "Test", "User A"),
-    )
-
-    val reference = "aa-bb-cc-dd"
-    val prisonerId = "prisoner-id"
-    val visitors = listOf(createVisitorDto(visitor1, false), createVisitorDto(visitor2, false), createVisitorDto(visitor3, true))
-    val visit = createVisitDto(reference = reference, prisonCode = prisonCode, prisonerId = prisonerId, visitors = visitors)
-    // contacts returned does not have visitor 3
-    val contactsList = listOf(visitor1, visitor2)
-    val eventList = mutableListOf(eventAudit1, eventAudit2, eventAudit3)
-    val expectedEventActionedByFullNames = listOf("abcd", null, "Test User A")
-
-    val notifications = emptyList<VisitNotificationEventDto>()
-
-    visitSchedulerMockServer.stubGetVisit(reference, visit)
-    prisonOffenderSearchMockServer.stubGetPrisonerById(prisonerId, prisonerDto)
-    prisonRegisterMockServer.stubGetPrison(prisonCode, prison)
-    // alert 3's alert code is not relevant for visits so should be ignored
-    alertApiMockServer.stubGetPrisonerAlertsMono(prisonerId, listOf(alert1, alert2, alert3))
-    prisonApiMockServer.stubGetPrisonerRestrictions(prisonerId, offenderRestrictions)
-    prisonerContactRegistryMockServer.stubGetPrisonerContacts(prisonerId = prisonerId, hasDateOfBirth = null, contactsList = contactsList)
-    visitSchedulerMockServer.stubGetVisitHistory(visit.reference, eventList)
-    visitSchedulerMockServer.stubGetVisitNotificationEvents(visit.reference, notifications)
-    manageUsersApiMockServer.stubGetMultipleUserDetails(userIds, userDetails = userNamesMap)
-
-    // When
-    val responseSpec = callGetVisitFullDetailsByReference(webTestClient, reference, roleVSIPOrchestrationServiceHttpHeaders)
-
-    // Then
-    responseSpec.expectStatus().isOk
-    val visitBookingResponse = getResult(responseSpec.expectBody())
-    val expectedVisitContact = VisitContactDto(
-      contactDto = visit.visitContact!!,
-      visitContactId = visitor3.personId,
-    )
-
     assertVisitBookingDetails(visitBookingResponse, visit, prison, prisonerDto, listOf(alert1, alert2), offenderRestrictions, contactsList, expectedVisitContact, eventList, expectedEventActionedByFullNames, notifications)
     verify(manageUsersApiClientSpy, times(1)).getUsersByUsernames(any())
     verify(manageUsersApiClientSpy, times(1)).getUsersByUsernames(userIds.toSet())
@@ -250,7 +223,11 @@ class GetVisitBookingDetailsTest : IntegrationTestBase() {
     // alert 3's alert code is not relevant for visits so should be ignored
     alertApiMockServer.stubGetPrisonerAlertsMono(prisonerId, listOf(alert1, alert2, alert3))
     prisonApiMockServer.stubGetPrisonerRestrictions(prisonerId, offenderRestrictions)
-    prisonerContactRegistryMockServer.stubGetPrisonerContacts(prisonerId = prisonerId, hasDateOfBirth = null, contactsList = contactsList)
+    prisonerContactRegistryMockServer.stubSearchPrisonerContacts(
+      prisonerId = prisonerId,
+      contactIds = contactsList.map { it.contactId },
+      contactsList = contactsList,
+    )
     visitSchedulerMockServer.stubGetVisitHistory(visit.reference, eventList)
     visitSchedulerMockServer.stubGetVisitNotificationEvents(visit.reference, notifications)
     manageUsersApiMockServer.stubGetMultipleUserDetails(userIds, userDetails = userNamesMap)
@@ -267,56 +244,6 @@ class GetVisitBookingDetailsTest : IntegrationTestBase() {
   }
 
   @Test
-  fun `when a visit's contact is not from the contact list then visitContactDetails are populated without contactId for that visit`() {
-    // Given
-    val userIds = listOf("test-user")
-    val userNamesMap = mapOf(
-      "test-user" to UserExtendedDetailsDto("test-user", "Test", "User A"),
-    )
-
-    val reference = "aa-bb-cc-dd"
-    val prisonerId = "prisoner-id"
-
-    // none of the 3 visitors are main contacts
-    val visitors = listOf(createVisitorDto(visitor1, false), createVisitorDto(visitor2, false), createVisitorDto(visitor3, false))
-
-    // main contact details
-    val contact = ContactDto("Johnny Doe", "01234567890", "email@example.com")
-    val visit = createVisitDto(reference = reference, prisonCode = prisonCode, prisonerId = prisonerId, visitors = visitors, contact = contact)
-    // contacts returned does not have visitor 3
-    val contactsList = listOf(visitor1, visitor2)
-    val eventList = mutableListOf(eventAudit1, eventAudit2, eventAudit3)
-    val expectedEventActionedByFullNames = listOf("abcd", null, "Test User A")
-
-    val notifications = emptyList<VisitNotificationEventDto>()
-
-    visitSchedulerMockServer.stubGetVisit(reference, visit)
-    prisonOffenderSearchMockServer.stubGetPrisonerById(prisonerId, prisonerDto)
-    prisonRegisterMockServer.stubGetPrison(prisonCode, prison)
-    // alert 3's alert code is not relevant for visits so should be ignored
-    alertApiMockServer.stubGetPrisonerAlertsMono(prisonerId, listOf(alert1, alert2, alert3))
-    prisonApiMockServer.stubGetPrisonerRestrictions(prisonerId, offenderRestrictions)
-    prisonerContactRegistryMockServer.stubGetPrisonerContacts(prisonerId = prisonerId, hasDateOfBirth = null, contactsList = contactsList)
-    visitSchedulerMockServer.stubGetVisitHistory(visit.reference, eventList)
-    visitSchedulerMockServer.stubGetVisitNotificationEvents(visit.reference, notifications)
-    manageUsersApiMockServer.stubGetMultipleUserDetails(userIds, userDetails = userNamesMap)
-
-    // When
-    val responseSpec = callGetVisitFullDetailsByReference(webTestClient, reference, roleVSIPOrchestrationServiceHttpHeaders)
-
-    // Then
-    responseSpec.expectStatus().isOk
-    val visitBookingResponse = getResult(responseSpec.expectBody())
-    val expectedVisitContact = VisitContactDto(
-      contactDto = visit.visitContact!!,
-      visitContactId = null,
-    )
-    assertVisitBookingDetails(visitBookingResponse, visit, prison, prisonerDto, listOf(alert1, alert2), offenderRestrictions, contactsList, expectedVisitContact, eventList, expectedEventActionedByFullNames, notifications)
-    verify(manageUsersApiClientSpy, times(1)).getUsersByUsernames(any())
-    verify(manageUsersApiClientSpy, times(1)).getUsersByUsernames(userIds.toSet())
-  }
-
-  @Test
   fun `when a visit's visitor has no primary address then the address is still populated on the visit booking details`() {
     // Given
     val userIds = listOf("test-user")
@@ -328,10 +255,10 @@ class GetVisitBookingDetailsTest : IntegrationTestBase() {
     val prisonerId = "prisoner-id"
 
     // address3 is the first address on the list
-    val visitorWithNoPrimaryAddress = createContactDto(
-      21,
-      "Visitor",
-      "TwentyOne",
+    val visitorWithNoPrimaryAddress = createContactWithOptionalPrisonerRelationshipDto(
+      personId = 21,
+      firstName = "Visitor",
+      lastName = "TwentyOne",
       address = createAddressDto(street = "ABC Street", primary = false),
     )
 
@@ -352,7 +279,11 @@ class GetVisitBookingDetailsTest : IntegrationTestBase() {
     // alert 3's alert code is not relevant for visits so should be ignored
     alertApiMockServer.stubGetPrisonerAlertsMono(prisonerId, listOf(alert1, alert2, alert3))
     prisonApiMockServer.stubGetPrisonerRestrictions(prisonerId, offenderRestrictions)
-    prisonerContactRegistryMockServer.stubGetPrisonerContacts(prisonerId = prisonerId, hasDateOfBirth = null, contactsList = contactsList)
+    prisonerContactRegistryMockServer.stubSearchPrisonerContacts(
+      prisonerId = prisonerId,
+      contactIds = contactsList.map { it.contactId },
+      contactsList = contactsList,
+    )
     visitSchedulerMockServer.stubGetVisitHistory(visit.reference, eventList)
     visitSchedulerMockServer.stubGetVisitNotificationEvents(visit.reference, notifications)
     manageUsersApiMockServer.stubGetMultipleUserDetails(userIds, userDetails = userNamesMap)
@@ -365,7 +296,7 @@ class GetVisitBookingDetailsTest : IntegrationTestBase() {
     val visitBookingResponse = getResult(responseSpec.expectBody())
     val expectedVisitContact = VisitContactDto(
       contactDto = visit.visitContact!!,
-      visitContactId = visitorWithNoPrimaryAddress.personId,
+      visitContactId = visitorWithNoPrimaryAddress.contactId,
     )
     assertVisitBookingDetails(visitBookingResponse, visit, prison, prisonerDto, listOf(alert1, alert2), offenderRestrictions, contactsList, expectedVisitContact, eventList, expectedEventActionedByFullNames, notifications)
     assertThat(visitBookingResponse.visitors[0].primaryAddress).isEqualTo(createAddressDto(street = "ABC Street", primary = false))
@@ -385,11 +316,11 @@ class GetVisitBookingDetailsTest : IntegrationTestBase() {
     val prisonerId = "prisoner-id"
 
     // address3 is the first address on the list
-    val visitorWithNoAddress = createContactDto(
-      21,
-      "Visitor",
-      "TwentyOne",
-      address = null, // the visitor has no address
+    val visitorWithNoAddress = createContactWithOptionalPrisonerRelationshipDto(
+      personId = 21,
+      firstName = "Visitor",
+      lastName = "TwentyOne",
+      address = null,
     )
     val visitors = listOf(createVisitorDto(visitorWithNoAddress, true))
 
@@ -409,7 +340,11 @@ class GetVisitBookingDetailsTest : IntegrationTestBase() {
     // alert 3's alert code is not relevant for visits so should be ignored
     alertApiMockServer.stubGetPrisonerAlertsMono(prisonerId, listOf(alert1, alert2, alert3))
     prisonApiMockServer.stubGetPrisonerRestrictions(prisonerId, offenderRestrictions)
-    prisonerContactRegistryMockServer.stubGetPrisonerContacts(prisonerId = prisonerId, hasDateOfBirth = null, contactsList = contactsList)
+    prisonerContactRegistryMockServer.stubSearchPrisonerContacts(
+      prisonerId = prisonerId,
+      contactIds = contactsList.map { it.contactId },
+      contactsList = contactsList,
+    )
     visitSchedulerMockServer.stubGetVisitHistory(visit.reference, eventList)
     visitSchedulerMockServer.stubGetVisitNotificationEvents(visit.reference, notifications)
     manageUsersApiMockServer.stubGetMultipleUserDetails(userIds, userDetails = userNamesMap)
@@ -422,7 +357,7 @@ class GetVisitBookingDetailsTest : IntegrationTestBase() {
     val visitBookingResponse = getResult(responseSpec.expectBody())
     val expectedVisitContact = VisitContactDto(
       contactDto = visit.visitContact!!,
-      visitContactId = visitorWithNoAddress.personId,
+      visitContactId = visitorWithNoAddress.contactId,
     )
     assertVisitBookingDetails(visitBookingResponse, visit, prison, prisonerDto, listOf(alert1, alert2), offenderRestrictions, contactsList, expectedVisitContact, eventList, expectedEventActionedByFullNames, notifications)
     assertThat(visitBookingResponse.visitors[0].primaryAddress).isNull()
@@ -448,7 +383,11 @@ class GetVisitBookingDetailsTest : IntegrationTestBase() {
     prisonRegisterMockServer.stubGetPrison(prisonCode, prison)
     alertApiMockServer.stubGetPrisonerAlertsMono(prisonerId, listOf(alert1, alert2, alert3))
     prisonApiMockServer.stubGetPrisonerRestrictions(prisonerId, offenderRestrictions)
-    prisonerContactRegistryMockServer.stubGetPrisonerContacts(prisonerId, contactsList = contactsList)
+    prisonerContactRegistryMockServer.stubSearchPrisonerContacts(
+      prisonerId = prisonerId,
+      contactIds = contactsList.map { it.contactId },
+      contactsList = contactsList,
+    )
     visitSchedulerMockServer.stubGetVisitHistory(visit.reference, eventList)
     visitSchedulerMockServer.stubGetVisitNotificationEvents(visit.reference, notifications)
 
@@ -477,7 +416,11 @@ class GetVisitBookingDetailsTest : IntegrationTestBase() {
     prisonRegisterMockServer.stubGetPrison(prisonCode, prison)
     alertApiMockServer.stubGetPrisonerAlertsMono(prisonerId, listOf(alert1, alert2, alert3))
     prisonApiMockServer.stubGetPrisonerRestrictions(prisonerId, offenderRestrictions)
-    prisonerContactRegistryMockServer.stubGetPrisonerContacts(prisonerId, contactsList = contactsList)
+    prisonerContactRegistryMockServer.stubSearchPrisonerContacts(
+      prisonerId = prisonerId,
+      contactIds = contactsList.map { it.contactId },
+      contactsList = contactsList,
+    )
     visitSchedulerMockServer.stubGetVisitHistory(visit.reference, eventList)
     visitSchedulerMockServer.stubGetVisitNotificationEvents(visit.reference, notifications)
 
@@ -507,7 +450,11 @@ class GetVisitBookingDetailsTest : IntegrationTestBase() {
     prisonRegisterMockServer.stubGetPrison(prisonCode, null, HttpStatus.NOT_FOUND)
     alertApiMockServer.stubGetPrisonerAlertsMono(prisonerId, listOf(alert1, alert2, alert3))
     prisonApiMockServer.stubGetPrisonerRestrictions(prisonerId, offenderRestrictions)
-    prisonerContactRegistryMockServer.stubGetPrisonerContacts(prisonerId, contactsList = contactsList)
+    prisonerContactRegistryMockServer.stubSearchPrisonerContacts(
+      prisonerId = prisonerId,
+      contactIds = contactsList.map { it.contactId },
+      contactsList = contactsList,
+    )
     visitSchedulerMockServer.stubGetVisitHistory(visit.reference, eventList)
     visitSchedulerMockServer.stubGetVisitNotificationEvents(visit.reference, notifications)
 
@@ -522,7 +469,7 @@ class GetVisitBookingDetailsTest : IntegrationTestBase() {
     val expectedPrison = PrisonRegisterPrisonDto(prisonCode, prisonCode)
     val expectedVisitContact = VisitContactDto(
       contactDto = visit.visitContact!!,
-      visitContactId = visitor3.personId,
+      visitContactId = visitor3.contactId,
     )
 
     assertVisitBookingDetails(visitBookingResponse, visit, expectedPrison, prisonerDto, listOf(alert1, alert2), offenderRestrictions, contactsList, expectedVisitContact, eventList, expectedEventActionedByFullNames, notifications)
@@ -545,7 +492,11 @@ class GetVisitBookingDetailsTest : IntegrationTestBase() {
     prisonRegisterMockServer.stubGetPrison(prisonCode, null, HttpStatus.INTERNAL_SERVER_ERROR)
     alertApiMockServer.stubGetPrisonerAlertsMono(prisonerId, listOf(alert1, alert2, alert3))
     prisonApiMockServer.stubGetPrisonerRestrictions(prisonerId, offenderRestrictions)
-    prisonerContactRegistryMockServer.stubGetPrisonerContacts(prisonerId, contactsList = contactsList)
+    prisonerContactRegistryMockServer.stubSearchPrisonerContacts(
+      prisonerId = prisonerId,
+      contactIds = contactsList.map { it.contactId },
+      contactsList = contactsList,
+    )
     visitSchedulerMockServer.stubGetVisitHistory(visit.reference, eventList)
 
     // When
@@ -572,7 +523,11 @@ class GetVisitBookingDetailsTest : IntegrationTestBase() {
     // alert API returns a 500
     alertApiMockServer.stubGetPrisonerAlertsMono(prisonerId, null, HttpStatus.INTERNAL_SERVER_ERROR)
     prisonApiMockServer.stubGetPrisonerRestrictions(prisonerId, offenderRestrictions)
-    prisonerContactRegistryMockServer.stubGetPrisonerContacts(prisonerId, contactsList = contactsList)
+    prisonerContactRegistryMockServer.stubSearchPrisonerContacts(
+      prisonerId = prisonerId,
+      contactIds = contactsList.map { it.contactId },
+      contactsList = contactsList,
+    )
     visitSchedulerMockServer.stubGetVisitHistory(visit.reference, eventList)
     visitSchedulerMockServer.stubGetVisitNotificationEvents(visit.reference, notifications)
 
@@ -600,7 +555,11 @@ class GetVisitBookingDetailsTest : IntegrationTestBase() {
     alertApiMockServer.stubGetPrisonerAlertsMono(prisonerId, listOf(alert1, alert2, alert3))
     // prison API returns a 404
     prisonApiMockServer.stubGetPrisonerRestrictions(prisonerId, null, HttpStatus.NOT_FOUND)
-    prisonerContactRegistryMockServer.stubGetPrisonerContacts(prisonerId, contactsList = contactsList)
+    prisonerContactRegistryMockServer.stubSearchPrisonerContacts(
+      prisonerId = prisonerId,
+      contactIds = contactsList.map { it.contactId },
+      contactsList = contactsList,
+    )
     visitSchedulerMockServer.stubGetVisitHistory(visit.reference, eventList)
     visitSchedulerMockServer.stubGetVisitNotificationEvents(visit.reference, notifications)
 
@@ -642,7 +601,12 @@ class GetVisitBookingDetailsTest : IntegrationTestBase() {
     prisonOffenderSearchMockServer.stubGetPrisonerById(prisonerId, releasedPrisoner)
     prisonRegisterMockServer.stubGetPrison(prisonCode, prison)
 
-    prisonerContactRegistryMockServer.stubGetPrisonerContacts(prisonerId, contactsList = contactsList, withRestrictions = false)
+    prisonerContactRegistryMockServer.stubSearchPrisonerContacts(
+      prisonerId = prisonerId,
+      contactIds = contactsList.map { it.contactId },
+      contactsList = contactsList,
+      withRestrictions = false,
+    )
     visitSchedulerMockServer.stubGetVisitHistory(visit.reference, eventList)
     visitSchedulerMockServer.stubGetVisitNotificationEvents(visit.reference, notifications)
     manageUsersApiMockServer.stubGetMultipleUserDetails(userIds, userDetails = userNamesMap)
@@ -655,14 +619,14 @@ class GetVisitBookingDetailsTest : IntegrationTestBase() {
     val visitBookingResponse = getResult(responseSpec.expectBody())
     val expectedVisitContact = VisitContactDto(
       contactDto = visit.visitContact!!,
-      visitContactId = visitor3.personId,
+      visitContactId = visitor3.contactId,
     )
     assertVisitBookingDetails(visitBookingResponse, visit, prison, releasedPrisoner, emptyList(), OffenderRestrictionsDto(null, emptyList()), contactsList, expectedVisitContact, eventList, expectedEventActionedByFullNames, notifications)
     verify(manageUsersApiClientSpy, times(1)).getUsersByUsernames(any())
     verify(manageUsersApiClientSpy, times(1)).getUsersByUsernames(userIds.toSet())
     verify(alertsApiClientSpy, times(0)).getPrisonerAlertsAsMono(any())
     verify(prisonApiClientSpy, times(0)).getPrisonerRestrictionsAsMono(any())
-    verify(prisonerContactRegistryClientSpy, times(1)).getPrisonersSocialContactsAsMono(prisonerId, null, false)
+    verify(prisonerContactRegistryClientSpy, times(1)).searchPrisonerContacts(prisonerId, contactsList.map { it.contactId }, false)
   }
 
   @Test
@@ -685,7 +649,12 @@ class GetVisitBookingDetailsTest : IntegrationTestBase() {
     prisonOffenderSearchMockServer.stubGetPrisonerById(prisonerId, prisonerDto)
     prisonRegisterMockServer.stubGetPrison(prisonCode, prison)
 
-    prisonerContactRegistryMockServer.stubGetPrisonerContacts(prisonerId, contactsList = contactsList, withRestrictions = false)
+    prisonerContactRegistryMockServer.stubSearchPrisonerContacts(
+      prisonerId = prisonerId,
+      contactIds = contactsList.map { it.contactId },
+      contactsList = contactsList,
+      withRestrictions = false,
+    )
     visitSchedulerMockServer.stubGetVisitHistory(visit.reference, eventList)
     visitSchedulerMockServer.stubGetVisitNotificationEvents(visit.reference, notifications)
     manageUsersApiMockServer.stubGetMultipleUserDetails(userIds, userDetails = userNamesMap)
@@ -698,14 +667,14 @@ class GetVisitBookingDetailsTest : IntegrationTestBase() {
     val visitBookingResponse = getResult(responseSpec.expectBody())
     val expectedVisitContact = VisitContactDto(
       contactDto = visit.visitContact!!,
-      visitContactId = visitor3.personId,
+      visitContactId = visitor3.contactId,
     )
     assertVisitBookingDetails(visitBookingResponse, visit, prison, prisonerDto, emptyList(), OffenderRestrictionsDto(null, emptyList()), contactsList, expectedVisitContact, eventList, expectedEventActionedByFullNames, notifications)
     verify(manageUsersApiClientSpy, times(1)).getUsersByUsernames(any())
     verify(manageUsersApiClientSpy, times(1)).getUsersByUsernames(userIds.toSet())
     verify(alertsApiClientSpy, times(0)).getPrisonerAlertsAsMono(any())
     verify(prisonApiClientSpy, times(0)).getPrisonerRestrictionsAsMono(any())
-    verify(prisonerContactRegistryClientSpy, times(1)).getPrisonersSocialContactsAsMono(prisonerId, null, false)
+    verify(prisonerContactRegistryClientSpy, times(1)).searchPrisonerContacts(prisonerId, contactsList.map { it.contactId }, false)
   }
 
   @Test
@@ -724,7 +693,11 @@ class GetVisitBookingDetailsTest : IntegrationTestBase() {
     alertApiMockServer.stubGetPrisonerAlertsMono(prisonerId, listOf(alert1, alert2, alert3))
     // prison API returns a 404
     prisonApiMockServer.stubGetPrisonerRestrictions(prisonerId, null, HttpStatus.INTERNAL_SERVER_ERROR)
-    prisonerContactRegistryMockServer.stubGetPrisonerContacts(prisonerId, contactsList = contactsList)
+    prisonerContactRegistryMockServer.stubSearchPrisonerContacts(
+      prisonerId = prisonerId,
+      contactIds = contactsList.map { it.contactId },
+      contactsList = contactsList,
+    )
     visitSchedulerMockServer.stubGetVisitHistory(visit.reference, eventList)
     visitSchedulerMockServer.stubGetVisitNotificationEvents(visit.reference, notifications)
 
@@ -751,7 +724,12 @@ class GetVisitBookingDetailsTest : IntegrationTestBase() {
     alertApiMockServer.stubGetPrisonerAlertsMono(prisonerId, listOf(alert1, alert2, alert3))
     prisonApiMockServer.stubGetPrisonerRestrictions(prisonerId, offenderRestrictions)
     // prisoner contact registry API returns a 404
-    prisonerContactRegistryMockServer.stubGetPrisonerContacts(prisonerId, contactsList = null, httpStatus = HttpStatus.NOT_FOUND)
+    prisonerContactRegistryMockServer.stubSearchPrisonerContacts(
+      prisonerId = prisonerId,
+      contactIds = visitors.map { it.nomisPersonId },
+      contactsList = null,
+      httpStatus = HttpStatus.NOT_FOUND,
+    )
     visitSchedulerMockServer.stubGetVisitHistory(visit.reference, eventList)
     visitSchedulerMockServer.stubGetVisitNotificationEvents(visit.reference, notifications)
 
@@ -778,8 +756,13 @@ class GetVisitBookingDetailsTest : IntegrationTestBase() {
     prisonRegisterMockServer.stubGetPrison(prisonCode, prison)
     alertApiMockServer.stubGetPrisonerAlertsMono(prisonerId, listOf(alert1, alert2, alert3))
     prisonApiMockServer.stubGetPrisonerRestrictions(prisonerId, offenderRestrictions)
-    // prisoner contact registry API returns a 404
-    prisonerContactRegistryMockServer.stubGetPrisonerContacts(prisonerId, contactsList = null, httpStatus = HttpStatus.INTERNAL_SERVER_ERROR)
+    // prisoner contact registry API returns a 500
+    prisonerContactRegistryMockServer.stubSearchPrisonerContacts(
+      prisonerId = prisonerId,
+      contactIds = visitors.map { it.nomisPersonId },
+      contactsList = null,
+      httpStatus = HttpStatus.INTERNAL_SERVER_ERROR,
+    )
     visitSchedulerMockServer.stubGetVisitHistory(visit.reference, eventList)
 
     // When
@@ -804,7 +787,11 @@ class GetVisitBookingDetailsTest : IntegrationTestBase() {
     prisonRegisterMockServer.stubGetPrison(prisonCode, prison)
     alertApiMockServer.stubGetPrisonerAlertsMono(prisonerId, listOf(alert1, alert2, alert3))
     prisonApiMockServer.stubGetPrisonerRestrictions(prisonerId, offenderRestrictions)
-    prisonerContactRegistryMockServer.stubGetPrisonerContacts(prisonerId, contactsList = contactsList)
+    prisonerContactRegistryMockServer.stubSearchPrisonerContacts(
+      prisonerId = prisonerId,
+      contactIds = contactsList.map { it.contactId },
+      contactsList = contactsList,
+    )
     // visits get history - returns a 404
     visitSchedulerMockServer.stubGetVisitHistory(visit.reference, emptyList(), HttpStatus.NOT_FOUND)
     visitSchedulerMockServer.stubGetVisitNotificationEvents(visit.reference, notifications)
@@ -831,7 +818,11 @@ class GetVisitBookingDetailsTest : IntegrationTestBase() {
     prisonRegisterMockServer.stubGetPrison(prisonCode, prison)
     alertApiMockServer.stubGetPrisonerAlertsMono(prisonerId, listOf(alert1, alert2, alert3))
     prisonApiMockServer.stubGetPrisonerRestrictions(prisonerId, offenderRestrictions)
-    prisonerContactRegistryMockServer.stubGetPrisonerContacts(prisonerId, contactsList = contactsList)
+    prisonerContactRegistryMockServer.stubSearchPrisonerContacts(
+      prisonerId = prisonerId,
+      contactIds = contactsList.map { it.contactId },
+      contactsList = contactsList,
+    )
     // visits get history - returns a 500
     visitSchedulerMockServer.stubGetVisitHistory(visit.reference, emptyList(), HttpStatus.INTERNAL_SERVER_ERROR)
     visitSchedulerMockServer.stubGetVisitNotificationEvents(visit.reference, notifications)
@@ -858,7 +849,11 @@ class GetVisitBookingDetailsTest : IntegrationTestBase() {
     prisonRegisterMockServer.stubGetPrison(prisonCode, prison)
     alertApiMockServer.stubGetPrisonerAlertsMono(prisonerId, listOf(alert1, alert2, alert3))
     prisonApiMockServer.stubGetPrisonerRestrictions(prisonerId, offenderRestrictions)
-    prisonerContactRegistryMockServer.stubGetPrisonerContacts(prisonerId, contactsList = contactsList)
+    prisonerContactRegistryMockServer.stubSearchPrisonerContacts(
+      prisonerId = prisonerId,
+      contactIds = contactsList.map { it.contactId },
+      contactsList = contactsList,
+    )
     visitSchedulerMockServer.stubGetVisitHistory(visit.reference, eventList)
     // visits get notifications - returns a 404
     visitSchedulerMockServer.stubGetVisitNotificationEvents(visit.reference, null, HttpStatus.NOT_FOUND)
@@ -885,9 +880,13 @@ class GetVisitBookingDetailsTest : IntegrationTestBase() {
     prisonRegisterMockServer.stubGetPrison(prisonCode, prison)
     alertApiMockServer.stubGetPrisonerAlertsMono(prisonerId, listOf(alert1, alert2, alert3))
     prisonApiMockServer.stubGetPrisonerRestrictions(prisonerId, offenderRestrictions)
-    prisonerContactRegistryMockServer.stubGetPrisonerContacts(prisonerId, contactsList = contactsList)
+    prisonerContactRegistryMockServer.stubSearchPrisonerContacts(
+      prisonerId = prisonerId,
+      contactIds = contactsList.map { it.contactId },
+      contactsList = contactsList,
+    )
     visitSchedulerMockServer.stubGetVisitHistory(visit.reference, eventList)
-    // visits get notifications - returns a 404
+    // visits get notifications - returns a 500
     visitSchedulerMockServer.stubGetVisitNotificationEvents(visit.reference, null, HttpStatus.INTERNAL_SERVER_ERROR)
 
     // When
@@ -917,7 +916,11 @@ class GetVisitBookingDetailsTest : IntegrationTestBase() {
     // alert 3's alert code is not relevant for visits so should be ignored
     alertApiMockServer.stubGetPrisonerAlertsMono(prisonerId, listOf(alert1, alert2, alert3))
     prisonApiMockServer.stubGetPrisonerRestrictions(prisonerId, offenderRestrictions)
-    prisonerContactRegistryMockServer.stubGetPrisonerContacts(prisonerId, contactsList = contactsList)
+    prisonerContactRegistryMockServer.stubSearchPrisonerContacts(
+      prisonerId = prisonerId,
+      contactIds = contactsList.map { it.contactId },
+      contactsList = contactsList,
+    )
     visitSchedulerMockServer.stubGetVisitHistory(visit.reference, eventList)
     visitSchedulerMockServer.stubGetVisitNotificationEvents(visit.reference, notifications)
     manageUsersApiMockServer.stubGetMultipleUserDetails(listOf("test-user"), null, HttpStatus.NOT_FOUND)
@@ -930,7 +933,7 @@ class GetVisitBookingDetailsTest : IntegrationTestBase() {
     val visitBookingResponse = getResult(responseSpec.expectBody())
     val expectedVisitContact = VisitContactDto(
       contactDto = visit.visitContact!!,
-      visitContactId = visitor3.personId,
+      visitContactId = visitor3.contactId,
     )
 
     assertVisitBookingDetails(visitBookingResponse, visit, prison, prisonerDto, listOf(alert1, alert2), offenderRestrictions, contactsList, expectedVisitContact, eventList, expectedEventActionedByFullNames, notifications)
@@ -955,7 +958,11 @@ class GetVisitBookingDetailsTest : IntegrationTestBase() {
     // alert 3's alert code is not relevant for visits so should be ignored
     alertApiMockServer.stubGetPrisonerAlertsMono(prisonerId, listOf(alert1, alert2, alert3))
     prisonApiMockServer.stubGetPrisonerRestrictions(prisonerId, offenderRestrictions)
-    prisonerContactRegistryMockServer.stubGetPrisonerContacts(prisonerId, contactsList = contactsList)
+    prisonerContactRegistryMockServer.stubSearchPrisonerContacts(
+      prisonerId = prisonerId,
+      contactIds = contactsList.map { it.contactId },
+      contactsList = contactsList,
+    )
     visitSchedulerMockServer.stubGetVisitHistory(visit.reference, eventList)
     visitSchedulerMockServer.stubGetVisitNotificationEvents(visit.reference, notifications)
     manageUsersApiMockServer.stubGetMultipleUserDetails(listOf("test-user"), null, HttpStatus.INTERNAL_SERVER_ERROR)
@@ -967,7 +974,7 @@ class GetVisitBookingDetailsTest : IntegrationTestBase() {
     val visitBookingResponse = getResult(responseSpec.expectBody())
     val expectedVisitContact = VisitContactDto(
       contactDto = visit.visitContact!!,
-      visitContactId = visitor3.personId,
+      visitContactId = visitor3.contactId,
     )
 
     assertVisitBookingDetails(visitBookingResponse, visit, prison, prisonerDto, listOf(alert1, alert2), offenderRestrictions, contactsList, expectedVisitContact, eventList, expectedEventActionedByFullNames, notifications)
@@ -1006,7 +1013,7 @@ class GetVisitBookingDetailsTest : IntegrationTestBase() {
     val alert6 = createAlertResponseDto(alertTypeCode = "F", lastModifiedAt = null, createdAt = LocalDateTime.now().minusYears(1).minusMinutes(1))
     // alert 7 - updated today, created last month
     val alert7 = createAlertResponseDto(alertTypeCode = "G", lastModifiedAt = LocalDateTime.now(), createdAt = LocalDateTime.now().minusMonths(1))
-    // alert 7 - updated today, created today
+    // alert 8 - updated today, created today
     val alert8 = createAlertResponseDto(alertTypeCode = "H", lastModifiedAt = LocalDateTime.now().minusMinutes(1), createdAt = LocalDateTime.now().minusMinutes(1))
     // alert 9 - created 3 years back, not updated, active to is 2 months from today
     val alert9 = createAlertResponseDto(alertTypeCode = "I", lastModifiedAt = null, createdAt = LocalDateTime.now().minusYears(3), activeFrom = LocalDate.now().minusYears(3), activeTo = LocalDate.now().plusMonths(2))
@@ -1020,7 +1027,11 @@ class GetVisitBookingDetailsTest : IntegrationTestBase() {
 
     alertApiMockServer.stubGetPrisonerAlertsMono(prisonerId, listOf(alert1, alert2, alert3, alert4, alert5, alert6, alert7, alert8, alert9, alert10, alert11))
     prisonApiMockServer.stubGetPrisonerRestrictions(prisonerId, offenderRestrictions)
-    prisonerContactRegistryMockServer.stubGetPrisonerContacts(prisonerId, contactsList = contactsList)
+    prisonerContactRegistryMockServer.stubSearchPrisonerContacts(
+      prisonerId = prisonerId,
+      contactIds = contactsList.map { it.contactId },
+      contactsList = contactsList,
+    )
     visitSchedulerMockServer.stubGetVisitHistory(visit.reference, eventList)
     visitSchedulerMockServer.stubGetVisitNotificationEvents(visit.reference, notifications)
     manageUsersApiMockServer.stubGetMultipleUserDetails(userIds, userDetails = userNamesMap)
@@ -1073,7 +1084,11 @@ class GetVisitBookingDetailsTest : IntegrationTestBase() {
     val expectedRestrictions = listOf(restriction2, restriction1, restriction4, restriction6, restriction5, restriction3)
     alertApiMockServer.stubGetPrisonerAlertsMono(prisonerId, listOf(alert1, alert2, alert3))
     prisonApiMockServer.stubGetPrisonerRestrictions(prisonerId, OffenderRestrictionsDto(1, listOf(restriction1, restriction2, restriction3, restriction4, restriction5, restriction6)))
-    prisonerContactRegistryMockServer.stubGetPrisonerContacts(prisonerId, contactsList = contactsList)
+    prisonerContactRegistryMockServer.stubSearchPrisonerContacts(
+      prisonerId = prisonerId,
+      contactIds = contactsList.map { it.contactId },
+      contactsList = contactsList,
+    )
     visitSchedulerMockServer.stubGetVisitHistory(visit.reference, eventList)
     visitSchedulerMockServer.stubGetVisitNotificationEvents(visit.reference, notifications)
     manageUsersApiMockServer.stubGetMultipleUserDetails(userIds, userDetails = userNamesMap)
@@ -1097,7 +1112,7 @@ class GetVisitBookingDetailsTest : IntegrationTestBase() {
     prisonerDto: PrisonerDto,
     relevantPrisonerAlerts: List<AlertResponseDto>,
     prisonerRestrictions: OffenderRestrictionsDto,
-    visitors: List<PrisonerContactDto>,
+    visitors: List<ContactWithOptionalPrisonerRelationshipDto>,
     expectedVisitContact: VisitContactDto?,
     events: List<EventAuditDto>,
     expectedEventActionedByFullNames: List<String?>,
@@ -1189,7 +1204,7 @@ class GetVisitBookingDetailsTest : IntegrationTestBase() {
 
   private fun assertVisitors(
     visitBookingDetailsDto: VisitBookingDetailsDto,
-    contacts: List<PrisonerContactDto>,
+    contacts: List<ContactWithOptionalPrisonerRelationshipDto>,
   ) {
     for (i in visitBookingDetailsDto.visitors.indices) {
       val primaryAddress = contacts[i].address
@@ -1199,13 +1214,13 @@ class GetVisitBookingDetailsTest : IntegrationTestBase() {
 
   private fun assertVisitor(
     visitorDetailsDto: VisitorDetailsDto,
-    contactDto: PrisonerContactDto,
+    contactDto: ContactWithOptionalPrisonerRelationshipDto,
     primaryAddressDto: AddressDto?,
   ) {
     assertThat(visitorDetailsDto.lastName).isEqualTo(contactDto.lastName)
     assertThat(visitorDetailsDto.dateOfBirth).isEqualTo(contactDto.dateOfBirth)
     assertThat(visitorDetailsDto.firstName).isEqualTo(contactDto.firstName)
-    assertThat(visitorDetailsDto.personId).isEqualTo(contactDto.personId)
+    assertThat(visitorDetailsDto.personId).isEqualTo(contactDto.contactId)
     assertThat(visitorDetailsDto.primaryAddress).isEqualTo(primaryAddressDto)
     assertThat(visitorDetailsDto.relationshipDescription).isEqualTo(contactDto.relationshipDescription)
     assertThat(visitorDetailsDto.restrictions).isEqualTo(contactDto.restrictions)


### PR DESCRIPTION
## What does this PR do?

Instead of using a full look-up of the prisoners social contacts and filtering to only keep the ones we want, this new endpoint does a direct search for the contacts given a list of contactIds.