### PR TITLE
VB-6593 - Allow booker to set a language preference for visitor request correspondence

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/dto/booker/registry/AddVisitorToBookerPrisonerRequestDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/dto/booker/registry/AddVisitorToBookerPrisonerRequestDto.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.bo
 
 import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.constraints.NotBlank
+import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.booker.registry.enums.LanguagePreference
 import java.time.LocalDate
 
 data class AddVisitorToBookerPrisonerRequestDto(
@@ -15,4 +16,7 @@ data class AddVisitorToBookerPrisonerRequestDto(
 
   @param:Schema(name = "dateOfBirth", description = "Date of birth of the visitor in request", required = true)
   val dateOfBirth: LocalDate,
+
+  @param:Schema(name = "languagePreference", description = "The language in which your correspondence will be sent", defaultValue = "EN", required = false)
+  val languagePreference: LanguagePreference = LanguagePreference.EN,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/dto/booker/registry/BookerPrisonerVisitorRequestDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/dto/booker/registry/BookerPrisonerVisitorRequestDto.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.bo
 
 import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.constraints.NotBlank
+import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.booker.registry.enums.LanguagePreference
 import java.time.LocalDate
 
 data class BookerPrisonerVisitorRequestDto(
@@ -26,4 +27,7 @@ data class BookerPrisonerVisitorRequestDto(
 
   @param:Schema(description = "Date when the visitor request was added", example = "2000-01-01", required = true)
   val requestedOn: LocalDate,
+
+  @param:Schema(name = "languagePreference", description = "The language in which your correspondence will be sent", required = true)
+  val languagePreference: LanguagePreference,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/dto/booker/registry/CreateVisitorRequestResponseDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/dto/booker/registry/CreateVisitorRequestResponseDto.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.booker.registry
 
 import io.swagger.v3.oas.annotations.media.Schema
+import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.booker.registry.enums.LanguagePreference
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.booker.registry.enums.VisitorRequestsStatus
 
 data class CreateVisitorRequestResponseDto(
@@ -15,4 +16,7 @@ data class CreateVisitorRequestResponseDto(
 
   @param:Schema(description = "The id of the booker's prisoner for the visitor request", example = "AA123456")
   val prisonerId: String,
+
+  @param:Schema(name = "languagePreference", description = "The language in which your correspondence will be sent", required = true)
+  val languagePreference: LanguagePreference,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/dto/booker/registry/PrisonVisitorRequestDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/dto/booker/registry/PrisonVisitorRequestDto.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.bo
 
 import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.constraints.NotBlank
+import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.booker.registry.enums.LanguagePreference
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.booker.registry.enums.VisitorRequestsStatus
 import java.time.LocalDate
 
@@ -38,4 +39,7 @@ data class PrisonVisitorRequestDto(
 
   @param:Schema(description = "The current status of the request", example = "REQUESTED", required = true)
   val status: VisitorRequestsStatus,
+
+  @param:Schema(name = "languagePreference", description = "The language in which your correspondence will be sent", required = true)
+  val languagePreference: LanguagePreference,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/dto/booker/registry/PrisonVisitorRequestListEntryDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/dto/booker/registry/PrisonVisitorRequestListEntryDto.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.bo
 
 import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.constraints.NotBlank
+import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.booker.registry.enums.LanguagePreference
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.prisoner.search.AttributeSearchPrisonerDto
 import java.time.LocalDate
 
@@ -43,6 +44,9 @@ data class PrisonVisitorRequestListEntryDto(
 
   @param:Schema(description = "Date request was submitted", example = "2025-10-28", required = true)
   val requestedOn: LocalDate,
+
+  @param:Schema(name = "languagePreference", description = "The language in which your correspondence will be sent", required = true)
+  val languagePreference: LanguagePreference,
 ) {
   constructor(prisonVisitorRequestDto: PrisonVisitorRequestDto, prisonerInfo: AttributeSearchPrisonerDto?) : this(
     reference = prisonVisitorRequestDto.reference,
@@ -55,5 +59,6 @@ data class PrisonVisitorRequestListEntryDto(
     lastName = prisonVisitorRequestDto.lastName,
     dateOfBirth = prisonVisitorRequestDto.dateOfBirth,
     requestedOn = prisonVisitorRequestDto.requestedOn,
+    languagePreference = prisonVisitorRequestDto.languagePreference,
   )
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/dto/booker/registry/SingleVisitorRequestForReviewDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/dto/booker/registry/SingleVisitorRequestForReviewDto.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.bo
 import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.constraints.NotBlank
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.booker.management.SocialContactsDto
+import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.booker.registry.enums.LanguagePreference
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.booker.registry.enums.VisitorRequestsStatus
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.prisoner.search.PrisonerDto
 import java.time.LocalDate
@@ -51,6 +52,9 @@ data class SingleVisitorRequestForReviewDto(
 
   @param:Schema(description = "Date request was submitted", example = "2025-10-28", required = true)
   val socialContacts: List<SocialContactsDto>,
+
+  @param:Schema(name = "languagePreference", description = "The language in which your correspondence will be sent", required = true)
+  val languagePreference: LanguagePreference,
 ) {
   constructor(request: PrisonVisitorRequestDto, prisonerInfo: PrisonerDto, contacts: List<SocialContactsDto>) : this(
     reference = request.reference,
@@ -65,5 +69,6 @@ data class SingleVisitorRequestForReviewDto(
     requestedOn = request.requestedOn,
     socialContacts = contacts,
     status = request.status,
+    languagePreference = request.languagePreference,
   )
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/dto/booker/registry/enums/LanguagePreference.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/dto/booker/registry/enums/LanguagePreference.kt
@@ -1,0 +1,7 @@
+package uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.booker.registry.enums
+
+@Suppress("unused")
+enum class LanguagePreference {
+  EN,
+  CY,
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/booker/ApproveVisitorRequestTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/booker/ApproveVisitorRequestTest.kt
@@ -12,6 +12,7 @@ import org.springframework.web.reactive.function.BodyInserters
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.controller.PUBLIC_BOOKER_APPROVE_VISITOR_REQUEST
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.booker.registry.ApproveVisitorRequestDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.booker.registry.PrisonVisitorRequestDto
+import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.booker.registry.enums.LanguagePreference
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.booker.registry.enums.VisitorRequestsStatus.APPROVED
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.integration.IntegrationTestBase
 import java.time.LocalDate
@@ -35,6 +36,7 @@ class ApproveVisitorRequestTest : IntegrationTestBase() {
       dateOfBirth = LocalDate.now().minusYears(21),
       requestedOn = LocalDate.now(),
       status = APPROVED,
+      languagePreference = LanguagePreference.EN,
     )
 
     prisonVisitBookerRegistryMockServer.stubApproveVisitorRequest(requestReference, approveVisitorRequestResponse, HttpStatus.OK)
@@ -77,6 +79,7 @@ class ApproveVisitorRequestTest : IntegrationTestBase() {
       dateOfBirth = LocalDate.now().minusYears(21),
       requestedOn = LocalDate.now(),
       status = APPROVED,
+      languagePreference = LanguagePreference.EN,
     )
 
     prisonVisitBookerRegistryMockServer.stubApproveVisitorRequest(requestReference, null, HttpStatus.INTERNAL_SERVER_ERROR)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/booker/BookerAddVisitorRequestTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/booker/BookerAddVisitorRequestTest.kt
@@ -13,6 +13,7 @@ import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.config.
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.controller.PUBLIC_BOOKER_VISITOR_REQUESTS_PATH
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.booker.registry.AddVisitorToBookerPrisonerRequestDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.booker.registry.CreateVisitorRequestResponseDto
+import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.booker.registry.enums.LanguagePreference
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.booker.registry.enums.VisitorRequestValidationErrorCodes
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.booker.registry.enums.VisitorRequestsStatus
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.integration.IntegrationTestBase
@@ -38,8 +39,8 @@ class BookerAddVisitorRequestTest : IntegrationTestBase() {
   @Test
   fun `when call to booker registry is successful a CREATED response code is returned`() {
     // Given
-    val addVisitorRequest = AddVisitorToBookerPrisonerRequestDto("Test", "User", LocalDate.of(2000, 1, 1))
-    val response = CreateVisitorRequestResponseDto(reference = "random-ref", status = VisitorRequestsStatus.REQUESTED, bookerReference = bookerReference, prisonerId = prisonerId)
+    val addVisitorRequest = AddVisitorToBookerPrisonerRequestDto("Test", "User", LocalDate.of(2000, 1, 1), LanguagePreference.EN)
+    val response = CreateVisitorRequestResponseDto(reference = "random-ref", status = VisitorRequestsStatus.REQUESTED, bookerReference = bookerReference, prisonerId = prisonerId, LanguagePreference.EN)
     prisonVisitBookerRegistryMockServer.stubAddVisitorRequest(bookerReference, prisonerId, addVisitorRequest, response, HttpStatus.CREATED)
 
     // When
@@ -53,7 +54,7 @@ class BookerAddVisitorRequestTest : IntegrationTestBase() {
   @Test
   fun `when call to booker registry throws a validation error then validation error is returned`() {
     // Given
-    val addVisitorRequest = AddVisitorToBookerPrisonerRequestDto("Test", "User", LocalDate.of(2000, 1, 1))
+    val addVisitorRequest = AddVisitorToBookerPrisonerRequestDto("Test", "User", LocalDate.of(2000, 1, 1), LanguagePreference.EN)
     val bookerVisitorRequestValidationErrorResponse = BookerVisitorRequestValidationErrorResponse(status = HttpStatus.UNPROCESSABLE_CONTENT.value(), validationError = VisitorRequestValidationErrorCodes.VISITOR_ALREADY_EXISTS)
     prisonVisitBookerRegistryMockServer.stubAddVisitorRequestValidationFailure(bookerReference, prisonerId, bookerVisitorRequestValidationErrorResponse)
 
@@ -70,8 +71,8 @@ class BookerAddVisitorRequestTest : IntegrationTestBase() {
   @Test
   fun `when call to booker registry fails with a NOT_FOUND error then NOT_FOUND error code is returned`() {
     // Given
-    val addVisitorRequest = AddVisitorToBookerPrisonerRequestDto("Test", "User", LocalDate.of(2000, 1, 1))
-    val response = CreateVisitorRequestResponseDto(reference = "random-ref", status = VisitorRequestsStatus.REQUESTED, bookerReference = bookerReference, prisonerId = prisonerId)
+    val addVisitorRequest = AddVisitorToBookerPrisonerRequestDto("Test", "User", LocalDate.of(2000, 1, 1), LanguagePreference.EN)
+    val response = CreateVisitorRequestResponseDto(reference = "random-ref", status = VisitorRequestsStatus.REQUESTED, bookerReference = bookerReference, prisonerId = prisonerId, LanguagePreference.EN)
     prisonVisitBookerRegistryMockServer.stubAddVisitorRequest(bookerReference, prisonerId, addVisitorRequest, response, HttpStatus.NOT_FOUND)
 
     // When
@@ -85,8 +86,8 @@ class BookerAddVisitorRequestTest : IntegrationTestBase() {
   @Test
   fun `when call to booker registry fails with an INTERNAL_SERVER_ERROR error then INTERNAL_SERVER_ERROR error code is returned`() {
     // Given
-    val addVisitorRequest = AddVisitorToBookerPrisonerRequestDto("Test", "User", LocalDate.of(2000, 1, 1))
-    val response = CreateVisitorRequestResponseDto(reference = "random-ref", status = VisitorRequestsStatus.REQUESTED, bookerReference = bookerReference, prisonerId = prisonerId)
+    val addVisitorRequest = AddVisitorToBookerPrisonerRequestDto("Test", "User", LocalDate.of(2000, 1, 1), LanguagePreference.EN)
+    val response = CreateVisitorRequestResponseDto(reference = "random-ref", status = VisitorRequestsStatus.REQUESTED, bookerReference = bookerReference, prisonerId = prisonerId, LanguagePreference.EN)
 
     prisonVisitBookerRegistryMockServer.stubAddVisitorRequest(bookerReference, prisonerId, addVisitorRequest, response, HttpStatus.INTERNAL_SERVER_ERROR)
 
@@ -101,8 +102,8 @@ class BookerAddVisitorRequestTest : IntegrationTestBase() {
   @Test
   fun `when booker authorisation is called without correct role then FORBIDDEN status is returned`() {
     // When
-    val addVisitorRequest = AddVisitorToBookerPrisonerRequestDto("Test", "User", LocalDate.of(2000, 1, 1))
-    val response = CreateVisitorRequestResponseDto(reference = "random-ref", status = VisitorRequestsStatus.REQUESTED, bookerReference = bookerReference, prisonerId = prisonerId)
+    val addVisitorRequest = AddVisitorToBookerPrisonerRequestDto("Test", "User", LocalDate.of(2000, 1, 1), LanguagePreference.EN)
+    val response = CreateVisitorRequestResponseDto(reference = "random-ref", status = VisitorRequestsStatus.REQUESTED, bookerReference = bookerReference, prisonerId = prisonerId, LanguagePreference.EN)
 
     prisonVisitBookerRegistryMockServer.stubAddVisitorRequest(bookerReference, prisonerId, addVisitorRequest, response, HttpStatus.CREATED)
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/booker/GetActiveVisitorRequestsForBookerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/booker/GetActiveVisitorRequestsForBookerTest.kt
@@ -12,6 +12,7 @@ import org.springframework.http.HttpStatus
 import org.springframework.test.web.reactive.server.WebTestClient
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.controller.PUBLIC_BOOKER_GET_VISITOR_REQUESTS_BY_BOOKER_REFERENCE
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.booker.registry.BookerPrisonerVisitorRequestDto
+import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.booker.registry.enums.LanguagePreference
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.integration.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.integration.TestObjectMapper
 import java.time.LocalDate
@@ -23,10 +24,10 @@ class GetActiveVisitorRequestsForBookerTest : IntegrationTestBase() {
   fun `when booker has active visitor requests then all active visitor requests are returned`() {
     // Given
     val bookerReference = "booker-ref"
-    val request1 = BookerPrisonerVisitorRequestDto(reference = "1", prisonerId = "A11", firstName = "VisitorOne", lastName = "First", dateOfBirth = LocalDate.of(1980, 1, 1), requestedOn = LocalDate.of(2026, 1, 31))
-    val request2 = BookerPrisonerVisitorRequestDto(reference = "2", prisonerId = "A11", firstName = "VisitorTwo", lastName = "Second", dateOfBirth = LocalDate.of(1990, 2, 2), requestedOn = LocalDate.of(2026, 2, 28))
-    val request3 = BookerPrisonerVisitorRequestDto(reference = "3", prisonerId = "A12", firstName = "VisitorThree", lastName = "Third", dateOfBirth = LocalDate.of(2000, 3, 3), requestedOn = LocalDate.of(2026, 3, 31))
-    val request4 = BookerPrisonerVisitorRequestDto(reference = "4", prisonerId = "A12", firstName = "VisitorFour", lastName = "Fourth", dateOfBirth = LocalDate.of(2010, 4, 4), requestedOn = LocalDate.of(2026, 4, 30))
+    val request1 = BookerPrisonerVisitorRequestDto(reference = "1", prisonerId = "A11", firstName = "VisitorOne", lastName = "First", dateOfBirth = LocalDate.of(1980, 1, 1), requestedOn = LocalDate.of(2026, 1, 31), LanguagePreference.EN)
+    val request2 = BookerPrisonerVisitorRequestDto(reference = "2", prisonerId = "A11", firstName = "VisitorTwo", lastName = "Second", dateOfBirth = LocalDate.of(1990, 2, 2), requestedOn = LocalDate.of(2026, 2, 28), LanguagePreference.EN)
+    val request3 = BookerPrisonerVisitorRequestDto(reference = "3", prisonerId = "A12", firstName = "VisitorThree", lastName = "Third", dateOfBirth = LocalDate.of(2000, 3, 3), requestedOn = LocalDate.of(2026, 3, 31), LanguagePreference.CY)
+    val request4 = BookerPrisonerVisitorRequestDto(reference = "4", prisonerId = "A12", firstName = "VisitorFour", lastName = "Fourth", dateOfBirth = LocalDate.of(2010, 4, 4), requestedOn = LocalDate.of(2026, 4, 30), LanguagePreference.CY)
     prisonVisitBookerRegistryMockServer.stubGetActiveVisitorRequestsForBooker(bookerReference, listOf(request1, request2, request3, request4))
 
     // When
@@ -116,6 +117,7 @@ class GetActiveVisitorRequestsForBookerTest : IntegrationTestBase() {
     Assertions.assertThat(bookerPrisonerVisitorRequestDto.lastName).isEqualTo(requestedVisitorRequestDto.lastName)
     Assertions.assertThat(bookerPrisonerVisitorRequestDto.dateOfBirth).isEqualTo(requestedVisitorRequestDto.dateOfBirth)
     Assertions.assertThat(bookerPrisonerVisitorRequestDto.requestedOn).isEqualTo(requestedVisitorRequestDto.requestedOn)
+    Assertions.assertThat(bookerPrisonerVisitorRequestDto.languagePreference).isEqualTo(requestedVisitorRequestDto.languagePreference)
   }
 
   private fun getResults(returnResult: WebTestClient.BodyContentSpec): List<BookerPrisonerVisitorRequestDto> = TestObjectMapper.mapper.readValue(returnResult.returnResult().responseBody, Array<BookerPrisonerVisitorRequestDto>::class.java).toList()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/booker/GetSingleVisitorRequestForReviewTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/booker/GetSingleVisitorRequestForReviewTest.kt
@@ -15,6 +15,7 @@ import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.boo
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.booker.registry.PrisonVisitorRequestDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.booker.registry.SingleVisitorRequestForReviewDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.booker.registry.admin.BookerInfoDto
+import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.booker.registry.enums.LanguagePreference
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.booker.registry.enums.VisitorRequestsStatus.APPROVED
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.booker.registry.enums.VisitorRequestsStatus.REJECTED
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.booker.registry.enums.VisitorRequestsStatus.REQUESTED
@@ -66,7 +67,7 @@ class GetSingleVisitorRequestForReviewTest : IntegrationTestBase() {
 
     prisonVisitBookerRegistryMockServer.stubGetSingleVisitorRequest(
       requestReference,
-      visitorRequest = PrisonVisitorRequestDto(requestReference, booker.reference, booker.email, prisonerId, "firstName", "lastName", LocalDate.now().minusYears(21), LocalDate.now(), status = REQUESTED),
+      visitorRequest = PrisonVisitorRequestDto(requestReference, booker.reference, booker.email, prisonerId, "firstName", "lastName", LocalDate.now().minusYears(21), LocalDate.now(), status = REQUESTED, languagePreference = LanguagePreference.EN),
     )
 
     prisonVisitBookerRegistryMockServer.stubGetBookerByBookerReference(booker.reference, booker = booker)
@@ -89,6 +90,9 @@ class GetSingleVisitorRequestForReviewTest : IntegrationTestBase() {
     val response = getResults(responseSpec.expectBody())
 
     assertThat(response.reference).isEqualTo(requestReference)
+    assertThat(response.firstName).isEqualTo("firstName")
+    assertThat(response.lastName).isEqualTo("lastName")
+    assertThat(response.languagePreference).isEqualTo(LanguagePreference.EN)
 
     verify(prisonVisitBookerRegistryClientSpy, times(1)).getSingleVisitorRequest(any())
     verify(prisonVisitBookerRegistryClientSpy, times(1)).getBookerByBookerReference(any())
@@ -135,7 +139,7 @@ class GetSingleVisitorRequestForReviewTest : IntegrationTestBase() {
 
     prisonVisitBookerRegistryMockServer.stubGetSingleVisitorRequest(
       requestReference,
-      visitorRequest = PrisonVisitorRequestDto(requestReference, booker.reference, booker.email, prisonerId, "firstName", "lastName", LocalDate.now().minusYears(21), LocalDate.now(), status = APPROVED),
+      visitorRequest = PrisonVisitorRequestDto(requestReference, booker.reference, booker.email, prisonerId, "firstName", "lastName", LocalDate.now().minusYears(21), LocalDate.now(), status = APPROVED, languagePreference = LanguagePreference.EN),
     )
 
     prisonVisitBookerRegistryMockServer.stubGetBookerByBookerReference(booker.reference, booker = booker)
@@ -184,7 +188,7 @@ class GetSingleVisitorRequestForReviewTest : IntegrationTestBase() {
 
     prisonVisitBookerRegistryMockServer.stubGetSingleVisitorRequest(
       requestReference,
-      visitorRequest = PrisonVisitorRequestDto(requestReference, booker.reference, booker.email, prisonerId, "firstName", "lastName", LocalDate.now().minusYears(21), LocalDate.now(), status = REJECTED),
+      visitorRequest = PrisonVisitorRequestDto(requestReference, booker.reference, booker.email, prisonerId, "firstName", "lastName", LocalDate.now().minusYears(21), LocalDate.now(), status = REJECTED, languagePreference = LanguagePreference.EN),
     )
 
     prisonVisitBookerRegistryMockServer.stubGetBookerByBookerReference(booker.reference, booker = booker)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/booker/GetVisitorRequestsForPrisonTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/booker/GetVisitorRequestsForPrisonTest.kt
@@ -14,6 +14,7 @@ import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.control
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.controller.PUBLIC_BOOKER_GET_VISITOR_REQUESTS_COUNT_BY_PRISON_CODE
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.booker.registry.PrisonVisitorRequestDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.booker.registry.PrisonVisitorRequestListEntryDto
+import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.booker.registry.enums.LanguagePreference
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.booker.registry.enums.VisitorRequestsStatus.REQUESTED
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.integration.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.integration.TestObjectMapper
@@ -28,7 +29,7 @@ class GetVisitorRequestsForPrisonTest : IntegrationTestBase() {
     val prisonCode = "HEI"
     val prisonerId = "AA123456"
 
-    prisonVisitBookerRegistryMockServer.stubGetVisitorRequestsForPrison(prisonCode, listOf(PrisonVisitorRequestDto(reference = "abc-def-ghi", bookerReference = "xyz-rhf-sjd", bookerEmail = "test@test.com", prisonerId, firstName = "VisitorTwo", lastName = "Second", dateOfBirth = LocalDate.of(1990, 2, 2), requestedOn = LocalDate.now(), status = REQUESTED)))
+    prisonVisitBookerRegistryMockServer.stubGetVisitorRequestsForPrison(prisonCode, listOf(PrisonVisitorRequestDto(reference = "abc-def-ghi", bookerReference = "xyz-rhf-sjd", bookerEmail = "test@test.com", prisonerId, firstName = "VisitorTwo", lastName = "Second", dateOfBirth = LocalDate.of(1990, 2, 2), requestedOn = LocalDate.now(), status = REQUESTED, LanguagePreference.EN)))
     prisonOffenderSearchMockServer.stubGetPrisonersByPrisonerIds(listOf(prisonerId), listOf(createPrisoner(prisonerId, "John", "Smith", LocalDate.now().minusYears(21), prisonCode, convictedStatus = "Convicted")))
 
     // When
@@ -47,7 +48,7 @@ class GetVisitorRequestsForPrisonTest : IntegrationTestBase() {
     val prisonCode = "HEI"
     val prisonerId = "AA123456"
 
-    prisonVisitBookerRegistryMockServer.stubGetVisitorRequestsForPrison(prisonCode, listOf(PrisonVisitorRequestDto(reference = "abc-def-ghi", bookerReference = "xyz-rhf-sjd", bookerEmail = "test@test.com", prisonerId, firstName = "VisitorTwo", lastName = "Second", dateOfBirth = LocalDate.of(1990, 2, 2), requestedOn = LocalDate.now(), status = REQUESTED)))
+    prisonVisitBookerRegistryMockServer.stubGetVisitorRequestsForPrison(prisonCode, listOf(PrisonVisitorRequestDto(reference = "abc-def-ghi", bookerReference = "xyz-rhf-sjd", bookerEmail = "test@test.com", prisonerId, firstName = "VisitorTwo", lastName = "Second", dateOfBirth = LocalDate.of(1990, 2, 2), requestedOn = LocalDate.now(), status = REQUESTED, LanguagePreference.EN)))
     prisonOffenderSearchMockServer.stubGetPrisonersByPrisonerIds(listOf(prisonerId), null, HttpStatus.NOT_FOUND)
 
     // When

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/booker/RejectVisitorRequestTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/booker/RejectVisitorRequestTest.kt
@@ -13,6 +13,7 @@ import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.control
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.controller.PUBLIC_BOOKER_REJECT_VISITOR_REQUEST
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.booker.registry.PrisonVisitorRequestDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.booker.registry.RejectVisitorRequestDto
+import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.booker.registry.enums.LanguagePreference
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.booker.registry.enums.VisitorRequestRejectionReason
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.booker.registry.enums.VisitorRequestsStatus.REJECTED
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.integration.IntegrationTestBase
@@ -38,6 +39,7 @@ class RejectVisitorRequestTest : IntegrationTestBase() {
       dateOfBirth = LocalDate.now().minusYears(21),
       requestedOn = LocalDate.now(),
       status = REJECTED,
+      languagePreference = LanguagePreference.EN,
     )
 
     prisonVisitBookerRegistryMockServer.stubRejectVisitorRequest(requestReference, rejectVisitorRequestResponse, HttpStatus.OK)


### PR DESCRIPTION
## What does this PR do?

Allow booker to set a language preference for visitor request correspondence

Let the booker choose at the point of creating a visitor request, which language they would like all further communication to be in. Current options will be EN english and CY welsh.

This will be used eventually by our notification service to determine which emails / sms to send in their chosen language.

## JIRA Links
https://dsdmoj.atlassian.net/browse/VB-6593
https://dsdmoj.atlassian.net/browse/VB-6745