### PR TITLE
VB-5817 - Use direct contact search over generic prisoner social contacts look-up

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/dto/booker/registry/VisitorInfoDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/dto/booker/registry/VisitorInfoDto.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.booker.registry
 
 import io.swagger.v3.oas.annotations.media.Schema
+import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.contact.registry.ContactWithOptionalPrisonerRelationshipDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.contact.registry.PrisonerContactDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.contact.registry.VisitorRestrictionDto
 import java.time.LocalDate
@@ -26,6 +27,15 @@ data class VisitorInfoDto(
     lastName = contact.lastName,
     dateOfBirth = contact.dateOfBirth,
     approved = contact.approvedVisitor,
+    visitorRestrictions = visitorRestrictions,
+  )
+
+  constructor(contact: ContactWithOptionalPrisonerRelationshipDto, visitorRestrictions: Set<VisitorRestrictionDto>) : this(
+    visitorId = contact.contactId,
+    firstName = contact.firstName,
+    lastName = contact.lastName,
+    dateOfBirth = contact.dateOfBirth,
+    approved = contact.approvedVisitor!!, // Force assignment because we only map contacts with a relationship so this cannot be null
     visitorRestrictions = visitorRestrictions,
   )
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/dto/contact/registry/ContactWithOptionalPrisonerRelationshipDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/dto/contact/registry/ContactWithOptionalPrisonerRelationshipDto.kt
@@ -37,4 +37,16 @@ data class ContactWithOptionalPrisonerRelationshipDto(
 
   @param:Schema(description = "Address associated with the contact", required = false)
   var address: AddressDto? = null,
+
+  @param:Schema(description = "Is this prisoner's contact relationship approved?", example = "true")
+  val approvedVisitor: Boolean? = null,
+
+  @param:Schema(description = "Is this prisoner's contact relationship the emergency contact?", example = "true")
+  val emergencyContact: Boolean? = null,
+
+  @param:Schema(description = "Is this prisoner's contact relationship the next of kin?", example = "true")
+  val nextOfKin: Boolean? = null,
+
+  @param:Schema(description = "comments of the relationship", nullable = true)
+  val comments: String?,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/service/PrisonerContactService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/service/PrisonerContactService.kt
@@ -4,6 +4,7 @@ import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.client.PrisonerContactRegistryClient
+import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.contact.registry.ContactWithOptionalPrisonerRelationshipDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.contact.registry.PrisonerContactDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.exception.NotFoundException
 
@@ -33,6 +34,11 @@ class PrisonerContactService(
     }
 
     return prisonersContactMap.toMap()
+  }
+
+  fun searchPrisonerContacts(prisonerId: String, contactIds: List<Long>, withRestrictions: Boolean = true): List<ContactWithOptionalPrisonerRelationshipDto> {
+    LOG.debug("Searching for contacts for prisoner - {}, contactIds - {}, withRestrictions - {}", prisonerId, contactIds, withRestrictions)
+    return prisonerContactRegistryClient.searchPrisonerContacts(prisonerId, contactIds, withRestrictions)
   }
 
   fun getPrisonerSocialContacts(prisonerId: String): List<PrisonerContactDto> = prisonerContactRegistryClient.getPrisonersSocialContacts(prisonerId = prisonerId)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/service/PublicBookerService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/service/PublicBookerService.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.servic
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
+import org.springframework.web.reactive.function.client.WebClientResponseException
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.client.BookerAuditHistoryClient
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.client.BookerPrisonerInfoClient
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.client.PrisonVisitBookerRegistryClient
@@ -22,7 +23,7 @@ import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.boo
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.booker.registry.admin.BookerSearchResultsDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.booker.registry.admin.SearchBookerDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.booker.registry.enums.BookerPrisonerValidationErrorCodes.REGISTERED_PRISON_NOT_SUPPORTED
-import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.contact.registry.PrisonerContactDto
+import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.contact.registry.ContactWithOptionalPrisonerRelationshipDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.contact.registry.RestrictionDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.contact.registry.VisitorRestrictionDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.contact.registry.VisitorRestrictionType
@@ -172,33 +173,43 @@ class PublicBookerService(
   private fun isPrisonSupportedOnVisits(prisonId: String): Boolean = visitSchedulerClient.getSupportedPrisons(PUBLIC).map { it.uppercase() }.contains(prisonId.uppercase())
 
   private fun getValidVisitors(bookerReference: String, prisonerNumber: String): List<VisitorInfoDto> {
-    val visitorDetailsList = mutableListOf<VisitorInfoDto>()
-    val associatedVisitors = prisonVisitBookerRegistryClient.getPermittedVisitorsForBookersAssociatedPrisoner(bookerReference, prisonerNumber)
+    val associatedVisitors =
+      prisonVisitBookerRegistryClient.getPermittedVisitorsForBookersAssociatedPrisoner(bookerReference, prisonerNumber)
 
-    if (associatedVisitors.isNotEmpty()) {
-      // get approved visitors for a prisoner with a DOB and not BANNED
-      var allValidContacts = emptyList<PrisonerContactDto>()
-      try {
-        allValidContacts = getAllValidContacts(prisonerNumber)
-      } catch (nfe: NotFoundException) {
-        logger.error("No valid contacts found for prisoner id - $prisonerNumber")
-      }
-
-      // filter them through the associated visitor list
-      if (allValidContacts.isNotEmpty()) {
-        associatedVisitors.forEach { associatedVisitor ->
-          allValidContacts.firstOrNull { it.personId == associatedVisitor.visitorId }?.let { contact ->
-            val visitorRestrictions = getRestrictions(contact.restrictions)
-            visitorDetailsList.add(VisitorInfoDto(contact, visitorRestrictions))
-          }
-        }
-      }
+    if (associatedVisitors.isEmpty()) {
+      logger.error("Booker has no visitors for prisoner id - {}", prisonerNumber)
+      return emptyList()
     }
 
-    return visitorDetailsList.toList()
-  }
+    val foundContacts: List<ContactWithOptionalPrisonerRelationshipDto> =
+      try {
+        prisonerContactService.searchPrisonerContacts(
+          prisonerNumber,
+          associatedVisitors.map { it.visitorId },
+          true,
+        )
+      } catch (e: WebClientResponseException.NotFound) {
+        logger.error("No valid contacts found for prisoner id - {}", prisonerNumber, e)
+        emptyList()
+      }
 
-  private fun getAllValidContacts(prisonerNumber: String): List<PrisonerContactDto> = prisonerContactService.getPrisonersSocialContactsWithDOB(prisonerNumber)
+    if (foundContacts.isEmpty()) {
+      return emptyList()
+    }
+
+    val associatedVisitorIds = associatedVisitors.map { it.visitorId }.toSet()
+
+    return foundContacts
+      .filter { contact ->
+        contact.contactType == "S" &&
+          contact.dateOfBirth != null &&
+          contact.contactId in associatedVisitorIds
+      }
+      .map { contact ->
+        val visitorRestrictions = getRestrictions(contact.restrictions)
+        VisitorInfoDto(contact, visitorRestrictions)
+      }
+  }
 
   private fun getMaxExpiryDate(restrictions: List<RestrictionDto>): LocalDate? {
     val expiryDates = restrictions.map { it.expiryDate }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/IntegrationTestBase.kt
@@ -661,6 +661,10 @@ abstract class IntegrationTestBase {
     contactTypeDescription: String? = "Social",
     restrictions: List<RestrictionDto> = emptyList(),
     address: AddressDto? = null,
+    approvedVisitor: Boolean? = true,
+    emergencyContact: Boolean? = false,
+    nextOfKin: Boolean? = false,
+    comments: String? = null,
   ): ContactWithOptionalPrisonerRelationshipDto = ContactWithOptionalPrisonerRelationshipDto(
     contactId = personId,
     firstName = firstName,
@@ -673,6 +677,10 @@ abstract class IntegrationTestBase {
     contactTypeDescription = contactTypeDescription,
     restrictions = restrictions,
     address = address,
+    approvedVisitor = approvedVisitor,
+    emergencyContact = emergencyContact,
+    nextOfKin = nextOfKin,
+    comments = comments,
   )
 
   final fun createPrisoner(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/booker/GetPermittedVisitorsForPermittedPrisonerForBookerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/booker/GetPermittedVisitorsForPermittedPrisonerForBookerTest.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.integr
 import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.springframework.http.HttpHeaders
@@ -14,6 +15,7 @@ import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.control
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.booker.registry.PermittedPrisonerForBookerDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.booker.registry.PermittedVisitorsForPermittedPrisonerBookerDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.booker.registry.VisitorInfoDto
+import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.contact.registry.ContactWithOptionalPrisonerRelationshipDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.contact.registry.RestrictionDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.contact.registry.VisitorRestrictionDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.contact.registry.VisitorRestrictionType
@@ -43,18 +45,21 @@ class GetPermittedVisitorsForPermittedPrisonerForBookerTest : IntegrationTestBas
     lastName = "VisitorA",
     dateOfBirth = LocalDate.now().minusYears(19),
   )
+  private val adultContact = createContactForVisitor(adultVisitor)
 
   private val childVisitor = createVisitor(
     firstName = "Second",
     lastName = "VisitorB",
     dateOfBirth = LocalDate.now().minusYears(4),
   )
+  private val childContact = createContactForVisitor(childVisitor)
 
   private val noDOBVisitor = createVisitor(
     firstName = "Third",
     lastName = "VisitorC",
     dateOfBirth = null,
   )
+  private val noDOBContact = createContactForVisitor(noDOBVisitor)
 
   private val unapprovedVisitor = createVisitor(
     firstName = "Fourth",
@@ -62,6 +67,7 @@ class GetPermittedVisitorsForPermittedPrisonerForBookerTest : IntegrationTestBas
     dateOfBirth = LocalDate.of(1990, 4, 1),
     approved = false,
   )
+  private val unapprovedContact = createContactForVisitor(unapprovedVisitor)
 
   private val indefinitelyBannedVisitor = createVisitor(
     firstName = "Fifth",
@@ -69,6 +75,7 @@ class GetPermittedVisitorsForPermittedPrisonerForBookerTest : IntegrationTestBas
     dateOfBirth = LocalDate.of(1990, 4, 1),
     restrictions = listOf(INDEFINITELY_BANNED_RESTRICTION, OTHER_RESTRICTION),
   )
+  private val indefinitelyBannedContact = createContactForVisitor(indefinitelyBannedVisitor)
 
   private val bannedVisitorForNext6Weeks = createVisitor(
     firstName = "Sixth",
@@ -76,6 +83,7 @@ class GetPermittedVisitorsForPermittedPrisonerForBookerTest : IntegrationTestBas
     dateOfBirth = LocalDate.of(1990, 4, 1),
     restrictions = listOf(EXPIRING_IN_6_WEEKS_BANNED_RESTRICTION, OTHER_RESTRICTION),
   )
+  private val bannedVisitorForNext6WeeksContact = createContactForVisitor(bannedVisitorForNext6Weeks)
 
   private val bannedVisitorForNext3Weeks = createVisitor(
     firstName = "Seventh",
@@ -83,6 +91,7 @@ class GetPermittedVisitorsForPermittedPrisonerForBookerTest : IntegrationTestBas
     dateOfBirth = LocalDate.of(1990, 4, 1),
     restrictions = listOf(EXPIRING_IN_3_WEEKS_BANNED_RESTRICTION, OTHER_RESTRICTION),
   )
+  private val bannedVisitorForNext3WeeksContact = createContactForVisitor(bannedVisitorForNext3Weeks)
 
   private val multipleBansVisitor = createVisitor(
     firstName = "Seventh",
@@ -90,6 +99,7 @@ class GetPermittedVisitorsForPermittedPrisonerForBookerTest : IntegrationTestBas
     dateOfBirth = LocalDate.of(1990, 4, 1),
     restrictions = listOf(EXPIRING_IN_3_WEEKS_BANNED_RESTRICTION, EXPIRING_IN_6_WEEKS_BANNED_RESTRICTION, OTHER_RESTRICTION),
   )
+  private val multipleBansContact = createContactForVisitor(multipleBansVisitor)
 
   private val expiredBanVisitor = createVisitor(
     firstName = "Seventh",
@@ -97,6 +107,7 @@ class GetPermittedVisitorsForPermittedPrisonerForBookerTest : IntegrationTestBas
     dateOfBirth = LocalDate.of(1990, 4, 1),
     restrictions = listOf(EXPIRED_BANNED_RESTRICTION, OTHER_RESTRICTION),
   )
+  private val expiredBanContact = createContactForVisitor(expiredBanVisitor)
 
   private val contactsList = createContactsList(
     listOf(
@@ -115,7 +126,7 @@ class GetPermittedVisitorsForPermittedPrisonerForBookerTest : IntegrationTestBas
   @Test
   fun `when booker's prisoners has valid visitors then all allowed visitors are returned`() {
     // Given
-    prisonerContactRegistryMockServer.stubGetPrisonerContacts(PRISONER_ID, hasDateOfBirth = true, contactsList = contactsList)
+    prisonerContactRegistryMockServer.stubSearchPrisonerContacts(PRISONER_ID, listOf(adultVisitor.personId, childVisitor.personId), true, listOf(adultContact, childContact))
     prisonVisitBookerRegistryMockServer.stubGetBookersPrisoners(BOOKER_REFERENCE, listOf(bookerRegistryPrisonerDto))
     prisonVisitBookerRegistryMockServer.stubGetBookersPrisonerVisitors(
       BOOKER_REFERENCE,
@@ -141,13 +152,18 @@ class GetPermittedVisitorsForPermittedPrisonerForBookerTest : IntegrationTestBas
 
     verify(prisonVisitBookerRegistryClientSpy, times(1)).getPermittedPrisonersForBooker(BOOKER_REFERENCE)
     verify(prisonVisitBookerRegistryClientSpy, times(1)).getPermittedVisitorsForBookersAssociatedPrisoner(BOOKER_REFERENCE, PRISONER_ID)
-    verify(prisonerContactRegistryClientSpy, times(1)).getPrisonersSocialContacts(PRISONER_ID, hasDateOfBirth = true)
+    verify(prisonerContactRegistryClientSpy, times(1)).searchPrisonerContacts(PRISONER_ID, listOf(adultVisitor.personId, childVisitor.personId), true)
   }
 
   @Test
   fun `when booker's prisoners has banned and unbanned visitors then visitors are returned with restriction list populated`() {
     // Given
-    prisonerContactRegistryMockServer.stubGetPrisonerContacts(PRISONER_ID, hasDateOfBirth = true, contactsList = contactsList)
+    prisonerContactRegistryMockServer.stubSearchPrisonerContacts(
+      PRISONER_ID,
+      listOf(adultVisitor.personId, childVisitor.personId, indefinitelyBannedVisitor.personId, bannedVisitorForNext3Weeks.personId, bannedVisitorForNext6Weeks.personId, multipleBansVisitor.personId, expiredBanVisitor.personId),
+      true,
+      listOf(adultContact, childContact, indefinitelyBannedContact, bannedVisitorForNext3WeeksContact, bannedVisitorForNext6WeeksContact, multipleBansContact, expiredBanContact),
+    )
     prisonVisitBookerRegistryMockServer.stubGetBookersPrisoners(BOOKER_REFERENCE, listOf(bookerRegistryPrisonerDto))
     prisonVisitBookerRegistryMockServer.stubGetBookersPrisonerVisitors(
       BOOKER_REFERENCE,
@@ -194,13 +210,18 @@ class GetPermittedVisitorsForPermittedPrisonerForBookerTest : IntegrationTestBas
 
     verify(prisonVisitBookerRegistryClientSpy, times(1)).getPermittedPrisonersForBooker(BOOKER_REFERENCE)
     verify(prisonVisitBookerRegistryClientSpy, times(1)).getPermittedVisitorsForBookersAssociatedPrisoner(BOOKER_REFERENCE, PRISONER_ID)
-    verify(prisonerContactRegistryClientSpy, times(1)).getPrisonersSocialContacts(PRISONER_ID, hasDateOfBirth = true)
+    verify(prisonerContactRegistryClientSpy, times(1)).searchPrisonerContacts(PRISONER_ID, listOf(adultVisitor.personId, childVisitor.personId, indefinitelyBannedVisitor.personId, bannedVisitorForNext3Weeks.personId, bannedVisitorForNext6Weeks.personId, multipleBansVisitor.personId, expiredBanVisitor.personId), true)
   }
 
   @Test
   fun `when booker's prisoner has unapproved visitors then they are included in the returned visitor list`() {
     // Given
-    prisonerContactRegistryMockServer.stubGetPrisonerContacts(PRISONER_ID, hasDateOfBirth = true, contactsList = contactsList)
+    prisonerContactRegistryMockServer.stubSearchPrisonerContacts(
+      PRISONER_ID,
+      listOf(adultVisitor.personId, childVisitor.personId, unapprovedVisitor.personId),
+      true,
+      listOf(adultContact, childContact, unapprovedContact),
+    )
     prisonVisitBookerRegistryMockServer.stubGetBookersPrisoners(BOOKER_REFERENCE, listOf(bookerRegistryPrisonerDto))
     prisonVisitBookerRegistryMockServer.stubGetBookersPrisonerVisitors(
       BOOKER_REFERENCE,
@@ -240,7 +261,7 @@ class GetPermittedVisitorsForPermittedPrisonerForBookerTest : IntegrationTestBas
 
     verify(prisonVisitBookerRegistryClientSpy, times(1)).getPermittedPrisonersForBooker(BOOKER_REFERENCE)
     verify(prisonVisitBookerRegistryClientSpy, times(1)).getPermittedVisitorsForBookersAssociatedPrisoner(BOOKER_REFERENCE, PRISONER_ID)
-    verify(prisonerContactRegistryClientSpy, times(1)).getPrisonersSocialContacts(PRISONER_ID, hasDateOfBirth = true)
+    verify(prisonerContactRegistryClientSpy, times(1)).searchPrisonerContacts(PRISONER_ID, listOf(adultVisitor.personId, childVisitor.personId, unapprovedVisitor.personId), true)
   }
 
   @Test
@@ -252,10 +273,14 @@ class GetPermittedVisitorsForPermittedPrisonerForBookerTest : IntegrationTestBas
       dateOfBirth = LocalDate.of(1990, 4, 1),
       restrictions = listOf(INDEFINITELY_BANNED_RESTRICTION, EXPIRING_IN_3_WEEKS_BANNED_RESTRICTION),
     )
+    val contactWithIndefiniteBan = createContactForVisitor(visitorWithIndefiniteBan)
 
-    val contacts = createContactsList(listOf(visitorWithIndefiniteBan))
-
-    prisonerContactRegistryMockServer.stubGetPrisonerContacts(PRISONER_ID, hasDateOfBirth = true, contactsList = contacts)
+    prisonerContactRegistryMockServer.stubSearchPrisonerContacts(
+      PRISONER_ID,
+      listOf(visitorWithIndefiniteBan.personId),
+      true,
+      listOf(contactWithIndefiniteBan),
+    )
     prisonVisitBookerRegistryMockServer.stubGetBookersPrisoners(BOOKER_REFERENCE, listOf(bookerRegistryPrisonerDto))
     prisonVisitBookerRegistryMockServer.stubGetBookersPrisonerVisitors(
       BOOKER_REFERENCE,
@@ -278,7 +303,7 @@ class GetPermittedVisitorsForPermittedPrisonerForBookerTest : IntegrationTestBas
 
     verify(prisonVisitBookerRegistryClientSpy, times(1)).getPermittedPrisonersForBooker(BOOKER_REFERENCE)
     verify(prisonVisitBookerRegistryClientSpy, times(1)).getPermittedVisitorsForBookersAssociatedPrisoner(BOOKER_REFERENCE, PRISONER_ID)
-    verify(prisonerContactRegistryClientSpy, times(1)).getPrisonersSocialContacts(PRISONER_ID, hasDateOfBirth = true)
+    verify(prisonerContactRegistryClientSpy, times(1)).searchPrisonerContacts(PRISONER_ID, listOf(visitorWithIndefiniteBan.personId), true)
   }
 
   @Test
@@ -290,10 +315,14 @@ class GetPermittedVisitorsForPermittedPrisonerForBookerTest : IntegrationTestBas
       dateOfBirth = LocalDate.of(1990, 4, 1),
       restrictions = listOf(EXPIRING_IN_6_WEEKS_BANNED_RESTRICTION, EXPIRING_IN_3_WEEKS_BANNED_RESTRICTION),
     )
+    val contactWithBan = createContactForVisitor(visitorWithBan)
 
-    val contacts = createContactsList(listOf(visitorWithBan))
-
-    prisonerContactRegistryMockServer.stubGetPrisonerContacts(PRISONER_ID, hasDateOfBirth = true, contactsList = contacts)
+    prisonerContactRegistryMockServer.stubSearchPrisonerContacts(
+      PRISONER_ID,
+      listOf(visitorWithBan.personId),
+      true,
+      listOf(contactWithBan),
+    )
     prisonVisitBookerRegistryMockServer.stubGetBookersPrisoners(BOOKER_REFERENCE, listOf(bookerRegistryPrisonerDto))
     prisonVisitBookerRegistryMockServer.stubGetBookersPrisonerVisitors(
       BOOKER_REFERENCE,
@@ -316,7 +345,7 @@ class GetPermittedVisitorsForPermittedPrisonerForBookerTest : IntegrationTestBas
 
     verify(prisonVisitBookerRegistryClientSpy, times(1)).getPermittedPrisonersForBooker(BOOKER_REFERENCE)
     verify(prisonVisitBookerRegistryClientSpy, times(1)).getPermittedVisitorsForBookersAssociatedPrisoner(BOOKER_REFERENCE, PRISONER_ID)
-    verify(prisonerContactRegistryClientSpy, times(1)).getPrisonersSocialContacts(PRISONER_ID, hasDateOfBirth = true)
+    verify(prisonerContactRegistryClientSpy, times(1)).searchPrisonerContacts(PRISONER_ID, listOf(visitorWithBan.personId), true)
   }
 
   @Test
@@ -328,10 +357,14 @@ class GetPermittedVisitorsForPermittedPrisonerForBookerTest : IntegrationTestBas
       dateOfBirth = LocalDate.of(1990, 4, 1),
       restrictions = listOf(EXPIRING_IN_3_WEEKS_BANNED_RESTRICTION, CLOSED_RESTRICTION),
     )
+    val contactWithBan = createContactForVisitor(visitorWithBan)
 
-    val contacts = createContactsList(listOf(visitorWithBan))
-
-    prisonerContactRegistryMockServer.stubGetPrisonerContacts(PRISONER_ID, hasDateOfBirth = true, contactsList = contacts)
+    prisonerContactRegistryMockServer.stubSearchPrisonerContacts(
+      PRISONER_ID,
+      listOf(visitorWithBan.personId),
+      true,
+      listOf(contactWithBan),
+    )
     prisonVisitBookerRegistryMockServer.stubGetBookersPrisoners(BOOKER_REFERENCE, listOf(bookerRegistryPrisonerDto))
     prisonVisitBookerRegistryMockServer.stubGetBookersPrisonerVisitors(
       BOOKER_REFERENCE,
@@ -354,7 +387,7 @@ class GetPermittedVisitorsForPermittedPrisonerForBookerTest : IntegrationTestBas
 
     verify(prisonVisitBookerRegistryClientSpy, times(1)).getPermittedPrisonersForBooker(BOOKER_REFERENCE)
     verify(prisonVisitBookerRegistryClientSpy, times(1)).getPermittedVisitorsForBookersAssociatedPrisoner(BOOKER_REFERENCE, PRISONER_ID)
-    verify(prisonerContactRegistryClientSpy, times(1)).getPrisonersSocialContacts(PRISONER_ID, hasDateOfBirth = true)
+    verify(prisonerContactRegistryClientSpy, times(1)).searchPrisonerContacts(PRISONER_ID, listOf(visitorWithBan.personId), true)
   }
 
   @Test
@@ -366,28 +399,35 @@ class GetPermittedVisitorsForPermittedPrisonerForBookerTest : IntegrationTestBas
       dateOfBirth = LocalDate.of(1990, 4, 1),
       approved = false,
     )
+    val contact1 = createContactForVisitor(visitor1)
 
     val visitor2 = createVisitor(
       firstName = "B",
       lastName = "c",
       dateOfBirth = LocalDate.of(1990, 4, 1),
     )
+    val contact2 = createContactForVisitor(visitor2)
 
     val visitor3 = createVisitor(
       firstName = "a",
       lastName = "c",
       dateOfBirth = LocalDate.of(1990, 4, 1),
     )
+    val contact3 = createContactForVisitor(visitor3)
 
     val visitor4 = createVisitor(
       firstName = "A",
       lastName = "A",
       dateOfBirth = LocalDate.of(1990, 4, 1),
     )
+    val contact4 = createContactForVisitor(visitor4)
 
-    val contacts = createContactsList(listOf(visitor1, visitor2, visitor3, visitor4))
-
-    prisonerContactRegistryMockServer.stubGetPrisonerContacts(PRISONER_ID, hasDateOfBirth = true, contactsList = contacts)
+    prisonerContactRegistryMockServer.stubSearchPrisonerContacts(
+      PRISONER_ID,
+      listOf(visitor1.personId, visitor2.personId, visitor3.personId, visitor4.personId),
+      true,
+      listOf(contact1, contact2, contact3, contact4),
+    )
     prisonVisitBookerRegistryMockServer.stubGetBookersPrisoners(BOOKER_REFERENCE, listOf(bookerRegistryPrisonerDto))
     prisonVisitBookerRegistryMockServer.stubGetBookersPrisonerVisitors(
       BOOKER_REFERENCE,
@@ -417,7 +457,6 @@ class GetPermittedVisitorsForPermittedPrisonerForBookerTest : IntegrationTestBas
   @Test
   fun `when booker's prisoners has no valid visitors then no visitors are returned`() {
     // Given
-    prisonerContactRegistryMockServer.stubGetPrisonerContacts(PRISONER_ID, hasDateOfBirth = true, contactsList = contactsList)
     prisonVisitBookerRegistryMockServer.stubGetBookersPrisoners(BOOKER_REFERENCE, listOf(bookerRegistryPrisonerDto))
     prisonVisitBookerRegistryMockServer.stubGetBookersPrisonerVisitors(
       BOOKER_REFERENCE,
@@ -436,7 +475,7 @@ class GetPermittedVisitorsForPermittedPrisonerForBookerTest : IntegrationTestBas
 
     verify(prisonVisitBookerRegistryClientSpy, times(1)).getPermittedPrisonersForBooker(BOOKER_REFERENCE)
     verify(prisonVisitBookerRegistryClientSpy, times(1)).getPermittedVisitorsForBookersAssociatedPrisoner(BOOKER_REFERENCE, PRISONER_ID)
-    verify(prisonerContactRegistryClientSpy, times(0)).getPrisonersSocialContacts(PRISONER_ID)
+    verify(prisonerContactRegistryClientSpy, times(0)).searchPrisonerContacts(any(), any(), any())
   }
 
   @Test
@@ -447,7 +486,6 @@ class GetPermittedVisitorsForPermittedPrisonerForBookerTest : IntegrationTestBas
       BOOKER_REFERENCE,
       null,
     )
-    prisonerContactRegistryMockServer.stubGetPrisonerContacts(PRISONER_ID, hasDateOfBirth = true, contactsList = contactsList)
 
     // When
     val responseSpec = callGetVisitorsByBookersPrisoner(webTestClient, roleVSIPOrchestrationServiceHttpHeaders, BOOKER_REFERENCE, PRISONER_ID)
@@ -458,7 +496,7 @@ class GetPermittedVisitorsForPermittedPrisonerForBookerTest : IntegrationTestBas
 
     verify(prisonVisitBookerRegistryClientSpy, times(1)).getPermittedPrisonersForBooker(BOOKER_REFERENCE)
     verify(prisonVisitBookerRegistryClientSpy, times(0)).getPermittedVisitorsForBookersAssociatedPrisoner(BOOKER_REFERENCE, PRISONER_ID)
-    verify(prisonerContactRegistryClientSpy, times(0)).getPrisonersSocialContacts(PRISONER_ID)
+    verify(prisonerContactRegistryClientSpy, times(0)).searchPrisonerContacts(any(), any(), any())
   }
 
   @Test
@@ -473,8 +511,6 @@ class GetPermittedVisitorsForPermittedPrisonerForBookerTest : IntegrationTestBas
       HttpStatus.NOT_FOUND,
     )
 
-    prisonerContactRegistryMockServer.stubGetPrisonerContacts(PRISONER_ID, hasDateOfBirth = true, contactsList = contactsList)
-
     // When
     val responseSpec = callGetVisitorsByBookersPrisoner(webTestClient, roleVSIPOrchestrationServiceHttpHeaders, BOOKER_REFERENCE, PRISONER_ID)
 
@@ -484,7 +520,7 @@ class GetPermittedVisitorsForPermittedPrisonerForBookerTest : IntegrationTestBas
 
     verify(prisonVisitBookerRegistryClientSpy, times(1)).getPermittedPrisonersForBooker(BOOKER_REFERENCE)
     verify(prisonVisitBookerRegistryClientSpy, times(1)).getPermittedVisitorsForBookersAssociatedPrisoner(BOOKER_REFERENCE, PRISONER_ID)
-    verify(prisonerContactRegistryClientSpy, times(0)).getPrisonersSocialContacts(PRISONER_ID)
+    verify(prisonerContactRegistryClientSpy, times(0)).searchPrisonerContacts(any(), any(), any())
   }
 
   @Test
@@ -498,8 +534,6 @@ class GetPermittedVisitorsForPermittedPrisonerForBookerTest : IntegrationTestBas
       HttpStatus.INTERNAL_SERVER_ERROR,
     )
 
-    prisonerContactRegistryMockServer.stubGetPrisonerContacts(PRISONER_ID, hasDateOfBirth = true, contactsList = contactsList)
-
     // When
     val responseSpec = callGetVisitorsByBookersPrisoner(webTestClient, roleVSIPOrchestrationServiceHttpHeaders, BOOKER_REFERENCE, PRISONER_ID)
 
@@ -508,7 +542,7 @@ class GetPermittedVisitorsForPermittedPrisonerForBookerTest : IntegrationTestBas
 
     verify(prisonVisitBookerRegistryClientSpy, times(1)).getPermittedPrisonersForBooker(BOOKER_REFERENCE)
     verify(prisonVisitBookerRegistryClientSpy, times(1)).getPermittedVisitorsForBookersAssociatedPrisoner(BOOKER_REFERENCE, PRISONER_ID)
-    verify(prisonerContactRegistryClientSpy, times(0)).getPrisonersSocialContacts(PRISONER_ID)
+    verify(prisonerContactRegistryClientSpy, times(0)).searchPrisonerContacts(any(), any(), any())
   }
 
   @Test
@@ -526,7 +560,13 @@ class GetPermittedVisitorsForPermittedPrisonerForBookerTest : IntegrationTestBas
     )
 
     // prisoner contact registry returns 404
-    prisonerContactRegistryMockServer.stubGetPrisonerContacts(PRISONER_ID, hasDateOfBirth = true, contactsList = null, httpStatus = HttpStatus.NOT_FOUND)
+    prisonerContactRegistryMockServer.stubSearchPrisonerContacts(
+      PRISONER_ID,
+      listOf(adultVisitor.personId, childVisitor.personId),
+      true,
+      null,
+      HttpStatus.NOT_FOUND,
+    )
 
     // When
     val responseSpec = callGetVisitorsByBookersPrisoner(webTestClient, roleVSIPOrchestrationServiceHttpHeaders, BOOKER_REFERENCE, PRISONER_ID)
@@ -539,7 +579,7 @@ class GetPermittedVisitorsForPermittedPrisonerForBookerTest : IntegrationTestBas
 
     verify(prisonVisitBookerRegistryClientSpy, times(1)).getPermittedPrisonersForBooker(BOOKER_REFERENCE)
     verify(prisonVisitBookerRegistryClientSpy, times(1)).getPermittedVisitorsForBookersAssociatedPrisoner(BOOKER_REFERENCE, PRISONER_ID)
-    verify(prisonerContactRegistryClientSpy, times(1)).getPrisonersSocialContacts(PRISONER_ID, hasDateOfBirth = true)
+    verify(prisonerContactRegistryClientSpy, times(1)).searchPrisonerContacts(PRISONER_ID, listOf(adultVisitor.personId, childVisitor.personId), true)
   }
 
   @Test
@@ -557,7 +597,13 @@ class GetPermittedVisitorsForPermittedPrisonerForBookerTest : IntegrationTestBas
     )
 
     // prisoner contact registry returns INTERNAL_SERVER_ERROR
-    prisonerContactRegistryMockServer.stubGetPrisonerContacts(PRISONER_ID, hasDateOfBirth = true, contactsList = null, httpStatus = HttpStatus.INTERNAL_SERVER_ERROR)
+    prisonerContactRegistryMockServer.stubSearchPrisonerContacts(
+      PRISONER_ID,
+      listOf(adultVisitor.personId, childVisitor.personId),
+      true,
+      null,
+      HttpStatus.INTERNAL_SERVER_ERROR,
+    )
 
     // When
     val responseSpec = callGetVisitorsByBookersPrisoner(webTestClient, roleVSIPOrchestrationServiceHttpHeaders, BOOKER_REFERENCE, PRISONER_ID)
@@ -567,7 +613,7 @@ class GetPermittedVisitorsForPermittedPrisonerForBookerTest : IntegrationTestBas
 
     verify(prisonVisitBookerRegistryClientSpy, times(1)).getPermittedPrisonersForBooker(BOOKER_REFERENCE)
     verify(prisonVisitBookerRegistryClientSpy, times(1)).getPermittedVisitorsForBookersAssociatedPrisoner(BOOKER_REFERENCE, PRISONER_ID)
-    verify(prisonerContactRegistryClientSpy, times(1)).getPrisonersSocialContacts(PRISONER_ID, hasDateOfBirth = true)
+    verify(prisonerContactRegistryClientSpy, times(1)).searchPrisonerContacts(PRISONER_ID, listOf(adultVisitor.personId, childVisitor.personId), true)
   }
 
   @Test
@@ -597,7 +643,7 @@ class GetPermittedVisitorsForPermittedPrisonerForBookerTest : IntegrationTestBas
     // And
     verify(prisonVisitBookerRegistryClientSpy, times(0)).getPermittedPrisonersForBooker(BOOKER_REFERENCE)
     verify(prisonVisitBookerRegistryClientSpy, times(0)).getPermittedVisitorsForBookersAssociatedPrisoner(BOOKER_REFERENCE, PRISONER_ID)
-    verify(prisonerContactRegistryClientSpy, times(0)).getPrisonersSocialContacts(PRISONER_ID, hasDateOfBirth = true)
+    verify(prisonerContactRegistryClientSpy, times(0)).searchPrisonerContacts(any(), any(), any())
   }
 
   private fun assertVisitorContactBasicDetails(visitorBasicInfo: VisitorInfoDto, visitorDetails: VisitorDetails) {
@@ -625,6 +671,15 @@ class GetPermittedVisitorsForPermittedPrisonerForBookerTest : IntegrationTestBas
       Assertions.assertThat(errorResponse.developerMessage).isEqualTo(errorMessage)
     }
   }
+
+  private fun createContactForVisitor(visitor: VisitorDetails): ContactWithOptionalPrisonerRelationshipDto = createContactWithOptionalPrisonerRelationshipDto(
+    personId = visitor.personId,
+    firstName = visitor.firstName,
+    lastName = visitor.lastName,
+    dateOfBirth = visitor.dateOfBirth,
+    approvedVisitor = visitor.approved,
+    restrictions = visitor.restrictions,
+  )
 
   private fun getResults(returnResult: WebTestClient.BodyContentSpec): List<VisitorInfoDto> = TestObjectMapper.mapper.readValue(returnResult.returnResult().responseBody, Array<VisitorInfoDto>::class.java).toList()
 


### PR DESCRIPTION
## What does this PR do?

Sometimes the relationship is deleted and it stops the contact from being included in the returned prisoners social contact list. Now we use the direct look-up this cannot happen.