### PR TITLE
Swap to new contact endpoint as original is deprecated

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/client/PrisonerContactRegistryClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/client/PrisonerContactRegistryClient.kt
@@ -140,7 +140,7 @@ class PrisonerContactRegistryClient(
 
   fun searchContacts(contactIds: List<Long>, prisonerId: String? = null, withRestrictions: Boolean = true): List<ContactWithOptionalPrisonerRelationshipDto> = searchContactsAsMono(contactIds, prisonerId, withRestrictions)
     .onErrorResume { e ->
-      LOG.error("searchPrisonerContacts error for get request $CONTACT_REGISTRY_SEARCH_CONTACTS_PATH, $e")
+      LOG.error("searchContacts error for get request $CONTACT_REGISTRY_SEARCH_CONTACTS_PATH, $e")
       Mono.error(e)
     }
     .blockOptional(apiTimeout).orElseThrow { IllegalStateException("Timeout searching contacts for request $CONTACT_REGISTRY_SEARCH_CONTACTS_PATH") }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/client/PrisonerContactRegistryClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/client/PrisonerContactRegistryClient.kt
@@ -31,14 +31,15 @@ class PrisonerContactRegistryClient(
 ) {
   companion object {
     val LOG: Logger = LoggerFactory.getLogger(this::class.java)
-    const val CONTACT_REGISTRY_CONTACTS_PATH: String = "/v2/prisoners/{prisonerId}/contacts"
-    const val CONTACT_REGISTRY_SEARCH_CONTACTS_PATH: String = "$CONTACT_REGISTRY_CONTACTS_PATH/search"
-    const val CONTACT_REGISTRY_APPROVED_SOCIAL_CONTACTS_PATH: String = "$CONTACT_REGISTRY_CONTACTS_PATH/social/approved"
-    const val CONTACT_REGISTRY_SOCIAL_CONTACTS_PATH: String = "$CONTACT_REGISTRY_CONTACTS_PATH/social"
+    const val CONTACT_REGISTRY_PRISONER_CONTACTS_PATH: String = "/v2/prisoners/{prisonerId}/contacts"
+    const val CONTACT_REGISTRY_APPROVED_SOCIAL_CONTACTS_PATH: String = "$CONTACT_REGISTRY_PRISONER_CONTACTS_PATH/social/approved"
+    const val CONTACT_REGISTRY_SOCIAL_CONTACTS_PATH: String = "$CONTACT_REGISTRY_PRISONER_CONTACTS_PATH/social"
     const val CONTACT_REGISTRY_APPROVED_SOCIAL_CONTACTS_RESTRICTIONS_PATH: String = "$CONTACT_REGISTRY_APPROVED_SOCIAL_CONTACTS_PATH/restrictions"
     const val CONTACT_REGISTRY_BANNED_RESTRICTION_DATE_RANGE_PATH: String = "$CONTACT_REGISTRY_APPROVED_SOCIAL_CONTACTS_RESTRICTIONS_PATH/banned/dateRange"
     const val CONTACT_REGISTRY_HAS_CLOSED_RESTRICTIONS_PATH: String = "$CONTACT_REGISTRY_APPROVED_SOCIAL_CONTACTS_RESTRICTIONS_PATH/closed"
     const val CONTACT_REGISTRY_REVIEW_RESTRICTIONS_DATE_RANGES_PATH: String = "$CONTACT_REGISTRY_APPROVED_SOCIAL_CONTACTS_RESTRICTIONS_PATH/visit-request/date-ranges"
+
+    const val CONTACT_REGISTRY_SEARCH_CONTACTS_PATH: String = "/v2/contacts/search"
   }
 
   fun getPrisonersSocialContacts(prisonerId: String, hasDateOfBirth: Boolean? = null): List<PrisonerContactDto> {
@@ -137,28 +138,25 @@ class PrisonerContactRegistryClient(
       }.block(apiTimeout)
   }
 
-  fun searchPrisonerContacts(prisonerId: String, contactIds: List<Long>, withRestrictions: Boolean = true): List<ContactWithOptionalPrisonerRelationshipDto> {
-    val uri = CONTACT_REGISTRY_SEARCH_CONTACTS_PATH.replace("{prisonerId}", prisonerId)
-    return searchPrisonerContactsAsMono(prisonerId, contactIds, withRestrictions)
-      .onErrorResume { e ->
-        LOG.error("searchPrisonerContacts error for get request $uri, $e")
-        Mono.error(e)
-      }
-      .blockOptional(apiTimeout).orElseThrow { IllegalStateException("Timeout searching contacts for request $uri") }
-  }
-
-  fun searchPrisonerContactsAsMono(prisonerId: String, contactIds: List<Long>, withRestrictions: Boolean = true): Mono<List<ContactWithOptionalPrisonerRelationshipDto>> {
-    val uri = CONTACT_REGISTRY_SEARCH_CONTACTS_PATH.replace("{prisonerId}", prisonerId)
-    return webClient.get().uri(uri) {
-      getSearchPrisonerContactsUriBuilder(contactIds, withRestrictions, it).build()
+  fun searchContacts(contactIds: List<Long>, prisonerId: String? = null, withRestrictions: Boolean = true): List<ContactWithOptionalPrisonerRelationshipDto> = searchContactsAsMono(contactIds, prisonerId, withRestrictions)
+    .onErrorResume { e ->
+      LOG.error("searchPrisonerContacts error for get request $CONTACT_REGISTRY_SEARCH_CONTACTS_PATH, $e")
+      Mono.error(e)
     }
-      .retrieve()
-      .bodyToMono<List<ContactWithOptionalPrisonerRelationshipDto>>()
-  }
+    .blockOptional(apiTimeout).orElseThrow { IllegalStateException("Timeout searching contacts for request $CONTACT_REGISTRY_SEARCH_CONTACTS_PATH") }
 
-  private fun getSearchPrisonerContactsUriBuilder(contactIds: List<Long>, withRestrictions: Boolean = true, uriBuilder: UriBuilder): UriBuilder {
+  fun searchContactsAsMono(contactIds: List<Long>, prisonerId: String? = null, withRestrictions: Boolean = true): Mono<List<ContactWithOptionalPrisonerRelationshipDto>> = webClient.get().uri(CONTACT_REGISTRY_SEARCH_CONTACTS_PATH) {
+    getSearchContactsUriBuilder(contactIds, prisonerId, withRestrictions, it).build()
+  }
+    .retrieve()
+    .bodyToMono<List<ContactWithOptionalPrisonerRelationshipDto>>()
+
+  private fun getSearchContactsUriBuilder(contactIds: List<Long>, prisonerId: String? = null, withRestrictions: Boolean = true, uriBuilder: UriBuilder): UriBuilder {
     uriBuilder.queryParam("contactIds", contactIds.joinToString(","))
     uriBuilder.queryParam("withRestrictions", withRestrictions)
+
+    prisonerId?.let { uriBuilder.queryParam("prisonerId", it) }
+
     return uriBuilder
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/client/PrisonerProfileClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/client/PrisonerProfileClient.kt
@@ -95,9 +95,9 @@ class PrisonerProfileClient(
         .map { it.nomisPersonId }
         .distinct()
 
-      val contacts = prisonerContactRegistryClient.searchPrisonerContacts(
-        prisonerId = prisonerProfile.prisonerId,
+      val contacts = prisonerContactRegistryClient.searchContacts(
         contactIds = contactIds,
+        prisonerId = prisonerProfile.prisonerId,
         withRestrictions = false,
       )
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/client/VisitBookingDetailsClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/client/VisitBookingDetailsClient.kt
@@ -81,9 +81,9 @@ class VisitBookingDetailsClient(
           prisonApiClient.getPrisonerRestrictionsAsMono(visit.prisonerId)
         }
 
-      val visitorsMono = prisonerContactRegistryClient.searchPrisonerContactsAsMono(
-        prisonerId = visit.prisonerId,
+      val visitorsMono = prisonerContactRegistryClient.searchContactsAsMono(
         contactIds = visit.visitors!!.map { it.nomisPersonId },
+        prisonerId = visit.prisonerId,
         withRestrictions = !skipAlertsAndRestrictions,
       )
 
@@ -114,7 +114,7 @@ class VisitBookingDetailsClient(
           }
 
           val visitContact = visit.visitContact?.let { contact ->
-            val contactId = visit.visitors?.firstOrNull { it.visitContact == true }?.nomisPersonId
+            val contactId = visit.visitors.firstOrNull { it.visitContact == true }?.nomisPersonId
             VisitContactDto(contact, contactId)
           }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/service/PrisonerContactService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/service/PrisonerContactService.kt
@@ -36,9 +36,15 @@ class PrisonerContactService(
     return prisonersContactMap.toMap()
   }
 
-  fun searchPrisonerContacts(prisonerId: String, contactIds: List<Long>, withRestrictions: Boolean = true): List<ContactWithOptionalPrisonerRelationshipDto> {
-    LOG.debug("Searching for contacts for prisoner - {}, contactIds - {}, withRestrictions - {}", prisonerId, contactIds, withRestrictions)
-    return prisonerContactRegistryClient.searchPrisonerContacts(prisonerId, contactIds, withRestrictions)
+  fun searchContacts(contactIds: List<Long>, prisonerId: String? = null, withRestrictions: Boolean = true): List<ContactWithOptionalPrisonerRelationshipDto> {
+    LOG.debug(
+      "searchContact called with contactIds: {}, prisonerId: {}, withRestrictions: {}",
+      contactIds,
+      prisonerId,
+      withRestrictions,
+    )
+
+    return prisonerContactRegistryClient.searchContacts(contactIds, prisonerId, withRestrictions)
   }
 
   fun getPrisonerSocialContacts(prisonerId: String): List<PrisonerContactDto> = prisonerContactRegistryClient.getPrisonersSocialContacts(prisonerId = prisonerId)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/service/PrisonerContactService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/service/PrisonerContactService.kt
@@ -38,7 +38,7 @@ class PrisonerContactService(
 
   fun searchContacts(contactIds: List<Long>, prisonerId: String? = null, withRestrictions: Boolean = true): List<ContactWithOptionalPrisonerRelationshipDto> {
     LOG.debug(
-      "searchContact called with contactIds: {}, prisonerId: {}, withRestrictions: {}",
+      "searchContacts called with contactIds: {}, prisonerId: {}, withRestrictions: {}",
       contactIds,
       prisonerId,
       withRestrictions,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/service/PublicBookerService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/service/PublicBookerService.kt
@@ -183,9 +183,9 @@ class PublicBookerService(
 
     val foundContacts: List<ContactWithOptionalPrisonerRelationshipDto> =
       try {
-        prisonerContactService.searchPrisonerContacts(
-          prisonerNumber,
+        prisonerContactService.searchContacts(
           associatedVisitors.map { it.visitorId },
+          prisonerNumber,
           true,
         )
       } catch (e: WebClientResponseException.NotFound) {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/booker/GetPermittedVisitorsForPermittedPrisonerForBookerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/booker/GetPermittedVisitorsForPermittedPrisonerForBookerTest.kt
@@ -54,13 +54,6 @@ class GetPermittedVisitorsForPermittedPrisonerForBookerTest : IntegrationTestBas
   )
   private val childContact = createContactForVisitor(childVisitor)
 
-  private val noDOBVisitor = createVisitor(
-    firstName = "Third",
-    lastName = "VisitorC",
-    dateOfBirth = null,
-  )
-  private val noDOBContact = createContactForVisitor(noDOBVisitor)
-
   private val unapprovedVisitor = createVisitor(
     firstName = "Fourth",
     lastName = "VisitorD",
@@ -109,24 +102,14 @@ class GetPermittedVisitorsForPermittedPrisonerForBookerTest : IntegrationTestBas
   )
   private val expiredBanContact = createContactForVisitor(expiredBanVisitor)
 
-  private val contactsList = createContactsList(
-    listOf(
-      adultVisitor,
-      childVisitor,
-      noDOBVisitor,
-      unapprovedVisitor,
-      indefinitelyBannedVisitor,
-      bannedVisitorForNext3Weeks,
-      bannedVisitorForNext6Weeks,
-      multipleBansVisitor,
-      expiredBanVisitor,
-    ),
-  )
-
   @Test
   fun `when booker's prisoners has valid visitors then all allowed visitors are returned`() {
     // Given
-    prisonerContactRegistryMockServer.stubSearchPrisonerContacts(PRISONER_ID, listOf(adultVisitor.personId, childVisitor.personId), true, listOf(adultContact, childContact))
+    prisonerContactRegistryMockServer.stubSearchContacts(
+      listOf(adultVisitor.personId, childVisitor.personId),
+      PRISONER_ID,
+      contactsList = listOf(adultContact, childContact),
+    )
     prisonVisitBookerRegistryMockServer.stubGetBookersPrisoners(BOOKER_REFERENCE, listOf(bookerRegistryPrisonerDto))
     prisonVisitBookerRegistryMockServer.stubGetBookersPrisonerVisitors(
       BOOKER_REFERENCE,
@@ -152,17 +135,16 @@ class GetPermittedVisitorsForPermittedPrisonerForBookerTest : IntegrationTestBas
 
     verify(prisonVisitBookerRegistryClientSpy, times(1)).getPermittedPrisonersForBooker(BOOKER_REFERENCE)
     verify(prisonVisitBookerRegistryClientSpy, times(1)).getPermittedVisitorsForBookersAssociatedPrisoner(BOOKER_REFERENCE, PRISONER_ID)
-    verify(prisonerContactRegistryClientSpy, times(1)).searchPrisonerContacts(PRISONER_ID, listOf(adultVisitor.personId, childVisitor.personId), true)
+    verify(prisonerContactRegistryClientSpy, times(1)).searchContacts(listOf(adultVisitor.personId, childVisitor.personId), PRISONER_ID, true)
   }
 
   @Test
   fun `when booker's prisoners has banned and unbanned visitors then visitors are returned with restriction list populated`() {
     // Given
-    prisonerContactRegistryMockServer.stubSearchPrisonerContacts(
-      PRISONER_ID,
+    prisonerContactRegistryMockServer.stubSearchContacts(
       listOf(adultVisitor.personId, childVisitor.personId, indefinitelyBannedVisitor.personId, bannedVisitorForNext3Weeks.personId, bannedVisitorForNext6Weeks.personId, multipleBansVisitor.personId, expiredBanVisitor.personId),
-      true,
-      listOf(adultContact, childContact, indefinitelyBannedContact, bannedVisitorForNext3WeeksContact, bannedVisitorForNext6WeeksContact, multipleBansContact, expiredBanContact),
+      PRISONER_ID,
+      contactsList = listOf(adultContact, childContact, indefinitelyBannedContact, bannedVisitorForNext3WeeksContact, bannedVisitorForNext6WeeksContact, multipleBansContact, expiredBanContact),
     )
     prisonVisitBookerRegistryMockServer.stubGetBookersPrisoners(BOOKER_REFERENCE, listOf(bookerRegistryPrisonerDto))
     prisonVisitBookerRegistryMockServer.stubGetBookersPrisonerVisitors(
@@ -210,17 +192,16 @@ class GetPermittedVisitorsForPermittedPrisonerForBookerTest : IntegrationTestBas
 
     verify(prisonVisitBookerRegistryClientSpy, times(1)).getPermittedPrisonersForBooker(BOOKER_REFERENCE)
     verify(prisonVisitBookerRegistryClientSpy, times(1)).getPermittedVisitorsForBookersAssociatedPrisoner(BOOKER_REFERENCE, PRISONER_ID)
-    verify(prisonerContactRegistryClientSpy, times(1)).searchPrisonerContacts(PRISONER_ID, listOf(adultVisitor.personId, childVisitor.personId, indefinitelyBannedVisitor.personId, bannedVisitorForNext3Weeks.personId, bannedVisitorForNext6Weeks.personId, multipleBansVisitor.personId, expiredBanVisitor.personId), true)
+    verify(prisonerContactRegistryClientSpy, times(1)).searchContacts(listOf(adultVisitor.personId, childVisitor.personId, indefinitelyBannedVisitor.personId, bannedVisitorForNext3Weeks.personId, bannedVisitorForNext6Weeks.personId, multipleBansVisitor.personId, expiredBanVisitor.personId), PRISONER_ID, true)
   }
 
   @Test
   fun `when booker's prisoner has unapproved visitors then they are included in the returned visitor list`() {
     // Given
-    prisonerContactRegistryMockServer.stubSearchPrisonerContacts(
-      PRISONER_ID,
+    prisonerContactRegistryMockServer.stubSearchContacts(
       listOf(adultVisitor.personId, childVisitor.personId, unapprovedVisitor.personId),
-      true,
-      listOf(adultContact, childContact, unapprovedContact),
+      PRISONER_ID,
+      contactsList = listOf(adultContact, childContact, unapprovedContact),
     )
     prisonVisitBookerRegistryMockServer.stubGetBookersPrisoners(BOOKER_REFERENCE, listOf(bookerRegistryPrisonerDto))
     prisonVisitBookerRegistryMockServer.stubGetBookersPrisonerVisitors(
@@ -261,7 +242,7 @@ class GetPermittedVisitorsForPermittedPrisonerForBookerTest : IntegrationTestBas
 
     verify(prisonVisitBookerRegistryClientSpy, times(1)).getPermittedPrisonersForBooker(BOOKER_REFERENCE)
     verify(prisonVisitBookerRegistryClientSpy, times(1)).getPermittedVisitorsForBookersAssociatedPrisoner(BOOKER_REFERENCE, PRISONER_ID)
-    verify(prisonerContactRegistryClientSpy, times(1)).searchPrisonerContacts(PRISONER_ID, listOf(adultVisitor.personId, childVisitor.personId, unapprovedVisitor.personId), true)
+    verify(prisonerContactRegistryClientSpy, times(1)).searchContacts(listOf(adultVisitor.personId, childVisitor.personId, unapprovedVisitor.personId), PRISONER_ID, true)
   }
 
   @Test
@@ -275,11 +256,10 @@ class GetPermittedVisitorsForPermittedPrisonerForBookerTest : IntegrationTestBas
     )
     val contactWithIndefiniteBan = createContactForVisitor(visitorWithIndefiniteBan)
 
-    prisonerContactRegistryMockServer.stubSearchPrisonerContacts(
-      PRISONER_ID,
+    prisonerContactRegistryMockServer.stubSearchContacts(
       listOf(visitorWithIndefiniteBan.personId),
-      true,
-      listOf(contactWithIndefiniteBan),
+      PRISONER_ID,
+      contactsList = listOf(contactWithIndefiniteBan),
     )
     prisonVisitBookerRegistryMockServer.stubGetBookersPrisoners(BOOKER_REFERENCE, listOf(bookerRegistryPrisonerDto))
     prisonVisitBookerRegistryMockServer.stubGetBookersPrisonerVisitors(
@@ -303,7 +283,7 @@ class GetPermittedVisitorsForPermittedPrisonerForBookerTest : IntegrationTestBas
 
     verify(prisonVisitBookerRegistryClientSpy, times(1)).getPermittedPrisonersForBooker(BOOKER_REFERENCE)
     verify(prisonVisitBookerRegistryClientSpy, times(1)).getPermittedVisitorsForBookersAssociatedPrisoner(BOOKER_REFERENCE, PRISONER_ID)
-    verify(prisonerContactRegistryClientSpy, times(1)).searchPrisonerContacts(PRISONER_ID, listOf(visitorWithIndefiniteBan.personId), true)
+    verify(prisonerContactRegistryClientSpy, times(1)).searchContacts(listOf(visitorWithIndefiniteBan.personId), PRISONER_ID, true)
   }
 
   @Test
@@ -317,11 +297,10 @@ class GetPermittedVisitorsForPermittedPrisonerForBookerTest : IntegrationTestBas
     )
     val contactWithBan = createContactForVisitor(visitorWithBan)
 
-    prisonerContactRegistryMockServer.stubSearchPrisonerContacts(
-      PRISONER_ID,
+    prisonerContactRegistryMockServer.stubSearchContacts(
       listOf(visitorWithBan.personId),
-      true,
-      listOf(contactWithBan),
+      PRISONER_ID,
+      contactsList = listOf(contactWithBan),
     )
     prisonVisitBookerRegistryMockServer.stubGetBookersPrisoners(BOOKER_REFERENCE, listOf(bookerRegistryPrisonerDto))
     prisonVisitBookerRegistryMockServer.stubGetBookersPrisonerVisitors(
@@ -345,7 +324,7 @@ class GetPermittedVisitorsForPermittedPrisonerForBookerTest : IntegrationTestBas
 
     verify(prisonVisitBookerRegistryClientSpy, times(1)).getPermittedPrisonersForBooker(BOOKER_REFERENCE)
     verify(prisonVisitBookerRegistryClientSpy, times(1)).getPermittedVisitorsForBookersAssociatedPrisoner(BOOKER_REFERENCE, PRISONER_ID)
-    verify(prisonerContactRegistryClientSpy, times(1)).searchPrisonerContacts(PRISONER_ID, listOf(visitorWithBan.personId), true)
+    verify(prisonerContactRegistryClientSpy, times(1)).searchContacts(listOf(visitorWithBan.personId), PRISONER_ID, true)
   }
 
   @Test
@@ -359,11 +338,10 @@ class GetPermittedVisitorsForPermittedPrisonerForBookerTest : IntegrationTestBas
     )
     val contactWithBan = createContactForVisitor(visitorWithBan)
 
-    prisonerContactRegistryMockServer.stubSearchPrisonerContacts(
-      PRISONER_ID,
+    prisonerContactRegistryMockServer.stubSearchContacts(
       listOf(visitorWithBan.personId),
-      true,
-      listOf(contactWithBan),
+      PRISONER_ID,
+      contactsList = listOf(contactWithBan),
     )
     prisonVisitBookerRegistryMockServer.stubGetBookersPrisoners(BOOKER_REFERENCE, listOf(bookerRegistryPrisonerDto))
     prisonVisitBookerRegistryMockServer.stubGetBookersPrisonerVisitors(
@@ -387,7 +365,7 @@ class GetPermittedVisitorsForPermittedPrisonerForBookerTest : IntegrationTestBas
 
     verify(prisonVisitBookerRegistryClientSpy, times(1)).getPermittedPrisonersForBooker(BOOKER_REFERENCE)
     verify(prisonVisitBookerRegistryClientSpy, times(1)).getPermittedVisitorsForBookersAssociatedPrisoner(BOOKER_REFERENCE, PRISONER_ID)
-    verify(prisonerContactRegistryClientSpy, times(1)).searchPrisonerContacts(PRISONER_ID, listOf(visitorWithBan.personId), true)
+    verify(prisonerContactRegistryClientSpy, times(1)).searchContacts(listOf(visitorWithBan.personId), PRISONER_ID, true)
   }
 
   @Test
@@ -422,11 +400,10 @@ class GetPermittedVisitorsForPermittedPrisonerForBookerTest : IntegrationTestBas
     )
     val contact4 = createContactForVisitor(visitor4)
 
-    prisonerContactRegistryMockServer.stubSearchPrisonerContacts(
-      PRISONER_ID,
+    prisonerContactRegistryMockServer.stubSearchContacts(
       listOf(visitor1.personId, visitor2.personId, visitor3.personId, visitor4.personId),
-      true,
-      listOf(contact1, contact2, contact3, contact4),
+      PRISONER_ID,
+      contactsList = listOf(contact1, contact2, contact3, contact4),
     )
     prisonVisitBookerRegistryMockServer.stubGetBookersPrisoners(BOOKER_REFERENCE, listOf(bookerRegistryPrisonerDto))
     prisonVisitBookerRegistryMockServer.stubGetBookersPrisonerVisitors(
@@ -475,7 +452,7 @@ class GetPermittedVisitorsForPermittedPrisonerForBookerTest : IntegrationTestBas
 
     verify(prisonVisitBookerRegistryClientSpy, times(1)).getPermittedPrisonersForBooker(BOOKER_REFERENCE)
     verify(prisonVisitBookerRegistryClientSpy, times(1)).getPermittedVisitorsForBookersAssociatedPrisoner(BOOKER_REFERENCE, PRISONER_ID)
-    verify(prisonerContactRegistryClientSpy, times(0)).searchPrisonerContacts(any(), any(), any())
+    verify(prisonerContactRegistryClientSpy, times(0)).searchContacts(any(), any(), any())
   }
 
   @Test
@@ -496,7 +473,7 @@ class GetPermittedVisitorsForPermittedPrisonerForBookerTest : IntegrationTestBas
 
     verify(prisonVisitBookerRegistryClientSpy, times(1)).getPermittedPrisonersForBooker(BOOKER_REFERENCE)
     verify(prisonVisitBookerRegistryClientSpy, times(0)).getPermittedVisitorsForBookersAssociatedPrisoner(BOOKER_REFERENCE, PRISONER_ID)
-    verify(prisonerContactRegistryClientSpy, times(0)).searchPrisonerContacts(any(), any(), any())
+    verify(prisonerContactRegistryClientSpy, times(0)).searchContacts(any(), any(), any())
   }
 
   @Test
@@ -520,7 +497,7 @@ class GetPermittedVisitorsForPermittedPrisonerForBookerTest : IntegrationTestBas
 
     verify(prisonVisitBookerRegistryClientSpy, times(1)).getPermittedPrisonersForBooker(BOOKER_REFERENCE)
     verify(prisonVisitBookerRegistryClientSpy, times(1)).getPermittedVisitorsForBookersAssociatedPrisoner(BOOKER_REFERENCE, PRISONER_ID)
-    verify(prisonerContactRegistryClientSpy, times(0)).searchPrisonerContacts(any(), any(), any())
+    verify(prisonerContactRegistryClientSpy, times(0)).searchContacts(any(), any(), any())
   }
 
   @Test
@@ -542,7 +519,7 @@ class GetPermittedVisitorsForPermittedPrisonerForBookerTest : IntegrationTestBas
 
     verify(prisonVisitBookerRegistryClientSpy, times(1)).getPermittedPrisonersForBooker(BOOKER_REFERENCE)
     verify(prisonVisitBookerRegistryClientSpy, times(1)).getPermittedVisitorsForBookersAssociatedPrisoner(BOOKER_REFERENCE, PRISONER_ID)
-    verify(prisonerContactRegistryClientSpy, times(0)).searchPrisonerContacts(any(), any(), any())
+    verify(prisonerContactRegistryClientSpy, times(0)).searchContacts(any(), any(), any())
   }
 
   @Test
@@ -560,12 +537,10 @@ class GetPermittedVisitorsForPermittedPrisonerForBookerTest : IntegrationTestBas
     )
 
     // prisoner contact registry returns 404
-    prisonerContactRegistryMockServer.stubSearchPrisonerContacts(
-      PRISONER_ID,
+    prisonerContactRegistryMockServer.stubSearchContacts(
       listOf(adultVisitor.personId, childVisitor.personId),
-      true,
-      null,
-      HttpStatus.NOT_FOUND,
+      PRISONER_ID,
+      contactsList = null,
     )
 
     // When
@@ -579,7 +554,7 @@ class GetPermittedVisitorsForPermittedPrisonerForBookerTest : IntegrationTestBas
 
     verify(prisonVisitBookerRegistryClientSpy, times(1)).getPermittedPrisonersForBooker(BOOKER_REFERENCE)
     verify(prisonVisitBookerRegistryClientSpy, times(1)).getPermittedVisitorsForBookersAssociatedPrisoner(BOOKER_REFERENCE, PRISONER_ID)
-    verify(prisonerContactRegistryClientSpy, times(1)).searchPrisonerContacts(PRISONER_ID, listOf(adultVisitor.personId, childVisitor.personId), true)
+    verify(prisonerContactRegistryClientSpy, times(1)).searchContacts(listOf(adultVisitor.personId, childVisitor.personId), PRISONER_ID, true)
   }
 
   @Test
@@ -597,12 +572,11 @@ class GetPermittedVisitorsForPermittedPrisonerForBookerTest : IntegrationTestBas
     )
 
     // prisoner contact registry returns INTERNAL_SERVER_ERROR
-    prisonerContactRegistryMockServer.stubSearchPrisonerContacts(
-      PRISONER_ID,
+    prisonerContactRegistryMockServer.stubSearchContacts(
       listOf(adultVisitor.personId, childVisitor.personId),
-      true,
-      null,
-      HttpStatus.INTERNAL_SERVER_ERROR,
+      PRISONER_ID,
+      contactsList = null,
+      httpStatus = HttpStatus.INTERNAL_SERVER_ERROR,
     )
 
     // When
@@ -613,7 +587,7 @@ class GetPermittedVisitorsForPermittedPrisonerForBookerTest : IntegrationTestBas
 
     verify(prisonVisitBookerRegistryClientSpy, times(1)).getPermittedPrisonersForBooker(BOOKER_REFERENCE)
     verify(prisonVisitBookerRegistryClientSpy, times(1)).getPermittedVisitorsForBookersAssociatedPrisoner(BOOKER_REFERENCE, PRISONER_ID)
-    verify(prisonerContactRegistryClientSpy, times(1)).searchPrisonerContacts(PRISONER_ID, listOf(adultVisitor.personId, childVisitor.personId), true)
+    verify(prisonerContactRegistryClientSpy, times(1)).searchContacts(listOf(adultVisitor.personId, childVisitor.personId), PRISONER_ID, true)
   }
 
   @Test
@@ -643,7 +617,7 @@ class GetPermittedVisitorsForPermittedPrisonerForBookerTest : IntegrationTestBas
     // And
     verify(prisonVisitBookerRegistryClientSpy, times(0)).getPermittedPrisonersForBooker(BOOKER_REFERENCE)
     verify(prisonVisitBookerRegistryClientSpy, times(0)).getPermittedVisitorsForBookersAssociatedPrisoner(BOOKER_REFERENCE, PRISONER_ID)
-    verify(prisonerContactRegistryClientSpy, times(0)).searchPrisonerContacts(any(), any(), any())
+    verify(prisonerContactRegistryClientSpy, times(0)).searchContacts(any(), any(), any())
   }
 
   private fun assertVisitorContactBasicDetails(visitorBasicInfo: VisitorInfoDto, visitorDetails: VisitorDetails) {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/booker/GetPermittedVisitorsForPermittedPrisonerForBookerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/booker/GetPermittedVisitorsForPermittedPrisonerForBookerTest.kt
@@ -4,6 +4,8 @@ import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.never
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.springframework.http.HttpHeaders
@@ -452,7 +454,7 @@ class GetPermittedVisitorsForPermittedPrisonerForBookerTest : IntegrationTestBas
 
     verify(prisonVisitBookerRegistryClientSpy, times(1)).getPermittedPrisonersForBooker(BOOKER_REFERENCE)
     verify(prisonVisitBookerRegistryClientSpy, times(1)).getPermittedVisitorsForBookersAssociatedPrisoner(BOOKER_REFERENCE, PRISONER_ID)
-    verify(prisonerContactRegistryClientSpy, times(0)).searchContacts(any(), any(), any())
+    verify(prisonerContactRegistryClientSpy, never()).searchContacts(any(), anyOrNull(), any())
   }
 
   @Test
@@ -473,7 +475,7 @@ class GetPermittedVisitorsForPermittedPrisonerForBookerTest : IntegrationTestBas
 
     verify(prisonVisitBookerRegistryClientSpy, times(1)).getPermittedPrisonersForBooker(BOOKER_REFERENCE)
     verify(prisonVisitBookerRegistryClientSpy, times(0)).getPermittedVisitorsForBookersAssociatedPrisoner(BOOKER_REFERENCE, PRISONER_ID)
-    verify(prisonerContactRegistryClientSpy, times(0)).searchContacts(any(), any(), any())
+    verify(prisonerContactRegistryClientSpy, never()).searchContacts(any(), anyOrNull(), any())
   }
 
   @Test
@@ -497,7 +499,7 @@ class GetPermittedVisitorsForPermittedPrisonerForBookerTest : IntegrationTestBas
 
     verify(prisonVisitBookerRegistryClientSpy, times(1)).getPermittedPrisonersForBooker(BOOKER_REFERENCE)
     verify(prisonVisitBookerRegistryClientSpy, times(1)).getPermittedVisitorsForBookersAssociatedPrisoner(BOOKER_REFERENCE, PRISONER_ID)
-    verify(prisonerContactRegistryClientSpy, times(0)).searchContacts(any(), any(), any())
+    verify(prisonerContactRegistryClientSpy, never()).searchContacts(any(), anyOrNull(), any())
   }
 
   @Test
@@ -519,7 +521,7 @@ class GetPermittedVisitorsForPermittedPrisonerForBookerTest : IntegrationTestBas
 
     verify(prisonVisitBookerRegistryClientSpy, times(1)).getPermittedPrisonersForBooker(BOOKER_REFERENCE)
     verify(prisonVisitBookerRegistryClientSpy, times(1)).getPermittedVisitorsForBookersAssociatedPrisoner(BOOKER_REFERENCE, PRISONER_ID)
-    verify(prisonerContactRegistryClientSpy, times(0)).searchContacts(any(), any(), any())
+    verify(prisonerContactRegistryClientSpy, never()).searchContacts(any(), anyOrNull(), any())
   }
 
   @Test
@@ -617,7 +619,7 @@ class GetPermittedVisitorsForPermittedPrisonerForBookerTest : IntegrationTestBas
     // And
     verify(prisonVisitBookerRegistryClientSpy, times(0)).getPermittedPrisonersForBooker(BOOKER_REFERENCE)
     verify(prisonVisitBookerRegistryClientSpy, times(0)).getPermittedVisitorsForBookersAssociatedPrisoner(BOOKER_REFERENCE, PRISONER_ID)
-    verify(prisonerContactRegistryClientSpy, times(0)).searchContacts(any(), any(), any())
+    verify(prisonerContactRegistryClientSpy, never()).searchContacts(any(), anyOrNull(), any())
   }
 
   private fun assertVisitorContactBasicDetails(visitorBasicInfo: VisitorInfoDto, visitorDetails: VisitorDetails) {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/mock/PrisonerContactRegistryMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/mock/PrisonerContactRegistryMockServer.kt
@@ -45,16 +45,20 @@ class PrisonerContactRegistryMockServer : WireMockServer(8095) {
     )
   }
 
-  fun stubSearchPrisonerContacts(
-    prisonerId: String,
+  fun stubSearchContacts(
     contactIds: List<Long>,
+    prisonerId: String? = null,
     withRestrictions: Boolean = true,
     contactsList: List<ContactWithOptionalPrisonerRelationshipDto>?,
     httpStatus: HttpStatus = HttpStatus.NOT_FOUND,
   ) {
     val responseBuilder = createJsonResponseBuilder()
 
-    val uri = "/v2/prisoners/$prisonerId/contacts/search?contactIds=${contactIds.joinToString(",")}&withRestrictions=$withRestrictions"
+    val uri = if (prisonerId != null) {
+      "/v2/contacts/search?contactIds=${contactIds.joinToString(",")}&withRestrictions=$withRestrictions&prisonerId=$prisonerId"
+    } else {
+      "/v2/contacts/search?contactIds=${contactIds.joinToString(",")}&withRestrictions=$withRestrictions"
+    }
 
     stubFor(
       get(uri)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/prisoner/profile/GetPrisonerProfileTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/prisoner/profile/GetPrisonerProfileTest.kt
@@ -120,11 +120,11 @@ class GetPrisonerProfileTest(
     prisonApiMockServer.stubGetInmateDetails(PRISONER_ID, inmateDetailDto)
     visitAllocationApiMockServer.stubGetPrisonerVOBalanceDetailed(PRISONER_ID, visitBalancesDto)
     alertApiMockServer.stubGetPrisonerAlertsMono(PRISONER_ID, listOf(alertResponseDto))
-    prisonerContactRegistryMockServer.stubSearchPrisonerContacts(
-      prisonerId = PRISONER_ID,
+    prisonerContactRegistryMockServer.stubSearchContacts(
       contactIds = getContactIdsFromVisits(listOf(visit1, visit2)),
-      contactsList = contactsDto,
+      prisonerId = PRISONER_ID,
       withRestrictions = false,
+      contactsList = contactsDto,
     )
     prisonRegisterMockServer.stubGetPrisonNames(prisons)
     prisonApiMockServer.stubGetPrisonerRestrictions(PRISONER_ID, OffenderRestrictionsDto(bookingId = 1, listOf(prisonerRestrictionDto)))
@@ -155,11 +155,11 @@ class GetPrisonerProfileTest(
     prisonOffenderSearchMockServer.stubGetPrisonerById(PRISONER_ID, null)
     prisonApiMockServer.stubGetInmateDetails(PRISONER_ID, inmateDetailDto)
     visitAllocationApiMockServer.stubGetPrisonerVOBalanceDetailed(PRISONER_ID, visitBalancesDto)
-    prisonerContactRegistryMockServer.stubSearchPrisonerContacts(
-      prisonerId = PRISONER_ID,
+    prisonerContactRegistryMockServer.stubSearchContacts(
       contactIds = getContactIdsFromVisits(listOf(visit1, visit2)),
-      contactsList = contactsDto,
+      prisonerId = PRISONER_ID,
       withRestrictions = false,
+      contactsList = contactsDto,
     )
     prisonApiMockServer.stubGetPrisonerRestrictions(PRISONER_ID, OffenderRestrictionsDto(bookingId = 1, listOf(prisonerRestrictionDto)))
     alertApiMockServer.stubGetPrisonerAlertsMono(PRISONER_ID, listOf(alertResponseDto))
@@ -181,12 +181,11 @@ class GetPrisonerProfileTest(
     prisonOffenderSearchMockServer.stubGetPrisonerById(PRISONER_ID, prisonerDto)
     prisonApiMockServer.stubGetInmateDetails(PRISONER_ID, null)
     visitAllocationApiMockServer.stubGetPrisonerVOBalanceDetailed(PRISONER_ID, visitBalancesDto)
-    prisonerContactRegistryMockServer.stubSearchPrisonerContacts(
-      prisonerId = PRISONER_ID,
+    prisonerContactRegistryMockServer.stubSearchContacts(
       contactIds = getContactIdsFromVisits(listOf(visit1, visit2)),
-      contactsList = contactsDto,
+      prisonerId = PRISONER_ID,
       withRestrictions = false,
-      httpStatus = HttpStatus.NOT_FOUND,
+      contactsList = contactsDto,
     )
     alertApiMockServer.stubGetPrisonerAlertsMono(PRISONER_ID, listOf(alertResponseDto))
     prisonApiMockServer.stubGetPrisonerRestrictions(PRISONER_ID, OffenderRestrictionsDto(bookingId = 1, listOf(prisonerRestrictionDto)))
@@ -218,12 +217,11 @@ class GetPrisonerProfileTest(
     prisonOffenderSearchMockServer.stubGetPrisonerById(PRISONER_ID, prisonerDto)
     prisonApiMockServer.stubGetInmateDetails(PRISONER_ID, inmateDetailDto)
     visitAllocationApiMockServer.stubGetPrisonerVOBalanceDetailed(PRISONER_ID, visitBalancesDto)
-    prisonerContactRegistryMockServer.stubSearchPrisonerContacts(
-      prisonerId = PRISONER_ID,
+    prisonerContactRegistryMockServer.stubSearchContacts(
       contactIds = getContactIdsFromVisits(listOf(visit1, visit2)),
-      contactsList = contactsDto,
+      prisonerId = PRISONER_ID,
       withRestrictions = false,
-      httpStatus = HttpStatus.NOT_FOUND,
+      contactsList = contactsDto,
     )
     alertApiMockServer.stubGetPrisonerAlertsMono(PRISONER_ID, listOf(alertResponseDto))
     prisonApiMockServer.stubGetPrisonerRestrictions(PRISONER_ID, OffenderRestrictionsDto(bookingId = 1, listOf(prisonerRestrictionDto)))
@@ -245,12 +243,11 @@ class GetPrisonerProfileTest(
     prisonOffenderSearchMockServer.stubGetPrisonerById(PRISONER_ID, prisonerDto)
     prisonApiMockServer.stubGetInmateDetails(PRISONER_ID, inmateDetailDto)
     visitAllocationApiMockServer.stubGetPrisonerVOBalanceDetailed(PRISONER_ID, null)
-    prisonerContactRegistryMockServer.stubSearchPrisonerContacts(
-      prisonerId = PRISONER_ID,
+    prisonerContactRegistryMockServer.stubSearchContacts(
       contactIds = getContactIdsFromVisits(listOf(visit1, visit2)),
-      contactsList = contactsDto,
+      prisonerId = PRISONER_ID,
       withRestrictions = false,
-      httpStatus = HttpStatus.NOT_FOUND,
+      contactsList = contactsDto,
     )
     alertApiMockServer.stubGetPrisonerAlertsMono(PRISONER_ID, listOf(alertResponseDto))
     prisonApiMockServer.stubGetPrisonerRestrictions(PRISONER_ID, OffenderRestrictionsDto(bookingId = 1, listOf(prisonerRestrictionDto)))
@@ -289,12 +286,11 @@ class GetPrisonerProfileTest(
     prisonOffenderSearchMockServer.stubGetPrisonerById(PRISONER_ID, prisonerDto)
     prisonApiMockServer.stubGetInmateDetails(PRISONER_ID, inmateDetailDto)
     visitAllocationApiMockServer.stubGetPrisonerVOBalanceDetailed(PRISONER_ID, visitBalancesDto)
-    prisonerContactRegistryMockServer.stubSearchPrisonerContacts(
-      prisonerId = PRISONER_ID,
+    prisonerContactRegistryMockServer.stubSearchContacts(
       contactIds = getContactIdsFromVisits(listOf(visit1, visit2)),
-      contactsList = contactsDto,
+      prisonerId = PRISONER_ID,
       withRestrictions = false,
-      httpStatus = HttpStatus.NOT_FOUND,
+      contactsList = contactsDto,
     )
     alertApiMockServer.stubGetPrisonerAlertsMono(PRISONER_ID, listOf(alertResponseDto))
     prisonApiMockServer.stubGetPrisonerRestrictions(PRISONER_ID, OffenderRestrictionsDto(bookingId = 1, listOf(prisonerRestrictionDto)))
@@ -324,12 +320,11 @@ class GetPrisonerProfileTest(
     prisonOffenderSearchMockServer.stubGetPrisonerById(PRISONER_ID, prisonerDto)
     prisonApiMockServer.stubGetInmateDetails(PRISONER_ID, inmateDetailDto)
     visitAllocationApiMockServer.stubGetPrisonerVOBalanceDetailed(PRISONER_ID, visitBalancesDto)
-    prisonerContactRegistryMockServer.stubSearchPrisonerContacts(
-      prisonerId = PRISONER_ID,
+    prisonerContactRegistryMockServer.stubSearchContacts(
       contactIds = emptyList(),
-      contactsList = contactsDto,
+      prisonerId = PRISONER_ID,
       withRestrictions = false,
-      httpStatus = HttpStatus.NOT_FOUND,
+      contactsList = contactsDto,
     )
     alertApiMockServer.stubGetPrisonerAlertsMono(PRISONER_ID, listOf(alertResponseDto))
     prisonApiMockServer.stubGetPrisonerRestrictions(PRISONER_ID, OffenderRestrictionsDto(bookingId = 1, listOf(prisonerRestrictionDto)))
@@ -360,11 +355,11 @@ class GetPrisonerProfileTest(
     prisonApiMockServer.stubGetInmateDetails(PRISONER_ID, inmateDetailDto)
     visitAllocationApiMockServer.stubGetPrisonerVOBalanceDetailed(PRISONER_ID, visitBalancesDto)
 
-    prisonerContactRegistryMockServer.stubSearchPrisonerContacts(
-      prisonerId = PRISONER_ID,
+    prisonerContactRegistryMockServer.stubSearchContacts(
       contactIds = getContactIdsFromVisits(listOf(visit1, visit2)),
-      contactsList = contactsDto,
+      prisonerId = PRISONER_ID,
       withRestrictions = false,
+      contactsList = contactsDto,
     )
 
     alertApiMockServer.stubGetPrisonerAlertsMono(PRISONER_ID, listOf(alertResponseDto))
@@ -394,9 +389,9 @@ class GetPrisonerProfileTest(
 
     verifyExternalAPIClientCalls()
 
-    verify(prisonerContactRegistryClientSpy, times(1)).searchPrisonerContactsAsMono(
-      eq(PRISONER_ID),
+    verify(prisonerContactRegistryClientSpy, times(1)).searchContactsAsMono(
       eq(getContactIdsFromVisits(listOf(visit1, visit2))),
+      eq(PRISONER_ID),
       eq(false),
     )
   }
@@ -411,11 +406,11 @@ class GetPrisonerProfileTest(
     prisonApiMockServer.stubGetPrisonerRestrictions(PRISONER_ID, OffenderRestrictionsDto(bookingId = 1, listOf(prisonerRestrictionDto)))
     prisonRegisterMockServer.stubGetPrisonNames(prisons)
 
-    prisonerContactRegistryMockServer.stubSearchPrisonerContacts(
-      prisonerId = PRISONER_ID,
+    prisonerContactRegistryMockServer.stubSearchContacts(
       contactIds = getContactIdsFromVisits(listOf(visit1, visit2)),
-      contactsList = null,
+      prisonerId = PRISONER_ID,
       withRestrictions = false,
+      contactsList = null,
       httpStatus = HttpStatus.BAD_REQUEST,
     )
     stubGetVisits(listOf(visit1, visit2))
@@ -441,9 +436,9 @@ class GetPrisonerProfileTest(
 
     verifyExternalAPIClientCalls()
     // verify the call to prisoner contact registry is made once
-    verify(prisonerContactRegistryClientSpy, times(1)).searchPrisonerContactsAsMono(
-      eq(PRISONER_ID),
+    verify(prisonerContactRegistryClientSpy, times(1)).searchContactsAsMono(
       eq(getContactIdsFromVisits(listOf(visit1, visit2))),
+      eq(PRISONER_ID),
       eq(false),
     )
   }
@@ -455,11 +450,11 @@ class GetPrisonerProfileTest(
     prisonApiMockServer.stubGetInmateDetails(PRISONER_ID, inmateDetailDto)
     visitAllocationApiMockServer.stubGetPrisonerVOBalanceDetailed(PRISONER_ID, visitBalancesDto)
     alertApiMockServer.stubGetPrisonerAlertsMono(PRISONER_ID, listOf(alertResponseDto))
-    prisonerContactRegistryMockServer.stubSearchPrisonerContacts(
-      prisonerId = PRISONER_ID,
+    prisonerContactRegistryMockServer.stubSearchContacts(
       contactIds = getContactIdsFromVisits(listOf(visit1, visit2)),
-      contactsList = contactsDto,
+      prisonerId = PRISONER_ID,
       withRestrictions = false,
+      contactsList = contactsDto,
     )
     prisonApiMockServer.stubGetPrisonerRestrictions(PRISONER_ID, OffenderRestrictionsDto(bookingId = 1, listOf(prisonerRestrictionDto)))
     prisonRegisterMockServer.stubGetPrisonNames(prisons)
@@ -492,11 +487,11 @@ class GetPrisonerProfileTest(
     prisonOffenderSearchMockServer.stubGetPrisonerById(PRISONER_ID, prisonerDto)
     prisonApiMockServer.stubGetInmateDetails(PRISONER_ID, inmateDetailDto)
     visitAllocationApiMockServer.stubGetPrisonerVOBalanceDetailed(PRISONER_ID, visitBalancesDto)
-    prisonerContactRegistryMockServer.stubSearchPrisonerContacts(
-      prisonerId = PRISONER_ID,
+    prisonerContactRegistryMockServer.stubSearchContacts(
       contactIds = getContactIdsFromVisits(listOf(incorrectPrisonVisit)),
-      contactsList = contactsDto,
+      prisonerId = PRISONER_ID,
       withRestrictions = false,
+      contactsList = contactsDto,
     )
     prisonRegisterMockServer.stubGetPrisonNames(prisons)
     alertApiMockServer.stubGetPrisonerAlertsMono(PRISONER_ID, listOf(alertResponseDto))
@@ -527,11 +522,11 @@ class GetPrisonerProfileTest(
     prisonOffenderSearchMockServer.stubGetPrisonerById(PRISONER_ID, prisonerDto)
     prisonApiMockServer.stubGetInmateDetails(PRISONER_ID, inmateDetailDto)
     visitAllocationApiMockServer.stubGetPrisonerVOBalanceDetailed(PRISONER_ID, visitBalancesDto)
-    prisonerContactRegistryMockServer.stubSearchPrisonerContacts(
-      prisonerId = PRISONER_ID,
+    prisonerContactRegistryMockServer.stubSearchContacts(
       contactIds = getContactIdsFromVisits(listOf(visit1, visit2)),
-      contactsList = contactsDto,
+      prisonerId = PRISONER_ID,
       withRestrictions = false,
+      contactsList = contactsDto,
     )
     alertApiMockServer.stubGetPrisonerAlertsMono(PRISONER_ID, listOf(alertResponseDto))
     prisonApiMockServer.stubGetPrisonerRestrictions(PRISONER_ID, OffenderRestrictionsDto(bookingId = 1, listOf(prisonerRestrictionDto)))
@@ -564,11 +559,11 @@ class GetPrisonerProfileTest(
     prisonOffenderSearchMockServer.stubGetPrisonerById(PRISONER_ID, prisonerDto)
     prisonApiMockServer.stubGetInmateDetails(PRISONER_ID, inmateDetailDto)
     visitAllocationApiMockServer.stubGetPrisonerVOBalanceDetailed(PRISONER_ID, visitBalancesDto)
-    prisonerContactRegistryMockServer.stubSearchPrisonerContacts(
-      prisonerId = PRISONER_ID,
+    prisonerContactRegistryMockServer.stubSearchContacts(
       contactIds = getContactIdsFromVisits(listOf(visit1, visit2)),
-      contactsList = contactsDto,
+      prisonerId = PRISONER_ID,
       withRestrictions = false,
+      contactsList = contactsDto,
     )
     alertApiMockServer.stubGetPrisonerAlertsMono(PRISONER_ID, listOf(alertResponseDto))
     prisonApiMockServer.stubGetPrisonerRestrictions(PRISONER_ID, OffenderRestrictionsDto(bookingId = 1, listOf(prisonerRestrictionDto)))
@@ -604,11 +599,11 @@ class GetPrisonerProfileTest(
     prisonApiMockServer.stubGetInmateDetails(PRISONER_ID, inmateDetailDto)
     visitAllocationApiMockServer.stubGetPrisonerVOBalanceDetailed(PRISONER_ID, visitBalancesDto)
     alertApiMockServer.stubGetPrisonerAlertsMono(PRISONER_ID, null, HttpStatus.NOT_FOUND)
-    prisonerContactRegistryMockServer.stubSearchPrisonerContacts(
-      prisonerId = PRISONER_ID,
+    prisonerContactRegistryMockServer.stubSearchContacts(
       contactIds = getContactIdsFromVisits(listOf(visit1, visit2)),
-      contactsList = contactsDto,
+      prisonerId = PRISONER_ID,
       withRestrictions = false,
+      contactsList = contactsDto,
     )
     prisonRegisterMockServer.stubGetPrisonNames(prisons)
     prisonApiMockServer.stubGetPrisonerRestrictions(PRISONER_ID, OffenderRestrictionsDto(bookingId = 1, listOf(prisonerRestrictionDto)))
@@ -630,11 +625,11 @@ class GetPrisonerProfileTest(
     prisonApiMockServer.stubGetInmateDetails(PRISONER_ID, inmateDetailDto)
     visitAllocationApiMockServer.stubGetPrisonerVOBalanceDetailed(PRISONER_ID, visitBalancesDto)
     alertApiMockServer.stubGetPrisonerAlertsMono(PRISONER_ID, null, HttpStatus.INTERNAL_SERVER_ERROR)
-    prisonerContactRegistryMockServer.stubSearchPrisonerContacts(
-      prisonerId = PRISONER_ID,
+    prisonerContactRegistryMockServer.stubSearchContacts(
       contactIds = getContactIdsFromVisits(listOf(visit1, visit2)),
-      contactsList = contactsDto,
+      prisonerId = PRISONER_ID,
       withRestrictions = false,
+      contactsList = contactsDto,
     )
     prisonRegisterMockServer.stubGetPrisonNames(prisons)
     prisonApiMockServer.stubGetPrisonerRestrictions(PRISONER_ID, OffenderRestrictionsDto(bookingId = 1, listOf(prisonerRestrictionDto)))
@@ -656,11 +651,11 @@ class GetPrisonerProfileTest(
     prisonApiMockServer.stubGetInmateDetails(PRISONER_ID, inmateDetailDto)
     visitAllocationApiMockServer.stubGetPrisonerVOBalanceDetailed(PRISONER_ID, visitBalancesDto)
     alertApiMockServer.stubGetPrisonerAlertsMono(PRISONER_ID, listOf(alertResponseDto))
-    prisonerContactRegistryMockServer.stubSearchPrisonerContacts(
-      prisonerId = PRISONER_ID,
+    prisonerContactRegistryMockServer.stubSearchContacts(
       contactIds = getContactIdsFromVisits(listOf(visit1, visit2)),
-      contactsList = contactsDto,
+      prisonerId = PRISONER_ID,
       withRestrictions = false,
+      contactsList = contactsDto,
     )
     prisonRegisterMockServer.stubGetPrisonNames(prisons)
     prisonApiMockServer.stubGetPrisonerRestrictions(PRISONER_ID, null, HttpStatus.NOT_FOUND)
@@ -682,11 +677,11 @@ class GetPrisonerProfileTest(
     prisonApiMockServer.stubGetInmateDetails(PRISONER_ID, inmateDetailDto)
     visitAllocationApiMockServer.stubGetPrisonerVOBalanceDetailed(PRISONER_ID, visitBalancesDto)
     alertApiMockServer.stubGetPrisonerAlertsMono(PRISONER_ID, listOf(alertResponseDto))
-    prisonerContactRegistryMockServer.stubSearchPrisonerContacts(
-      prisonerId = PRISONER_ID,
+    prisonerContactRegistryMockServer.stubSearchContacts(
       contactIds = getContactIdsFromVisits(listOf(visit1, visit2)),
-      contactsList = contactsDto,
+      prisonerId = PRISONER_ID,
       withRestrictions = false,
+      contactsList = contactsDto,
     )
     prisonRegisterMockServer.stubGetPrisonNames(prisons)
     prisonApiMockServer.stubGetPrisonerRestrictions(PRISONER_ID, null, HttpStatus.INTERNAL_SERVER_ERROR)
@@ -735,11 +730,11 @@ class GetPrisonerProfileTest(
     prisonApiMockServer.stubGetInmateDetails(PRISONER_ID, inmateDetailDto)
     visitAllocationApiMockServer.stubGetPrisonerVOBalanceDetailed(PRISONER_ID, visitBalancesDto)
     alertApiMockServer.stubGetPrisonerAlertsMono(PRISONER_ID, listOf(alert1, alert2, alert3, alert4, alert5, alert6, alert7, alert8, alert9, alert10, alert11))
-    prisonerContactRegistryMockServer.stubSearchPrisonerContacts(
-      prisonerId = PRISONER_ID,
+    prisonerContactRegistryMockServer.stubSearchContacts(
       contactIds = getContactIdsFromVisits(listOf(visit1, visit2)),
-      contactsList = contactsDto,
+      prisonerId = PRISONER_ID,
       withRestrictions = false,
+      contactsList = contactsDto,
     )
     prisonRegisterMockServer.stubGetPrisonNames(prisons)
     prisonApiMockServer.stubGetPrisonerRestrictions(PRISONER_ID, OffenderRestrictionsDto(bookingId = 1, listOf(prisonerRestrictionDto)))
@@ -787,11 +782,11 @@ class GetPrisonerProfileTest(
     prisonApiMockServer.stubGetInmateDetails(PRISONER_ID, inmateDetailDto)
     visitAllocationApiMockServer.stubGetPrisonerVOBalanceDetailed(PRISONER_ID, visitBalancesDto)
     alertApiMockServer.stubGetPrisonerAlertsMono(PRISONER_ID, listOf(alertResponseDto))
-    prisonerContactRegistryMockServer.stubSearchPrisonerContacts(
-      prisonerId = PRISONER_ID,
+    prisonerContactRegistryMockServer.stubSearchContacts(
       contactIds = getContactIdsFromVisits(listOf(visit1, visit2)),
-      contactsList = contactsDto,
+      prisonerId = PRISONER_ID,
       withRestrictions = false,
+      contactsList = contactsDto,
     )
     prisonRegisterMockServer.stubGetPrisonNames(prisons)
     prisonApiMockServer.stubGetPrisonerRestrictions(PRISONER_ID, OffenderRestrictionsDto(bookingId = 1, listOf(restriction1, restriction2, restriction3, restriction4, restriction5, restriction6)))

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/visit/GetVisitBookingDetailsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/visit/GetVisitBookingDetailsTest.kt
@@ -173,9 +173,9 @@ class GetVisitBookingDetailsTest : IntegrationTestBase() {
     // alert 3's alert code is not relevant for visits so should be ignored
     alertApiMockServer.stubGetPrisonerAlertsMono(prisonerId, listOf(alert1, alert2, alert3))
     prisonApiMockServer.stubGetPrisonerRestrictions(prisonerId, offenderRestrictions)
-    prisonerContactRegistryMockServer.stubSearchPrisonerContacts(
-      prisonerId = prisonerId,
+    prisonerContactRegistryMockServer.stubSearchContacts(
       contactIds = contactsList.map { it.contactId },
+      prisonerId = prisonerId,
       contactsList = contactsList,
     )
     visitSchedulerMockServer.stubGetVisitHistory(visit.reference, eventList)
@@ -223,9 +223,9 @@ class GetVisitBookingDetailsTest : IntegrationTestBase() {
     // alert 3's alert code is not relevant for visits so should be ignored
     alertApiMockServer.stubGetPrisonerAlertsMono(prisonerId, listOf(alert1, alert2, alert3))
     prisonApiMockServer.stubGetPrisonerRestrictions(prisonerId, offenderRestrictions)
-    prisonerContactRegistryMockServer.stubSearchPrisonerContacts(
-      prisonerId = prisonerId,
+    prisonerContactRegistryMockServer.stubSearchContacts(
       contactIds = contactsList.map { it.contactId },
+      prisonerId = prisonerId,
       contactsList = contactsList,
     )
     visitSchedulerMockServer.stubGetVisitHistory(visit.reference, eventList)
@@ -279,9 +279,9 @@ class GetVisitBookingDetailsTest : IntegrationTestBase() {
     // alert 3's alert code is not relevant for visits so should be ignored
     alertApiMockServer.stubGetPrisonerAlertsMono(prisonerId, listOf(alert1, alert2, alert3))
     prisonApiMockServer.stubGetPrisonerRestrictions(prisonerId, offenderRestrictions)
-    prisonerContactRegistryMockServer.stubSearchPrisonerContacts(
-      prisonerId = prisonerId,
+    prisonerContactRegistryMockServer.stubSearchContacts(
       contactIds = contactsList.map { it.contactId },
+      prisonerId = prisonerId,
       contactsList = contactsList,
     )
     visitSchedulerMockServer.stubGetVisitHistory(visit.reference, eventList)
@@ -340,9 +340,9 @@ class GetVisitBookingDetailsTest : IntegrationTestBase() {
     // alert 3's alert code is not relevant for visits so should be ignored
     alertApiMockServer.stubGetPrisonerAlertsMono(prisonerId, listOf(alert1, alert2, alert3))
     prisonApiMockServer.stubGetPrisonerRestrictions(prisonerId, offenderRestrictions)
-    prisonerContactRegistryMockServer.stubSearchPrisonerContacts(
-      prisonerId = prisonerId,
+    prisonerContactRegistryMockServer.stubSearchContacts(
       contactIds = contactsList.map { it.contactId },
+      prisonerId = prisonerId,
       contactsList = contactsList,
     )
     visitSchedulerMockServer.stubGetVisitHistory(visit.reference, eventList)
@@ -383,9 +383,9 @@ class GetVisitBookingDetailsTest : IntegrationTestBase() {
     prisonRegisterMockServer.stubGetPrison(prisonCode, prison)
     alertApiMockServer.stubGetPrisonerAlertsMono(prisonerId, listOf(alert1, alert2, alert3))
     prisonApiMockServer.stubGetPrisonerRestrictions(prisonerId, offenderRestrictions)
-    prisonerContactRegistryMockServer.stubSearchPrisonerContacts(
-      prisonerId = prisonerId,
+    prisonerContactRegistryMockServer.stubSearchContacts(
       contactIds = contactsList.map { it.contactId },
+      prisonerId = prisonerId,
       contactsList = contactsList,
     )
     visitSchedulerMockServer.stubGetVisitHistory(visit.reference, eventList)
@@ -416,9 +416,9 @@ class GetVisitBookingDetailsTest : IntegrationTestBase() {
     prisonRegisterMockServer.stubGetPrison(prisonCode, prison)
     alertApiMockServer.stubGetPrisonerAlertsMono(prisonerId, listOf(alert1, alert2, alert3))
     prisonApiMockServer.stubGetPrisonerRestrictions(prisonerId, offenderRestrictions)
-    prisonerContactRegistryMockServer.stubSearchPrisonerContacts(
-      prisonerId = prisonerId,
+    prisonerContactRegistryMockServer.stubSearchContacts(
       contactIds = contactsList.map { it.contactId },
+      prisonerId = prisonerId,
       contactsList = contactsList,
     )
     visitSchedulerMockServer.stubGetVisitHistory(visit.reference, eventList)
@@ -450,9 +450,9 @@ class GetVisitBookingDetailsTest : IntegrationTestBase() {
     prisonRegisterMockServer.stubGetPrison(prisonCode, null, HttpStatus.NOT_FOUND)
     alertApiMockServer.stubGetPrisonerAlertsMono(prisonerId, listOf(alert1, alert2, alert3))
     prisonApiMockServer.stubGetPrisonerRestrictions(prisonerId, offenderRestrictions)
-    prisonerContactRegistryMockServer.stubSearchPrisonerContacts(
-      prisonerId = prisonerId,
+    prisonerContactRegistryMockServer.stubSearchContacts(
       contactIds = contactsList.map { it.contactId },
+      prisonerId = prisonerId,
       contactsList = contactsList,
     )
     visitSchedulerMockServer.stubGetVisitHistory(visit.reference, eventList)
@@ -492,9 +492,9 @@ class GetVisitBookingDetailsTest : IntegrationTestBase() {
     prisonRegisterMockServer.stubGetPrison(prisonCode, null, HttpStatus.INTERNAL_SERVER_ERROR)
     alertApiMockServer.stubGetPrisonerAlertsMono(prisonerId, listOf(alert1, alert2, alert3))
     prisonApiMockServer.stubGetPrisonerRestrictions(prisonerId, offenderRestrictions)
-    prisonerContactRegistryMockServer.stubSearchPrisonerContacts(
-      prisonerId = prisonerId,
+    prisonerContactRegistryMockServer.stubSearchContacts(
       contactIds = contactsList.map { it.contactId },
+      prisonerId = prisonerId,
       contactsList = contactsList,
     )
     visitSchedulerMockServer.stubGetVisitHistory(visit.reference, eventList)
@@ -523,9 +523,9 @@ class GetVisitBookingDetailsTest : IntegrationTestBase() {
     // alert API returns a 500
     alertApiMockServer.stubGetPrisonerAlertsMono(prisonerId, null, HttpStatus.INTERNAL_SERVER_ERROR)
     prisonApiMockServer.stubGetPrisonerRestrictions(prisonerId, offenderRestrictions)
-    prisonerContactRegistryMockServer.stubSearchPrisonerContacts(
-      prisonerId = prisonerId,
+    prisonerContactRegistryMockServer.stubSearchContacts(
       contactIds = contactsList.map { it.contactId },
+      prisonerId = prisonerId,
       contactsList = contactsList,
     )
     visitSchedulerMockServer.stubGetVisitHistory(visit.reference, eventList)
@@ -555,9 +555,9 @@ class GetVisitBookingDetailsTest : IntegrationTestBase() {
     alertApiMockServer.stubGetPrisonerAlertsMono(prisonerId, listOf(alert1, alert2, alert3))
     // prison API returns a 404
     prisonApiMockServer.stubGetPrisonerRestrictions(prisonerId, null, HttpStatus.NOT_FOUND)
-    prisonerContactRegistryMockServer.stubSearchPrisonerContacts(
-      prisonerId = prisonerId,
+    prisonerContactRegistryMockServer.stubSearchContacts(
       contactIds = contactsList.map { it.contactId },
+      prisonerId = prisonerId,
       contactsList = contactsList,
     )
     visitSchedulerMockServer.stubGetVisitHistory(visit.reference, eventList)
@@ -601,11 +601,11 @@ class GetVisitBookingDetailsTest : IntegrationTestBase() {
     prisonOffenderSearchMockServer.stubGetPrisonerById(prisonerId, releasedPrisoner)
     prisonRegisterMockServer.stubGetPrison(prisonCode, prison)
 
-    prisonerContactRegistryMockServer.stubSearchPrisonerContacts(
-      prisonerId = prisonerId,
+    prisonerContactRegistryMockServer.stubSearchContacts(
       contactIds = contactsList.map { it.contactId },
-      contactsList = contactsList,
+      prisonerId = prisonerId,
       withRestrictions = false,
+      contactsList = contactsList,
     )
     visitSchedulerMockServer.stubGetVisitHistory(visit.reference, eventList)
     visitSchedulerMockServer.stubGetVisitNotificationEvents(visit.reference, notifications)
@@ -626,7 +626,7 @@ class GetVisitBookingDetailsTest : IntegrationTestBase() {
     verify(manageUsersApiClientSpy, times(1)).getUsersByUsernames(userIds.toSet())
     verify(alertsApiClientSpy, times(0)).getPrisonerAlertsAsMono(any())
     verify(prisonApiClientSpy, times(0)).getPrisonerRestrictionsAsMono(any())
-    verify(prisonerContactRegistryClientSpy, times(1)).searchPrisonerContactsAsMono(prisonerId, contactsList.map { it.contactId }, false)
+    verify(prisonerContactRegistryClientSpy, times(1)).searchContactsAsMono(contactsList.map { it.contactId }, prisonerId, false)
   }
 
   @Test
@@ -649,11 +649,11 @@ class GetVisitBookingDetailsTest : IntegrationTestBase() {
     prisonOffenderSearchMockServer.stubGetPrisonerById(prisonerId, prisonerDto)
     prisonRegisterMockServer.stubGetPrison(prisonCode, prison)
 
-    prisonerContactRegistryMockServer.stubSearchPrisonerContacts(
-      prisonerId = prisonerId,
+    prisonerContactRegistryMockServer.stubSearchContacts(
       contactIds = contactsList.map { it.contactId },
-      contactsList = contactsList,
+      prisonerId = prisonerId,
       withRestrictions = false,
+      contactsList = contactsList,
     )
     visitSchedulerMockServer.stubGetVisitHistory(visit.reference, eventList)
     visitSchedulerMockServer.stubGetVisitNotificationEvents(visit.reference, notifications)
@@ -674,7 +674,7 @@ class GetVisitBookingDetailsTest : IntegrationTestBase() {
     verify(manageUsersApiClientSpy, times(1)).getUsersByUsernames(userIds.toSet())
     verify(alertsApiClientSpy, times(0)).getPrisonerAlertsAsMono(any())
     verify(prisonApiClientSpy, times(0)).getPrisonerRestrictionsAsMono(any())
-    verify(prisonerContactRegistryClientSpy, times(1)).searchPrisonerContactsAsMono(prisonerId, contactsList.map { it.contactId }, false)
+    verify(prisonerContactRegistryClientSpy, times(1)).searchContactsAsMono(contactsList.map { it.contactId }, prisonerId, false)
   }
 
   @Test
@@ -693,9 +693,9 @@ class GetVisitBookingDetailsTest : IntegrationTestBase() {
     alertApiMockServer.stubGetPrisonerAlertsMono(prisonerId, listOf(alert1, alert2, alert3))
     // prison API returns a 404
     prisonApiMockServer.stubGetPrisonerRestrictions(prisonerId, null, HttpStatus.INTERNAL_SERVER_ERROR)
-    prisonerContactRegistryMockServer.stubSearchPrisonerContacts(
-      prisonerId = prisonerId,
+    prisonerContactRegistryMockServer.stubSearchContacts(
       contactIds = contactsList.map { it.contactId },
+      prisonerId = prisonerId,
       contactsList = contactsList,
     )
     visitSchedulerMockServer.stubGetVisitHistory(visit.reference, eventList)
@@ -724,11 +724,10 @@ class GetVisitBookingDetailsTest : IntegrationTestBase() {
     alertApiMockServer.stubGetPrisonerAlertsMono(prisonerId, listOf(alert1, alert2, alert3))
     prisonApiMockServer.stubGetPrisonerRestrictions(prisonerId, offenderRestrictions)
     // prisoner contact registry API returns a 404
-    prisonerContactRegistryMockServer.stubSearchPrisonerContacts(
-      prisonerId = prisonerId,
+    prisonerContactRegistryMockServer.stubSearchContacts(
       contactIds = visitors.map { it.nomisPersonId },
+      prisonerId = prisonerId,
       contactsList = null,
-      httpStatus = HttpStatus.NOT_FOUND,
     )
     visitSchedulerMockServer.stubGetVisitHistory(visit.reference, eventList)
     visitSchedulerMockServer.stubGetVisitNotificationEvents(visit.reference, notifications)
@@ -757,9 +756,9 @@ class GetVisitBookingDetailsTest : IntegrationTestBase() {
     alertApiMockServer.stubGetPrisonerAlertsMono(prisonerId, listOf(alert1, alert2, alert3))
     prisonApiMockServer.stubGetPrisonerRestrictions(prisonerId, offenderRestrictions)
     // prisoner contact registry API returns a 500
-    prisonerContactRegistryMockServer.stubSearchPrisonerContacts(
-      prisonerId = prisonerId,
+    prisonerContactRegistryMockServer.stubSearchContacts(
       contactIds = visitors.map { it.nomisPersonId },
+      prisonerId = prisonerId,
       contactsList = null,
       httpStatus = HttpStatus.INTERNAL_SERVER_ERROR,
     )
@@ -787,9 +786,9 @@ class GetVisitBookingDetailsTest : IntegrationTestBase() {
     prisonRegisterMockServer.stubGetPrison(prisonCode, prison)
     alertApiMockServer.stubGetPrisonerAlertsMono(prisonerId, listOf(alert1, alert2, alert3))
     prisonApiMockServer.stubGetPrisonerRestrictions(prisonerId, offenderRestrictions)
-    prisonerContactRegistryMockServer.stubSearchPrisonerContacts(
-      prisonerId = prisonerId,
+    prisonerContactRegistryMockServer.stubSearchContacts(
       contactIds = contactsList.map { it.contactId },
+      prisonerId = prisonerId,
       contactsList = contactsList,
     )
     // visits get history - returns a 404
@@ -818,9 +817,9 @@ class GetVisitBookingDetailsTest : IntegrationTestBase() {
     prisonRegisterMockServer.stubGetPrison(prisonCode, prison)
     alertApiMockServer.stubGetPrisonerAlertsMono(prisonerId, listOf(alert1, alert2, alert3))
     prisonApiMockServer.stubGetPrisonerRestrictions(prisonerId, offenderRestrictions)
-    prisonerContactRegistryMockServer.stubSearchPrisonerContacts(
-      prisonerId = prisonerId,
+    prisonerContactRegistryMockServer.stubSearchContacts(
       contactIds = contactsList.map { it.contactId },
+      prisonerId = prisonerId,
       contactsList = contactsList,
     )
     // visits get history - returns a 500
@@ -849,9 +848,9 @@ class GetVisitBookingDetailsTest : IntegrationTestBase() {
     prisonRegisterMockServer.stubGetPrison(prisonCode, prison)
     alertApiMockServer.stubGetPrisonerAlertsMono(prisonerId, listOf(alert1, alert2, alert3))
     prisonApiMockServer.stubGetPrisonerRestrictions(prisonerId, offenderRestrictions)
-    prisonerContactRegistryMockServer.stubSearchPrisonerContacts(
-      prisonerId = prisonerId,
+    prisonerContactRegistryMockServer.stubSearchContacts(
       contactIds = contactsList.map { it.contactId },
+      prisonerId = prisonerId,
       contactsList = contactsList,
     )
     visitSchedulerMockServer.stubGetVisitHistory(visit.reference, eventList)
@@ -880,9 +879,9 @@ class GetVisitBookingDetailsTest : IntegrationTestBase() {
     prisonRegisterMockServer.stubGetPrison(prisonCode, prison)
     alertApiMockServer.stubGetPrisonerAlertsMono(prisonerId, listOf(alert1, alert2, alert3))
     prisonApiMockServer.stubGetPrisonerRestrictions(prisonerId, offenderRestrictions)
-    prisonerContactRegistryMockServer.stubSearchPrisonerContacts(
-      prisonerId = prisonerId,
+    prisonerContactRegistryMockServer.stubSearchContacts(
       contactIds = contactsList.map { it.contactId },
+      prisonerId = prisonerId,
       contactsList = contactsList,
     )
     visitSchedulerMockServer.stubGetVisitHistory(visit.reference, eventList)
@@ -916,9 +915,9 @@ class GetVisitBookingDetailsTest : IntegrationTestBase() {
     // alert 3's alert code is not relevant for visits so should be ignored
     alertApiMockServer.stubGetPrisonerAlertsMono(prisonerId, listOf(alert1, alert2, alert3))
     prisonApiMockServer.stubGetPrisonerRestrictions(prisonerId, offenderRestrictions)
-    prisonerContactRegistryMockServer.stubSearchPrisonerContacts(
-      prisonerId = prisonerId,
+    prisonerContactRegistryMockServer.stubSearchContacts(
       contactIds = contactsList.map { it.contactId },
+      prisonerId = prisonerId,
       contactsList = contactsList,
     )
     visitSchedulerMockServer.stubGetVisitHistory(visit.reference, eventList)
@@ -958,9 +957,9 @@ class GetVisitBookingDetailsTest : IntegrationTestBase() {
     // alert 3's alert code is not relevant for visits so should be ignored
     alertApiMockServer.stubGetPrisonerAlertsMono(prisonerId, listOf(alert1, alert2, alert3))
     prisonApiMockServer.stubGetPrisonerRestrictions(prisonerId, offenderRestrictions)
-    prisonerContactRegistryMockServer.stubSearchPrisonerContacts(
-      prisonerId = prisonerId,
+    prisonerContactRegistryMockServer.stubSearchContacts(
       contactIds = contactsList.map { it.contactId },
+      prisonerId = prisonerId,
       contactsList = contactsList,
     )
     visitSchedulerMockServer.stubGetVisitHistory(visit.reference, eventList)
@@ -1027,9 +1026,9 @@ class GetVisitBookingDetailsTest : IntegrationTestBase() {
 
     alertApiMockServer.stubGetPrisonerAlertsMono(prisonerId, listOf(alert1, alert2, alert3, alert4, alert5, alert6, alert7, alert8, alert9, alert10, alert11))
     prisonApiMockServer.stubGetPrisonerRestrictions(prisonerId, offenderRestrictions)
-    prisonerContactRegistryMockServer.stubSearchPrisonerContacts(
-      prisonerId = prisonerId,
+    prisonerContactRegistryMockServer.stubSearchContacts(
       contactIds = contactsList.map { it.contactId },
+      prisonerId = prisonerId,
       contactsList = contactsList,
     )
     visitSchedulerMockServer.stubGetVisitHistory(visit.reference, eventList)
@@ -1084,9 +1083,9 @@ class GetVisitBookingDetailsTest : IntegrationTestBase() {
     val expectedRestrictions = listOf(restriction2, restriction1, restriction4, restriction6, restriction5, restriction3)
     alertApiMockServer.stubGetPrisonerAlertsMono(prisonerId, listOf(alert1, alert2, alert3))
     prisonApiMockServer.stubGetPrisonerRestrictions(prisonerId, OffenderRestrictionsDto(1, listOf(restriction1, restriction2, restriction3, restriction4, restriction5, restriction6)))
-    prisonerContactRegistryMockServer.stubSearchPrisonerContacts(
-      prisonerId = prisonerId,
+    prisonerContactRegistryMockServer.stubSearchContacts(
       contactIds = contactsList.map { it.contactId },
+      prisonerId = prisonerId,
       contactsList = contactsList,
     )
     visitSchedulerMockServer.stubGetVisitHistory(visit.reference, eventList)


### PR DESCRIPTION
## What does this PR do?
The format of the URL has changed to make prisonerId optional when looking up contacts. This moves it out of the URL and into the request params.

Update to new endpoint. No functionality change on what is returned