### PR TITLE
VB-6495 - Expose session vo restriction in all DTOs which require it

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/dto/visit/allocation/enums/VisitOrderHistoryAttributeType.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/dto/visit/allocation/enums/VisitOrderHistoryAttributeType.kt
@@ -7,4 +7,5 @@ enum class VisitOrderHistoryAttributeType {
   OLD_PRISONER_ID,
   NEW_PRISONER_ID,
   ADJUSTMENT_REASON_TYPE,
+  VISIT_ORDER_TYPE_USED,
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/dto/visit/scheduler/AvailableVisitSessionDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/dto/visit/scheduler/AvailableVisitSessionDto.kt
@@ -5,6 +5,7 @@ import jakarta.validation.Valid
 import jakarta.validation.constraints.FutureOrPresent
 import jakarta.validation.constraints.NotNull
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.visit.scheduler.enums.SessionRestriction
+import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.visit.scheduler.enums.SessionTemplateVisitOrderRestrictionType
 import java.time.LocalDate
 
 @Schema(description = "Visit Session")
@@ -28,4 +29,7 @@ data class AvailableVisitSessionDto(
 
   @param:Schema(description = "Does session need review, defaults to false", example = "true", required = true)
   var sessionForReview: Boolean = false,
+
+  @param:Schema(description = "Session vo restriction", required = true)
+  val visitOrderRestriction: SessionTemplateVisitOrderRestrictionType,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/dto/visit/scheduler/SessionScheduleDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/dto/visit/scheduler/SessionScheduleDto.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.vi
 import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.NotNull
+import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.visit.scheduler.enums.SessionTemplateVisitOrderRestrictionType
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.visit.scheduler.enums.VisitType
 
 @Schema(description = "Session schedule")
@@ -55,4 +56,7 @@ data class SessionScheduleDto(
 
   @param:Schema(description = "visit room name", example = "Visits Room", required = true)
   val visitRoom: String,
+
+  @param:Schema(description = "Session vo restriction", required = true)
+  val visitOrderRestriction: SessionTemplateVisitOrderRestrictionType,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/dto/visit/scheduler/VisitSessionDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/dto/visit/scheduler/VisitSessionDto.kt
@@ -7,6 +7,7 @@ import jakarta.validation.Valid
 import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.NotNull
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.visit.scheduler.enums.SessionConflict
+import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.visit.scheduler.enums.SessionTemplateVisitOrderRestrictionType
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.visit.scheduler.enums.VisitType
 import java.time.LocalDateTime
 
@@ -24,6 +25,9 @@ data class VisitSessionDto(
   @param:Schema(description = "The type of visits taking place within this session", example = "SOCIAL", required = true)
   @field:NotNull
   val visitType: VisitType,
+
+  @param:Schema(description = "Session vo restriction", required = true)
+  val visitOrderRestriction: SessionTemplateVisitOrderRestrictionType,
 
   @param:JsonProperty("prisonId")
   @param:JsonAlias("prisonCode")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/dto/visit/scheduler/enums/SessionTemplateVisitOrderRestrictionType.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/dto/visit/scheduler/enums/SessionTemplateVisitOrderRestrictionType.kt
@@ -1,0 +1,9 @@
+package uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.visit.scheduler.enums
+
+@Suppress("unused")
+enum class SessionTemplateVisitOrderRestrictionType {
+  VO_PVO,
+  VO,
+  PVO,
+  NONE,
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/dto/visit/scheduler/sessions/VisitSessionV2Dto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/dto/visit/scheduler/sessions/VisitSessionV2Dto.kt
@@ -7,6 +7,7 @@ import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.NotNull
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.visit.scheduler.VisitSessionDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.visit.scheduler.enums.SessionConflict
+import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.visit.scheduler.enums.SessionTemplateVisitOrderRestrictionType
 import java.time.LocalTime
 
 data class VisitSessionV2Dto(
@@ -42,6 +43,9 @@ data class VisitSessionV2Dto(
 
   @param:Schema(description = "Session conflicts", required = false)
   val sessionConflicts: MutableSet<@Valid SessionConflict>? = mutableSetOf(),
+
+  @param:Schema(description = "Session vo restriction", required = true)
+  val visitOrderRestriction: SessionTemplateVisitOrderRestrictionType,
 ) {
   constructor(visitSessionDto: VisitSessionDto) : this (
     sessionTemplateReference = visitSessionDto.sessionTemplateReference,
@@ -53,5 +57,6 @@ data class VisitSessionV2Dto(
     startTime = visitSessionDto.startTimestamp.toLocalTime(),
     endTime = visitSessionDto.endTimestamp.toLocalTime(),
     sessionConflicts = visitSessionDto.sessionConflicts,
+    visitOrderRestriction = visitSessionDto.visitOrderRestriction,
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/IntegrationTestBase.kt
@@ -55,6 +55,7 @@ import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.vis
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.visit.scheduler.enums.ApplicationStatus
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.visit.scheduler.enums.OutcomeStatus
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.visit.scheduler.enums.SessionRestriction
+import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.visit.scheduler.enums.SessionTemplateVisitOrderRestrictionType
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.visit.scheduler.enums.UserType
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.visit.scheduler.enums.UserType.PUBLIC
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.visit.scheduler.enums.UserType.STAFF
@@ -436,11 +437,13 @@ abstract class IntegrationTestBase {
     sessionTemplateReference: String,
     startTimestamp: LocalDateTime = LocalDateTime.now(),
     endTimestamp: LocalDateTime = LocalDateTime.now().plusHours(1),
+    visitOrderRestriction: SessionTemplateVisitOrderRestrictionType = SessionTemplateVisitOrderRestrictionType.NONE,
   ): VisitSessionDto = VisitSessionDto(
     sessionTemplateReference = sessionTemplateReference,
     prisonCode = prisonCode,
     visitRoom = "Visit Main Hall",
     visitType = VisitType.SOCIAL,
+    visitOrderRestriction = visitOrderRestriction,
     closedVisitCapacity = 5,
     openVisitCapacity = 30,
     startTimestamp = startTimestamp,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/allocation/GetVisitOrderHistoryForPrisonerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/allocation/GetVisitOrderHistoryForPrisonerTest.kt
@@ -53,7 +53,7 @@ class GetVisitOrderHistoryForPrisonerTest : IntegrationTestBase() {
     val incentiveLevels = listOf(IncentiveLevelDto("STD", "Standard"), IncentiveLevelDto("ENH", "Enhanced"))
     val visitOrderHistory1 = VisitOrderHistoryDto(VisitOrderHistoryType.MIGRATION, LocalDateTime.now().minusDays(10), 10, null, 3, null, userName = "user1", attributes = emptyList())
     val visitOrderHistory2 = VisitOrderHistoryDto(VisitOrderHistoryType.PRISONER_BALANCE_RESET, LocalDateTime.now().minusDays(9), 0, null, 0, null, userName = "user2", attributes = emptyList())
-    val visitOrderHistory3 = VisitOrderHistoryDto(VisitOrderHistoryType.ALLOCATION_USED_BY_VISIT, LocalDateTime.now().minusDays(8), -1, null, 0, null, userName = "SYSTEM", attributes = listOf(VisitOrderHistoryAttributesDto(VisitOrderHistoryAttributeType.VISIT_REFERENCE, "aa-bb-cc-dd")))
+    val visitOrderHistory3 = VisitOrderHistoryDto(VisitOrderHistoryType.ALLOCATION_USED_BY_VISIT, LocalDateTime.now().minusDays(8), -1, null, 0, null, userName = "SYSTEM", attributes = listOf(VisitOrderHistoryAttributesDto(VisitOrderHistoryAttributeType.VISIT_REFERENCE, "aa-bb-cc-dd"), VisitOrderHistoryAttributesDto(VisitOrderHistoryAttributeType.VISIT_ORDER_TYPE_USED, "VO")))
 
     // this entry needs to be ignored as balance does not change
     val visitOrderHistory4 = VisitOrderHistoryDto(VisitOrderHistoryType.SYNC_FROM_NOMIS, LocalDateTime.now().minusDays(7), -1, null, 0, null, userName = "SYSTEM", attributes = emptyList())
@@ -77,7 +77,7 @@ class GetVisitOrderHistoryForPrisonerTest : IntegrationTestBase() {
     assertVisitOrderHistory(visitOrderHistory[1], visitOrderHistory4, 0, 0, "SYSTEM")
     assertVisitOrderHistoryAttributes(visitOrderHistory4.attributes, emptyList())
     assertVisitOrderHistory(visitOrderHistory[2], visitOrderHistory3, -1, 0, "SYSTEM")
-    assertVisitOrderHistoryAttributes(visitOrderHistory3.attributes, listOf(Pair(VisitOrderHistoryAttributeType.VISIT_REFERENCE, "aa-bb-cc-dd")))
+    assertVisitOrderHistoryAttributes(visitOrderHistory3.attributes, listOf(Pair(VisitOrderHistoryAttributeType.VISIT_REFERENCE, "aa-bb-cc-dd"), Pair(VisitOrderHistoryAttributeType.VISIT_ORDER_TYPE_USED, "VO")))
     assertVisitOrderHistory(visitOrderHistory[3], visitOrderHistory2, -10, -3, "Sarah Jones")
     assertVisitOrderHistoryAttributes(visitOrderHistory2.attributes, emptyList())
     assertVisitOrderHistory(visitOrderHistory[4], visitOrderHistory1, 0, 0, "John Smith")
@@ -121,7 +121,7 @@ class GetVisitOrderHistoryForPrisonerTest : IntegrationTestBase() {
     val incentiveLevels = listOf(IncentiveLevelDto("STD", "Standard"), IncentiveLevelDto("ENH", "Enhanced"))
     val visitOrderHistory1 = VisitOrderHistoryDto(VisitOrderHistoryType.MIGRATION, LocalDateTime.now().minusDays(10), 10, null, 3, null, userName = "user1", attributes = emptyList())
     val visitOrderHistory2 = VisitOrderHistoryDto(VisitOrderHistoryType.PRISONER_BALANCE_RESET, LocalDateTime.now().minusDays(9), 0, null, 0, null, userName = "user2", attributes = emptyList())
-    val visitOrderHistory3 = VisitOrderHistoryDto(VisitOrderHistoryType.ALLOCATION_USED_BY_VISIT, LocalDateTime.now().minusDays(8), -1, null, 0, null, userName = "SYSTEM", attributes = listOf(VisitOrderHistoryAttributesDto(VisitOrderHistoryAttributeType.VISIT_REFERENCE, "aa-bb-cc-dd")))
+    val visitOrderHistory3 = VisitOrderHistoryDto(VisitOrderHistoryType.ALLOCATION_USED_BY_VISIT, LocalDateTime.now().minusDays(8), -1, null, 0, null, userName = "SYSTEM", attributes = listOf(VisitOrderHistoryAttributesDto(VisitOrderHistoryAttributeType.VISIT_REFERENCE, "aa-bb-cc-dd"), VisitOrderHistoryAttributesDto(VisitOrderHistoryAttributeType.VISIT_ORDER_TYPE_USED, "VO")))
 
     // this entry needs to be ignored as balance does not change
     val visitOrderHistory4 = VisitOrderHistoryDto(VisitOrderHistoryType.SYNC_FROM_NOMIS, LocalDateTime.now().minusDays(7), -1, null, 0, null, userName = "SYSTEM", attributes = emptyList())
@@ -165,7 +165,7 @@ class GetVisitOrderHistoryForPrisonerTest : IntegrationTestBase() {
     val incentiveLevels = listOf(IncentiveLevelDto("STD", "Standard"), IncentiveLevelDto("ENH", "Enhanced"))
     val visitOrderHistory1 = VisitOrderHistoryDto(VisitOrderHistoryType.MIGRATION, LocalDateTime.now().minusDays(10), 10, null, 3, null, userName = "user1", attributes = emptyList())
     val visitOrderHistory2 = VisitOrderHistoryDto(VisitOrderHistoryType.PRISONER_BALANCE_RESET, LocalDateTime.now().minusDays(9), 0, null, 0, null, userName = "user2", attributes = emptyList())
-    val visitOrderHistory3 = VisitOrderHistoryDto(VisitOrderHistoryType.ALLOCATION_USED_BY_VISIT, LocalDateTime.now().minusDays(8), -1, null, 0, null, userName = "SYSTEM", attributes = listOf(VisitOrderHistoryAttributesDto(VisitOrderHistoryAttributeType.VISIT_REFERENCE, "aa-bb-cc-dd")))
+    val visitOrderHistory3 = VisitOrderHistoryDto(VisitOrderHistoryType.ALLOCATION_USED_BY_VISIT, LocalDateTime.now().minusDays(8), -1, null, 0, null, userName = "SYSTEM", attributes = listOf(VisitOrderHistoryAttributesDto(VisitOrderHistoryAttributeType.VISIT_REFERENCE, "aa-bb-cc-dd"), VisitOrderHistoryAttributesDto(VisitOrderHistoryAttributeType.VISIT_ORDER_TYPE_USED, "VO")))
 
     // this entry needs to be ignored as balance does not change
     val visitOrderHistory4 = VisitOrderHistoryDto(VisitOrderHistoryType.SYNC_FROM_NOMIS, LocalDateTime.now().minusDays(7), -1, null, 0, null, userName = "SYSTEM", attributes = emptyList())
@@ -190,7 +190,7 @@ class GetVisitOrderHistoryForPrisonerTest : IntegrationTestBase() {
     assertVisitOrderHistory(visitOrderHistory[1], visitOrderHistory4, 0, 0, "SYSTEM")
     assertVisitOrderHistoryAttributes(visitOrderHistory4.attributes, emptyList())
     assertVisitOrderHistory(visitOrderHistory[2], visitOrderHistory3, -1, 0, "SYSTEM")
-    assertVisitOrderHistoryAttributes(visitOrderHistory3.attributes, listOf(Pair(VisitOrderHistoryAttributeType.VISIT_REFERENCE, "aa-bb-cc-dd")))
+    assertVisitOrderHistoryAttributes(visitOrderHistory3.attributes, listOf(Pair(VisitOrderHistoryAttributeType.VISIT_REFERENCE, "aa-bb-cc-dd"), Pair(VisitOrderHistoryAttributeType.VISIT_ORDER_TYPE_USED, "VO")))
 
     assertVisitOrderHistory(visitOrderHistory[3], visitOrderHistory2, -10, -3, "Sarah Jones")
     assertVisitOrderHistoryAttributes(visitOrderHistory2.attributes, emptyList())
@@ -216,7 +216,7 @@ class GetVisitOrderHistoryForPrisonerTest : IntegrationTestBase() {
     val incentiveLevels = listOf(IncentiveLevelDto("STD", "Standard"), IncentiveLevelDto("ENH", "Enhanced"))
     val visitOrderHistory1 = VisitOrderHistoryDto(VisitOrderHistoryType.MIGRATION, LocalDateTime.now().minusDays(10), 10, null, 3, null, userName = "user1", attributes = emptyList())
     val visitOrderHistory2 = VisitOrderHistoryDto(VisitOrderHistoryType.PRISONER_BALANCE_RESET, LocalDateTime.now().minusDays(9), 0, null, 0, null, userName = "user2", attributes = emptyList())
-    val visitOrderHistory3 = VisitOrderHistoryDto(VisitOrderHistoryType.ALLOCATION_USED_BY_VISIT, LocalDateTime.now().minusDays(8), -1, null, 0, null, userName = "SYSTEM", attributes = listOf(VisitOrderHistoryAttributesDto(VisitOrderHistoryAttributeType.VISIT_REFERENCE, "aa-bb-cc-dd")))
+    val visitOrderHistory3 = VisitOrderHistoryDto(VisitOrderHistoryType.ALLOCATION_USED_BY_VISIT, LocalDateTime.now().minusDays(8), -1, null, 0, null, userName = "SYSTEM", attributes = listOf(VisitOrderHistoryAttributesDto(VisitOrderHistoryAttributeType.VISIT_REFERENCE, "aa-bb-cc-dd"), VisitOrderHistoryAttributesDto(VisitOrderHistoryAttributeType.VISIT_ORDER_TYPE_USED, "VO")))
 
     // this entry needs to be ignored as balance does not change
     val visitOrderHistory4 = VisitOrderHistoryDto(VisitOrderHistoryType.SYNC_FROM_NOMIS, LocalDateTime.now().minusDays(7), -1, null, 0, null, userName = "SYSTEM", attributes = emptyList())
@@ -241,7 +241,7 @@ class GetVisitOrderHistoryForPrisonerTest : IntegrationTestBase() {
     assertVisitOrderHistory(visitOrderHistory[1], visitOrderHistory4, 0, 0, "SYSTEM")
     assertVisitOrderHistoryAttributes(visitOrderHistory4.attributes, emptyList())
     assertVisitOrderHistory(visitOrderHistory[2], visitOrderHistory3, -1, 0, "SYSTEM")
-    assertVisitOrderHistoryAttributes(visitOrderHistory3.attributes, listOf(Pair(VisitOrderHistoryAttributeType.VISIT_REFERENCE, "aa-bb-cc-dd")))
+    assertVisitOrderHistoryAttributes(visitOrderHistory3.attributes, listOf(Pair(VisitOrderHistoryAttributeType.VISIT_REFERENCE, "aa-bb-cc-dd"), Pair(VisitOrderHistoryAttributeType.VISIT_ORDER_TYPE_USED, "VO")))
     assertVisitOrderHistory(visitOrderHistory[3], visitOrderHistory2, -10, -3, "Sarah Jones")
     assertVisitOrderHistoryAttributes(visitOrderHistory2.attributes, emptyList())
     assertVisitOrderHistory(visitOrderHistory[4], visitOrderHistory1, 0, 0, "John Smith")
@@ -266,7 +266,7 @@ class GetVisitOrderHistoryForPrisonerTest : IntegrationTestBase() {
     val incentiveLevels = listOf(IncentiveLevelDto("STD", "Standard"), IncentiveLevelDto("ENH", "Enhanced"))
     val visitOrderHistory1 = VisitOrderHistoryDto(VisitOrderHistoryType.MIGRATION, LocalDateTime.now().minusDays(10), 10, null, 3, null, userName = "user1", attributes = emptyList())
     val visitOrderHistory2 = VisitOrderHistoryDto(VisitOrderHistoryType.PRISONER_BALANCE_RESET, LocalDateTime.now().minusDays(9), 0, null, 0, null, userName = "user2", attributes = emptyList())
-    val visitOrderHistory3 = VisitOrderHistoryDto(VisitOrderHistoryType.ALLOCATION_USED_BY_VISIT, LocalDateTime.now().minusDays(8), -1, null, 0, null, userName = "SYSTEM", attributes = listOf(VisitOrderHistoryAttributesDto(VisitOrderHistoryAttributeType.VISIT_REFERENCE, "aa-bb-cc-dd")))
+    val visitOrderHistory3 = VisitOrderHistoryDto(VisitOrderHistoryType.ALLOCATION_USED_BY_VISIT, LocalDateTime.now().minusDays(8), -1, null, 0, null, userName = "SYSTEM", attributes = listOf(VisitOrderHistoryAttributesDto(VisitOrderHistoryAttributeType.VISIT_REFERENCE, "aa-bb-cc-dd"), VisitOrderHistoryAttributesDto(VisitOrderHistoryAttributeType.VISIT_ORDER_TYPE_USED, "VO")))
 
     // this entry needs to be ignored as balance does not change
     val visitOrderHistory4 = VisitOrderHistoryDto(VisitOrderHistoryType.SYNC_FROM_NOMIS, LocalDateTime.now().minusDays(7), -1, null, 0, null, userName = "SYSTEM", attributes = emptyList())
@@ -291,7 +291,7 @@ class GetVisitOrderHistoryForPrisonerTest : IntegrationTestBase() {
     assertVisitOrderHistory(visitOrderHistory[1], visitOrderHistory4, 0, 0, "SYSTEM")
     assertVisitOrderHistoryAttributes(visitOrderHistory4.attributes, emptyList())
     assertVisitOrderHistory(visitOrderHistory[2], visitOrderHistory3, -1, 0, "SYSTEM")
-    assertVisitOrderHistoryAttributes(visitOrderHistory3.attributes, listOf(Pair(VisitOrderHistoryAttributeType.VISIT_REFERENCE, "aa-bb-cc-dd")))
+    assertVisitOrderHistoryAttributes(visitOrderHistory3.attributes, listOf(Pair(VisitOrderHistoryAttributeType.VISIT_REFERENCE, "aa-bb-cc-dd"), Pair(VisitOrderHistoryAttributeType.VISIT_ORDER_TYPE_USED, "VO")))
     assertVisitOrderHistory(visitOrderHistory[3], visitOrderHistory2, -10, -3, "Sarah Jones")
     assertVisitOrderHistoryAttributes(visitOrderHistory2.attributes, emptyList())
     assertVisitOrderHistory(visitOrderHistory[4], visitOrderHistory1, 0, 0, "John Smith")
@@ -424,7 +424,7 @@ class GetVisitOrderHistoryForPrisonerTest : IntegrationTestBase() {
     val incentiveLevels = listOf(IncentiveLevelDto("STD", "Standard"), IncentiveLevelDto("ENH", "Enhanced"))
     val visitOrderHistory1 = VisitOrderHistoryDto(VisitOrderHistoryType.MIGRATION, LocalDateTime.now().minusDays(10), 10, null, 3, null, userName = "user1", attributes = emptyList())
     val visitOrderHistory2 = VisitOrderHistoryDto(VisitOrderHistoryType.PRISONER_BALANCE_RESET, LocalDateTime.now().minusDays(9), 0, null, 0, null, userName = "user2", attributes = emptyList())
-    val visitOrderHistory3 = VisitOrderHistoryDto(VisitOrderHistoryType.ALLOCATION_USED_BY_VISIT, LocalDateTime.now().minusDays(8), -1, null, 0, null, userName = "SYSTEM", attributes = listOf(VisitOrderHistoryAttributesDto(VisitOrderHistoryAttributeType.VISIT_REFERENCE, "aa-bb-cc-dd")))
+    val visitOrderHistory3 = VisitOrderHistoryDto(VisitOrderHistoryType.ALLOCATION_USED_BY_VISIT, LocalDateTime.now().minusDays(8), -1, null, 0, null, userName = "SYSTEM", attributes = listOf(VisitOrderHistoryAttributesDto(VisitOrderHistoryAttributeType.VISIT_REFERENCE, "aa-bb-cc-dd"), VisitOrderHistoryAttributesDto(VisitOrderHistoryAttributeType.VISIT_ORDER_TYPE_USED, "VO")))
 
     // this entry needs to be ignored as balance does not change
     val visitOrderHistory4 = VisitOrderHistoryDto(VisitOrderHistoryType.SYNC_FROM_NOMIS, LocalDateTime.now().minusDays(7), -1, null, 0, null, userName = "SYSTEM", attributes = emptyList())
@@ -667,7 +667,7 @@ class GetVisitOrderHistoryForPrisonerTest : IntegrationTestBase() {
     val incentiveLevels = listOf(IncentiveLevelDto("STD", "Standard"), IncentiveLevelDto("ENH", "Enhanced"))
     val visitOrderHistory1 = VisitOrderHistoryDto(VisitOrderHistoryType.MIGRATION, LocalDateTime.now().minusDays(10), 10, null, 3, null, userName = "user1", attributes = emptyList())
     val visitOrderHistory2 = VisitOrderHistoryDto(VisitOrderHistoryType.PRISONER_BALANCE_RESET, LocalDateTime.now().minusDays(9), 0, null, 0, null, userName = "user2", attributes = emptyList())
-    val visitOrderHistory3 = VisitOrderHistoryDto(VisitOrderHistoryType.ALLOCATION_USED_BY_VISIT, LocalDateTime.now().minusDays(8), -1, null, 0, null, userName = "SYSTEM", attributes = listOf(VisitOrderHistoryAttributesDto(VisitOrderHistoryAttributeType.VISIT_REFERENCE, "aa-bb-cc-dd")))
+    val visitOrderHistory3 = VisitOrderHistoryDto(VisitOrderHistoryType.ALLOCATION_USED_BY_VISIT, LocalDateTime.now().minusDays(8), -1, null, 0, null, userName = "SYSTEM", attributes = listOf(VisitOrderHistoryAttributesDto(VisitOrderHistoryAttributeType.VISIT_REFERENCE, "aa-bb-cc-dd"), VisitOrderHistoryAttributesDto(VisitOrderHistoryAttributeType.VISIT_ORDER_TYPE_USED, "VO")))
 
     // this entry needs to be ignored as balance does not change
     val visitOrderHistory4 = VisitOrderHistoryDto(VisitOrderHistoryType.SYNC_FROM_NOMIS, LocalDateTime.now().minusDays(7), -1, null, 0, null, userName = "SYSTEM", attributes = emptyList())
@@ -691,7 +691,7 @@ class GetVisitOrderHistoryForPrisonerTest : IntegrationTestBase() {
     assertVisitOrderHistory(visitOrderHistory[1], visitOrderHistory4, 0, 0, "SYSTEM")
     assertVisitOrderHistoryAttributes(visitOrderHistory4.attributes, emptyList())
     assertVisitOrderHistory(visitOrderHistory[2], visitOrderHistory3, -1, 0, "SYSTEM")
-    assertVisitOrderHistoryAttributes(visitOrderHistory3.attributes, listOf(Pair(VisitOrderHistoryAttributeType.VISIT_REFERENCE, "aa-bb-cc-dd")))
+    assertVisitOrderHistoryAttributes(visitOrderHistory3.attributes, listOf(Pair(VisitOrderHistoryAttributeType.VISIT_REFERENCE, "aa-bb-cc-dd"), Pair(VisitOrderHistoryAttributeType.VISIT_ORDER_TYPE_USED, "VO")))
     assertVisitOrderHistory(visitOrderHistory[3], visitOrderHistory2, -10, -3, "user2")
     assertVisitOrderHistoryAttributes(visitOrderHistory2.attributes, emptyList())
     assertVisitOrderHistory(visitOrderHistory[4], visitOrderHistory1, 0, 0, "user1")
@@ -712,7 +712,7 @@ class GetVisitOrderHistoryForPrisonerTest : IntegrationTestBase() {
     val incentiveLevels = listOf(IncentiveLevelDto("STD", "Standard"), IncentiveLevelDto("ENH", "Enhanced"))
     val visitOrderHistory1 = VisitOrderHistoryDto(VisitOrderHistoryType.MIGRATION, LocalDateTime.now().minusDays(10), 10, null, 3, null, userName = "user1", attributes = emptyList())
     val visitOrderHistory2 = VisitOrderHistoryDto(VisitOrderHistoryType.PRISONER_BALANCE_RESET, LocalDateTime.now().minusDays(9), 0, null, 0, null, userName = "user2", attributes = emptyList())
-    val visitOrderHistory3 = VisitOrderHistoryDto(VisitOrderHistoryType.ALLOCATION_USED_BY_VISIT, LocalDateTime.now().minusDays(8), -1, null, 0, null, userName = "SYSTEM", attributes = listOf(VisitOrderHistoryAttributesDto(VisitOrderHistoryAttributeType.VISIT_REFERENCE, "aa-bb-cc-dd")))
+    val visitOrderHistory3 = VisitOrderHistoryDto(VisitOrderHistoryType.ALLOCATION_USED_BY_VISIT, LocalDateTime.now().minusDays(8), -1, null, 0, null, userName = "SYSTEM", attributes = listOf(VisitOrderHistoryAttributesDto(VisitOrderHistoryAttributeType.VISIT_REFERENCE, "aa-bb-cc-dd"), VisitOrderHistoryAttributesDto(VisitOrderHistoryAttributeType.VISIT_ORDER_TYPE_USED, "VO")))
 
     // this entry needs to be ignored as balance does not change
     val visitOrderHistory4 = VisitOrderHistoryDto(VisitOrderHistoryType.SYNC_FROM_NOMIS, LocalDateTime.now().minusDays(7), -1, null, 0, null, userName = "SYSTEM", attributes = emptyList())
@@ -736,7 +736,7 @@ class GetVisitOrderHistoryForPrisonerTest : IntegrationTestBase() {
     assertVisitOrderHistory(visitOrderHistory[1], visitOrderHistory4, 0, 0, "SYSTEM")
     assertVisitOrderHistoryAttributes(visitOrderHistory4.attributes, emptyList())
     assertVisitOrderHistory(visitOrderHistory[2], visitOrderHistory3, -1, 0, "SYSTEM")
-    assertVisitOrderHistoryAttributes(visitOrderHistory3.attributes, listOf(Pair(VisitOrderHistoryAttributeType.VISIT_REFERENCE, "aa-bb-cc-dd")))
+    assertVisitOrderHistoryAttributes(visitOrderHistory3.attributes, listOf(Pair(VisitOrderHistoryAttributeType.VISIT_REFERENCE, "aa-bb-cc-dd"), Pair(VisitOrderHistoryAttributeType.VISIT_ORDER_TYPE_USED, "VO")))
     assertVisitOrderHistory(visitOrderHistory[3], visitOrderHistory2, -10, -3, "user2")
     assertVisitOrderHistoryAttributes(visitOrderHistory2.attributes, emptyList())
     assertVisitOrderHistory(visitOrderHistory[4], visitOrderHistory1, 0, 0, "user1")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/sessions/AvailableVisitSessionsDateRangeTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/sessions/AvailableVisitSessionsDateRangeTest.kt
@@ -12,6 +12,7 @@ import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.vis
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.visit.scheduler.SessionTimeSlotDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.visit.scheduler.VisitSchedulerPrisonDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.visit.scheduler.enums.SessionRestriction.OPEN
+import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.visit.scheduler.enums.SessionTemplateVisitOrderRestrictionType.NONE
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.visit.scheduler.enums.UserType.PUBLIC
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.integration.IntegrationTestBase
 import java.time.DayOfWeek
@@ -23,9 +24,9 @@ class AvailableVisitSessionsDateRangeTest : IntegrationTestBase() {
 
   private val prisonCode = "MDI"
   private val prisonerId = "AA123456B"
-  private val visitSession1 = AvailableVisitSessionDto(LocalDate.now().plusDays(3), "session1", SessionTimeSlotDto(LocalTime.of(9, 0), LocalTime.of(10, 0)), OPEN)
-  private val visitSession2 = AvailableVisitSessionDto(LocalDate.now().plusDays(4), "session2", SessionTimeSlotDto(LocalTime.of(9, 0), LocalTime.of(10, 0)), OPEN)
-  private val visitSession3 = AvailableVisitSessionDto(LocalDate.now().plusDays(5), "session3", SessionTimeSlotDto(LocalTime.of(9, 0), LocalTime.of(10, 0)), OPEN)
+  private val visitSession1 = AvailableVisitSessionDto(LocalDate.now().plusDays(3), "session1", SessionTimeSlotDto(LocalTime.of(9, 0), LocalTime.of(10, 0)), OPEN, visitOrderRestriction = NONE)
+  private val visitSession2 = AvailableVisitSessionDto(LocalDate.now().plusDays(4), "session2", SessionTimeSlotDto(LocalTime.of(9, 0), LocalTime.of(10, 0)), OPEN, visitOrderRestriction = NONE)
+  private val visitSession3 = AvailableVisitSessionDto(LocalDate.now().plusDays(5), "session3", SessionTimeSlotDto(LocalTime.of(9, 0), LocalTime.of(10, 0)), OPEN, visitOrderRestriction = NONE)
 
   private val visitSchedulerPrisonDto = VisitSchedulerPrisonDto(prisonCode, true, 2, 28, 6, 3, 3, 18, DayOfWeek.MONDAY, 3)
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/sessions/AvailableVisitSessionsForReviewFailuresTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/sessions/AvailableVisitSessionsForReviewFailuresTest.kt
@@ -15,6 +15,9 @@ import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.vis
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.visit.scheduler.SessionTimeSlotDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.visit.scheduler.VisitSchedulerPrisonDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.visit.scheduler.enums.SessionRestriction.OPEN
+import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.visit.scheduler.enums.SessionTemplateVisitOrderRestrictionType.NONE
+import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.visit.scheduler.enums.SessionTemplateVisitOrderRestrictionType.PVO
+import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.visit.scheduler.enums.SessionTemplateVisitOrderRestrictionType.VO
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.visit.scheduler.enums.UserType.PUBLIC
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.integration.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.integration.TestObjectMapper
@@ -33,9 +36,9 @@ class AvailableVisitSessionsForReviewFailuresTest : IntegrationTestBase() {
   private val prisonCode = "MDI"
   private val prisonerId = "AA123456B"
   val tomorrow: LocalDate = LocalDate.now().plusDays(1)
-  private val visitSession1 = AvailableVisitSessionDto(tomorrow.plusDays(7), "session1", SessionTimeSlotDto(LocalTime.of(9, 0), LocalTime.of(10, 0)), OPEN)
-  private val visitSession2 = AvailableVisitSessionDto(tomorrow.plusDays(14), "session2", SessionTimeSlotDto(LocalTime.of(9, 0), LocalTime.of(10, 0)), OPEN)
-  private val visitSession3 = AvailableVisitSessionDto(tomorrow.plusDays(21), "session3", SessionTimeSlotDto(LocalTime.of(9, 0), LocalTime.of(10, 0)), OPEN)
+  private val visitSession1 = AvailableVisitSessionDto(tomorrow.plusDays(7), "session1", SessionTimeSlotDto(LocalTime.of(9, 0), LocalTime.of(10, 0)), OPEN, visitOrderRestriction = VO)
+  private val visitSession2 = AvailableVisitSessionDto(tomorrow.plusDays(14), "session2", SessionTimeSlotDto(LocalTime.of(9, 0), LocalTime.of(10, 0)), OPEN, visitOrderRestriction = PVO)
+  private val visitSession3 = AvailableVisitSessionDto(tomorrow.plusDays(21), "session3", SessionTimeSlotDto(LocalTime.of(9, 0), LocalTime.of(10, 0)), OPEN, visitOrderRestriction = NONE)
 
   private val visitSchedulerPrisonDto = VisitSchedulerPrisonDto(prisonCode, true, 2, 28, 6, 3, 3, 18, DayOfWeek.MONDAY, 3)
   private val visitorIds = listOf(1L, 2L, 3L)
@@ -68,10 +71,13 @@ class AvailableVisitSessionsForReviewFailuresTest : IntegrationTestBase() {
     val availableSessions = getResults(returnResult)
     assertThat(availableSessions.size).isEqualTo(3)
     assertThat(availableSessions[0].sessionTemplateReference).isEqualTo(visitSession1.sessionTemplateReference)
+    assertThat(availableSessions[0].visitOrderRestriction).isEqualTo(visitSession1.visitOrderRestriction)
     assertThat(availableSessions[0].sessionForReview).isTrue
     assertThat(availableSessions[1].sessionTemplateReference).isEqualTo(visitSession2.sessionTemplateReference)
+    assertThat(availableSessions[1].visitOrderRestriction).isEqualTo(visitSession2.visitOrderRestriction)
     assertThat(availableSessions[1].sessionForReview).isTrue
     assertThat(availableSessions[2].sessionTemplateReference).isEqualTo(visitSession3.sessionTemplateReference)
+    assertThat(availableSessions[2].visitOrderRestriction).isEqualTo(visitSession3.visitOrderRestriction)
     assertThat(availableSessions[2].sessionForReview).isTrue
 
     verify(alertsApiClientSpy, times(1)).getPrisonerAlerts(prisonerId)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/sessions/AvailableVisitSessionsForReviewTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/sessions/AvailableVisitSessionsForReviewTest.kt
@@ -17,6 +17,9 @@ import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.vis
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.visit.scheduler.SessionTimeSlotDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.visit.scheduler.VisitSchedulerPrisonDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.visit.scheduler.enums.SessionRestriction.OPEN
+import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.visit.scheduler.enums.SessionTemplateVisitOrderRestrictionType.NONE
+import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.visit.scheduler.enums.SessionTemplateVisitOrderRestrictionType.PVO
+import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.visit.scheduler.enums.SessionTemplateVisitOrderRestrictionType.VO
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.visit.scheduler.enums.UserType.PUBLIC
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.integration.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.integration.TestObjectMapper
@@ -28,9 +31,9 @@ import java.time.LocalTime
 class AvailableVisitSessionsForReviewTest : IntegrationTestBase() {
   private val prisonCode = "MDI"
   private val prisonerId = "AA123456B"
-  private val visitSession1 = AvailableVisitSessionDto(LocalDate.now().plusDays(7), "session1", SessionTimeSlotDto(LocalTime.of(9, 0), LocalTime.of(10, 0)), OPEN)
-  private val visitSession2 = AvailableVisitSessionDto(LocalDate.now().plusDays(14), "session2", SessionTimeSlotDto(LocalTime.of(9, 0), LocalTime.of(10, 0)), OPEN)
-  private val visitSession3 = AvailableVisitSessionDto(LocalDate.now().plusDays(21), "session3", SessionTimeSlotDto(LocalTime.of(9, 0), LocalTime.of(10, 0)), OPEN)
+  private val visitSession1 = AvailableVisitSessionDto(LocalDate.now().plusDays(7), "session1", SessionTimeSlotDto(LocalTime.of(9, 0), LocalTime.of(10, 0)), OPEN, visitOrderRestriction = VO)
+  private val visitSession2 = AvailableVisitSessionDto(LocalDate.now().plusDays(14), "session2", SessionTimeSlotDto(LocalTime.of(9, 0), LocalTime.of(10, 0)), OPEN, visitOrderRestriction = PVO)
+  private val visitSession3 = AvailableVisitSessionDto(LocalDate.now().plusDays(21), "session3", SessionTimeSlotDto(LocalTime.of(9, 0), LocalTime.of(10, 0)), OPEN, visitOrderRestriction = NONE)
 
   private val visitSchedulerPrisonDto = VisitSchedulerPrisonDto(prisonCode, true, 2, 28, 6, 3, 3, 18, DayOfWeek.MONDAY, 3)
   private val visitorIds = listOf(1L, 2L, 3L)
@@ -62,10 +65,13 @@ class AvailableVisitSessionsForReviewTest : IntegrationTestBase() {
     val availableSessions = getResults(returnResult)
     assertThat(availableSessions.size).isEqualTo(3)
     assertThat(availableSessions[0].sessionTemplateReference).isEqualTo(visitSession1.sessionTemplateReference)
+    assertThat(availableSessions[0].visitOrderRestriction).isEqualTo(visitSession1.visitOrderRestriction)
     assertThat(availableSessions[0].sessionForReview).isFalse
     assertThat(availableSessions[1].sessionTemplateReference).isEqualTo(visitSession2.sessionTemplateReference)
+    assertThat(availableSessions[1].visitOrderRestriction).isEqualTo(visitSession2.visitOrderRestriction)
     assertThat(availableSessions[1].sessionForReview).isFalse
     assertThat(availableSessions[2].sessionTemplateReference).isEqualTo(visitSession3.sessionTemplateReference)
+    assertThat(availableSessions[2].visitOrderRestriction).isEqualTo(visitSession3.visitOrderRestriction)
     assertThat(availableSessions[2].sessionForReview).isFalse
     verify(prisonerContactRegistryClientSpy, times(1)).doVisitorsHaveClosedRestrictions(prisonerId, visitorIds)
     verify(prisonerContactRegistryClientSpy, times(1)).getBannedRestrictionDateRange(prisonerId, visitorIds, dateRange)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/sessions/AvailableVisitSessionsForReviewWithWeekendCheckTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/sessions/AvailableVisitSessionsForReviewWithWeekendCheckTest.kt
@@ -20,6 +20,7 @@ import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.vis
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.visit.scheduler.SessionTimeSlotDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.visit.scheduler.VisitSchedulerPrisonDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.visit.scheduler.enums.SessionRestriction.OPEN
+import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.visit.scheduler.enums.SessionTemplateVisitOrderRestrictionType.NONE
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.visit.scheduler.enums.UserType.PUBLIC
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.integration.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.integration.TestObjectMapper
@@ -63,13 +64,13 @@ class AvailableVisitSessionsForReviewWithWeekendCheckTest : IntegrationTestBase(
     val dateRange = DateRange(today.plusDays(2).plusDays(1), today.plusDays(28))
     Mockito.`when`(currentDateUtils.getCurrentDate()).thenReturn(today)
 
-    val saturdaySession = AvailableVisitSessionDto(today.plusDays(2), "session3", SessionTimeSlotDto(LocalTime.of(9, 0), LocalTime.of(10, 0)), OPEN)
+    val saturdaySession = AvailableVisitSessionDto(today.plusDays(2), "session3", SessionTimeSlotDto(LocalTime.of(9, 0), LocalTime.of(10, 0)), OPEN, visitOrderRestriction = NONE)
     // as this is a weekend but there are no reviews this session will be available
-    val sundaySession = AvailableVisitSessionDto(today.plusDays(3), "session4", SessionTimeSlotDto(LocalTime.of(9, 0), LocalTime.of(10, 0)), OPEN)
+    val sundaySession = AvailableVisitSessionDto(today.plusDays(3), "session4", SessionTimeSlotDto(LocalTime.of(9, 0), LocalTime.of(10, 0)), OPEN, visitOrderRestriction = NONE)
     // this should be available
-    val mondaySession = AvailableVisitSessionDto(today.plusDays(4), "session5", SessionTimeSlotDto(LocalTime.of(9, 0), LocalTime.of(10, 0)), OPEN)
+    val mondaySession = AvailableVisitSessionDto(today.plusDays(4), "session5", SessionTimeSlotDto(LocalTime.of(9, 0), LocalTime.of(10, 0)), OPEN, visitOrderRestriction = NONE)
     // this should be available
-    val nextTuesdaySession = AvailableVisitSessionDto(today.plusDays(5), "session6", SessionTimeSlotDto(LocalTime.of(9, 0), LocalTime.of(10, 0)), OPEN)
+    val nextTuesdaySession = AvailableVisitSessionDto(today.plusDays(5), "session6", SessionTimeSlotDto(LocalTime.of(9, 0), LocalTime.of(10, 0)), OPEN, visitOrderRestriction = NONE)
 
     visitSchedulerMockServer.stubGetAvailableVisitSessions(visitSchedulerPrisonDto, prisonerId, OPEN, mutableListOf(saturdaySession, sundaySession, mondaySession, nextTuesdaySession), userType = PUBLIC, dateRange = dateRange)
     prisonerContactRegistryMockServer.stubGetBannedRestrictionDateRage(prisonerId, visitorIds = visitorIds, dateRange = dateRange, result = dateRange)
@@ -103,21 +104,21 @@ class AvailableVisitSessionsForReviewWithWeekendCheckTest : IntegrationTestBase(
     Mockito.`when`(currentDateUtils.getCurrentDate()).thenReturn(today)
 
     // same day session not available
-    val tuesdaySession = AvailableVisitSessionDto(today, "session1", SessionTimeSlotDto(LocalTime.of(9, 0), LocalTime.of(10, 0)), OPEN)
+    val tuesdaySession = AvailableVisitSessionDto(today, "session1", SessionTimeSlotDto(LocalTime.of(9, 0), LocalTime.of(10, 0)), OPEN, visitOrderRestriction = NONE)
     // next day session not available
-    val wednesdaySession = AvailableVisitSessionDto(today.plusDays(1), "session1", SessionTimeSlotDto(LocalTime.of(9, 0), LocalTime.of(10, 0)), OPEN)
+    val wednesdaySession = AvailableVisitSessionDto(today.plusDays(1), "session1", SessionTimeSlotDto(LocalTime.of(9, 0), LocalTime.of(10, 0)), OPEN, visitOrderRestriction = NONE)
     // as there are reviews this session will not be available
-    val thursdaySession = AvailableVisitSessionDto(today.plusDays(2), "session2", SessionTimeSlotDto(LocalTime.of(9, 0), LocalTime.of(10, 0)), OPEN)
+    val thursdaySession = AvailableVisitSessionDto(today.plusDays(2), "session2", SessionTimeSlotDto(LocalTime.of(9, 0), LocalTime.of(10, 0)), OPEN, visitOrderRestriction = NONE)
     // as there are reviews this session will not be available
-    val fridaySession = AvailableVisitSessionDto(today.plusDays(3), "session3", SessionTimeSlotDto(LocalTime.of(9, 0), LocalTime.of(10, 0)), OPEN)
+    val fridaySession = AvailableVisitSessionDto(today.plusDays(3), "session3", SessionTimeSlotDto(LocalTime.of(9, 0), LocalTime.of(10, 0)), OPEN, visitOrderRestriction = NONE)
     // as this is a weekend this session will not be available
-    val saturdaySession = AvailableVisitSessionDto(today.plusDays(4), "session4", SessionTimeSlotDto(LocalTime.of(9, 0), LocalTime.of(10, 0)), OPEN)
+    val saturdaySession = AvailableVisitSessionDto(today.plusDays(4), "session4", SessionTimeSlotDto(LocalTime.of(9, 0), LocalTime.of(10, 0)), OPEN, visitOrderRestriction = NONE)
     // as this is a weekend this session will not be available
-    val sundaySession = AvailableVisitSessionDto(today.plusDays(5), "session5", SessionTimeSlotDto(LocalTime.of(9, 0), LocalTime.of(10, 0)), OPEN)
+    val sundaySession = AvailableVisitSessionDto(today.plusDays(5), "session5", SessionTimeSlotDto(LocalTime.of(9, 0), LocalTime.of(10, 0)), OPEN, visitOrderRestriction = NONE)
     // this should be the first session available
-    val mondaySession = AvailableVisitSessionDto(today.plusDays(6), "session6", SessionTimeSlotDto(LocalTime.of(9, 0), LocalTime.of(10, 0)), OPEN)
+    val mondaySession = AvailableVisitSessionDto(today.plusDays(6), "session6", SessionTimeSlotDto(LocalTime.of(9, 0), LocalTime.of(10, 0)), OPEN, visitOrderRestriction = NONE)
     // this should be the next session available
-    val nextTuesdaySession = AvailableVisitSessionDto(today.plusDays(7), "session7", SessionTimeSlotDto(LocalTime.of(9, 0), LocalTime.of(10, 0)), OPEN)
+    val nextTuesdaySession = AvailableVisitSessionDto(today.plusDays(7), "session7", SessionTimeSlotDto(LocalTime.of(9, 0), LocalTime.of(10, 0)), OPEN, visitOrderRestriction = NONE)
 
     val alert1 = createAlertResponseDto(code = PrisonerSupportedAlertCodeType.CC1.name, activeFrom = LocalDate.now(), activeTo = null)
 
@@ -152,19 +153,19 @@ class AvailableVisitSessionsForReviewWithWeekendCheckTest : IntegrationTestBase(
     Mockito.`when`(currentDateUtils.getCurrentDate()).thenReturn(today)
 
     // same day session not available
-    val wednesdaySession = AvailableVisitSessionDto(today, "session1", SessionTimeSlotDto(LocalTime.of(9, 0), LocalTime.of(10, 0)), OPEN)
+    val wednesdaySession = AvailableVisitSessionDto(today, "session1", SessionTimeSlotDto(LocalTime.of(9, 0), LocalTime.of(10, 0)), OPEN, visitOrderRestriction = NONE)
     // next day session not available
-    val thursdaySession = AvailableVisitSessionDto(today.plusDays(1), "session1", SessionTimeSlotDto(LocalTime.of(9, 0), LocalTime.of(10, 0)), OPEN)
+    val thursdaySession = AvailableVisitSessionDto(today.plusDays(1), "session1", SessionTimeSlotDto(LocalTime.of(9, 0), LocalTime.of(10, 0)), OPEN, visitOrderRestriction = NONE)
     // as there are reviews this session will not be available
-    val fridaySession = AvailableVisitSessionDto(today.plusDays(2), "session2", SessionTimeSlotDto(LocalTime.of(9, 0), LocalTime.of(10, 0)), OPEN)
+    val fridaySession = AvailableVisitSessionDto(today.plusDays(2), "session2", SessionTimeSlotDto(LocalTime.of(9, 0), LocalTime.of(10, 0)), OPEN, visitOrderRestriction = NONE)
     // as there are reviews this session will not be available
-    val saturdaySession = AvailableVisitSessionDto(today.plusDays(3), "session3", SessionTimeSlotDto(LocalTime.of(9, 0), LocalTime.of(10, 0)), OPEN)
+    val saturdaySession = AvailableVisitSessionDto(today.plusDays(3), "session3", SessionTimeSlotDto(LocalTime.of(9, 0), LocalTime.of(10, 0)), OPEN, visitOrderRestriction = NONE)
     // as this is a weekend this session will not be available
-    val sundaySession = AvailableVisitSessionDto(today.plusDays(4), "session4", SessionTimeSlotDto(LocalTime.of(9, 0), LocalTime.of(10, 0)), OPEN)
+    val sundaySession = AvailableVisitSessionDto(today.plusDays(4), "session4", SessionTimeSlotDto(LocalTime.of(9, 0), LocalTime.of(10, 0)), OPEN, visitOrderRestriction = NONE)
     // this should be the first session available
-    val mondaySession = AvailableVisitSessionDto(today.plusDays(5), "session4", SessionTimeSlotDto(LocalTime.of(9, 0), LocalTime.of(10, 0)), OPEN)
+    val mondaySession = AvailableVisitSessionDto(today.plusDays(5), "session4", SessionTimeSlotDto(LocalTime.of(9, 0), LocalTime.of(10, 0)), OPEN, visitOrderRestriction = NONE)
     // this should be the next session available
-    val tuesdaySession = AvailableVisitSessionDto(today.plusDays(6), "session4", SessionTimeSlotDto(LocalTime.of(9, 0), LocalTime.of(10, 0)), OPEN)
+    val tuesdaySession = AvailableVisitSessionDto(today.plusDays(6), "session4", SessionTimeSlotDto(LocalTime.of(9, 0), LocalTime.of(10, 0)), OPEN, visitOrderRestriction = NONE)
 
     val alert1 = createAlertResponseDto(code = PrisonerSupportedAlertCodeType.CC1.name, activeFrom = LocalDate.now(), activeTo = null)
 
@@ -200,19 +201,19 @@ class AvailableVisitSessionsForReviewWithWeekendCheckTest : IntegrationTestBase(
     Mockito.`when`(currentDateUtils.getCurrentDate()).thenReturn(today)
 
     // same day session not available
-    val thursdaySession = AvailableVisitSessionDto(today, "session1", SessionTimeSlotDto(LocalTime.of(9, 0), LocalTime.of(10, 0)), OPEN)
+    val thursdaySession = AvailableVisitSessionDto(today, "session1", SessionTimeSlotDto(LocalTime.of(9, 0), LocalTime.of(10, 0)), OPEN, visitOrderRestriction = NONE)
     // next day session not available
-    val fridaySession = AvailableVisitSessionDto(today.plusDays(1), "session2", SessionTimeSlotDto(LocalTime.of(9, 0), LocalTime.of(10, 0)), OPEN)
+    val fridaySession = AvailableVisitSessionDto(today.plusDays(1), "session2", SessionTimeSlotDto(LocalTime.of(9, 0), LocalTime.of(10, 0)), OPEN, visitOrderRestriction = NONE)
     // as there are reviews this session will not be available
-    val saturdaySession = AvailableVisitSessionDto(today.plusDays(2), "session3", SessionTimeSlotDto(LocalTime.of(9, 0), LocalTime.of(10, 0)), OPEN)
+    val saturdaySession = AvailableVisitSessionDto(today.plusDays(2), "session3", SessionTimeSlotDto(LocalTime.of(9, 0), LocalTime.of(10, 0)), OPEN, visitOrderRestriction = NONE)
     // as there are reviews this session will not be available
-    val sundaySession = AvailableVisitSessionDto(today.plusDays(3), "session4", SessionTimeSlotDto(LocalTime.of(9, 0), LocalTime.of(10, 0)), OPEN)
+    val sundaySession = AvailableVisitSessionDto(today.plusDays(3), "session4", SessionTimeSlotDto(LocalTime.of(9, 0), LocalTime.of(10, 0)), OPEN, visitOrderRestriction = NONE)
     // as this is a weekend this session will not be available
-    val mondaySession = AvailableVisitSessionDto(today.plusDays(4), "session5", SessionTimeSlotDto(LocalTime.of(9, 0), LocalTime.of(10, 0)), OPEN)
+    val mondaySession = AvailableVisitSessionDto(today.plusDays(4), "session5", SessionTimeSlotDto(LocalTime.of(9, 0), LocalTime.of(10, 0)), OPEN, visitOrderRestriction = NONE)
     // this should be the first session available
-    val tuesdaySession = AvailableVisitSessionDto(today.plusDays(5), "session6", SessionTimeSlotDto(LocalTime.of(9, 0), LocalTime.of(10, 0)), OPEN)
+    val tuesdaySession = AvailableVisitSessionDto(today.plusDays(5), "session6", SessionTimeSlotDto(LocalTime.of(9, 0), LocalTime.of(10, 0)), OPEN, visitOrderRestriction = NONE)
     // this should be the next session available
-    val wednesdaySession = AvailableVisitSessionDto(today.plusDays(6), "session7", SessionTimeSlotDto(LocalTime.of(9, 0), LocalTime.of(10, 0)), OPEN)
+    val wednesdaySession = AvailableVisitSessionDto(today.plusDays(6), "session7", SessionTimeSlotDto(LocalTime.of(9, 0), LocalTime.of(10, 0)), OPEN, visitOrderRestriction = NONE)
 
     val alert1 = createAlertResponseDto(code = PrisonerSupportedAlertCodeType.CC1.name, activeFrom = LocalDate.now(), activeTo = null)
 
@@ -246,15 +247,15 @@ class AvailableVisitSessionsForReviewWithWeekendCheckTest : IntegrationTestBase(
     Mockito.`when`(currentDateUtils.getCurrentDate()).thenReturn(today)
 
     // same day session not available
-    val fridaySession = AvailableVisitSessionDto(today.plusDays(1), "session2", SessionTimeSlotDto(LocalTime.of(9, 0), LocalTime.of(10, 0)), OPEN)
+    val fridaySession = AvailableVisitSessionDto(today.plusDays(1), "session2", SessionTimeSlotDto(LocalTime.of(9, 0), LocalTime.of(10, 0)), OPEN, visitOrderRestriction = NONE)
     // next day session not available
-    val saturdaySession = AvailableVisitSessionDto(today.plusDays(1), "session2", SessionTimeSlotDto(LocalTime.of(9, 0), LocalTime.of(10, 0)), OPEN)
+    val saturdaySession = AvailableVisitSessionDto(today.plusDays(1), "session2", SessionTimeSlotDto(LocalTime.of(9, 0), LocalTime.of(10, 0)), OPEN, visitOrderRestriction = NONE)
     // as there are reviews this session will not be available
-    val sundaySession = AvailableVisitSessionDto(today.plusDays(2), "session3", SessionTimeSlotDto(LocalTime.of(9, 0), LocalTime.of(10, 0)), OPEN)
+    val sundaySession = AvailableVisitSessionDto(today.plusDays(2), "session3", SessionTimeSlotDto(LocalTime.of(9, 0), LocalTime.of(10, 0)), OPEN, visitOrderRestriction = NONE)
     // as there are reviews this session will not be available
-    val mondaySession = AvailableVisitSessionDto(today.plusDays(3), "session4", SessionTimeSlotDto(LocalTime.of(9, 0), LocalTime.of(10, 0)), OPEN)
+    val mondaySession = AvailableVisitSessionDto(today.plusDays(3), "session4", SessionTimeSlotDto(LocalTime.of(9, 0), LocalTime.of(10, 0)), OPEN, visitOrderRestriction = NONE)
     // this should be the first session available
-    val tuesdaySession = AvailableVisitSessionDto(today.plusDays(5), "session6", SessionTimeSlotDto(LocalTime.of(9, 0), LocalTime.of(10, 0)), OPEN)
+    val tuesdaySession = AvailableVisitSessionDto(today.plusDays(5), "session6", SessionTimeSlotDto(LocalTime.of(9, 0), LocalTime.of(10, 0)), OPEN, visitOrderRestriction = NONE)
 
     val alert1 = createAlertResponseDto(code = PrisonerSupportedAlertCodeType.CC1.name, activeFrom = LocalDate.now(), activeTo = null)
 
@@ -287,15 +288,15 @@ class AvailableVisitSessionsForReviewWithWeekendCheckTest : IntegrationTestBase(
     Mockito.`when`(currentDateUtils.getCurrentDate()).thenReturn(today)
 
     // same day session not available
-    val saturdaySession = AvailableVisitSessionDto(today.plusDays(1), "session2", SessionTimeSlotDto(LocalTime.of(9, 0), LocalTime.of(10, 0)), OPEN)
+    val saturdaySession = AvailableVisitSessionDto(today.plusDays(1), "session2", SessionTimeSlotDto(LocalTime.of(9, 0), LocalTime.of(10, 0)), OPEN, visitOrderRestriction = NONE)
     // next day session not available
-    val sundaySession = AvailableVisitSessionDto(today.plusDays(1), "session2", SessionTimeSlotDto(LocalTime.of(9, 0), LocalTime.of(10, 0)), OPEN)
+    val sundaySession = AvailableVisitSessionDto(today.plusDays(1), "session2", SessionTimeSlotDto(LocalTime.of(9, 0), LocalTime.of(10, 0)), OPEN, visitOrderRestriction = NONE)
     // as there are reviews this session will not be available
-    val mondaySession = AvailableVisitSessionDto(today.plusDays(2), "session3", SessionTimeSlotDto(LocalTime.of(9, 0), LocalTime.of(10, 0)), OPEN)
+    val mondaySession = AvailableVisitSessionDto(today.plusDays(2), "session3", SessionTimeSlotDto(LocalTime.of(9, 0), LocalTime.of(10, 0)), OPEN, visitOrderRestriction = NONE)
     // as there are reviews this session will not be available
-    val tuesdaySession = AvailableVisitSessionDto(today.plusDays(3), "session4", SessionTimeSlotDto(LocalTime.of(9, 0), LocalTime.of(10, 0)), OPEN)
+    val tuesdaySession = AvailableVisitSessionDto(today.plusDays(3), "session4", SessionTimeSlotDto(LocalTime.of(9, 0), LocalTime.of(10, 0)), OPEN, visitOrderRestriction = NONE)
     // this should be the first session available
-    val wednesdaySession = AvailableVisitSessionDto(today.plusDays(5), "session6", SessionTimeSlotDto(LocalTime.of(9, 0), LocalTime.of(10, 0)), OPEN)
+    val wednesdaySession = AvailableVisitSessionDto(today.plusDays(5), "session6", SessionTimeSlotDto(LocalTime.of(9, 0), LocalTime.of(10, 0)), OPEN, visitOrderRestriction = NONE)
 
     val alert1 = createAlertResponseDto(code = PrisonerSupportedAlertCodeType.CC1.name, activeFrom = LocalDate.now(), activeTo = null)
 
@@ -324,21 +325,21 @@ class AvailableVisitSessionsForReviewWithWeekendCheckTest : IntegrationTestBase(
     // Given
     val today = if (LocalDate.now().dayOfWeek == DayOfWeek.TUESDAY) LocalDate.now() else LocalDate.now().with(TemporalAdjusters.next(DayOfWeek.TUESDAY))
     // same day session not available
-    val tuesdaySession = AvailableVisitSessionDto(today, "session1", SessionTimeSlotDto(LocalTime.of(9, 0), LocalTime.of(10, 0)), OPEN)
+    val tuesdaySession = AvailableVisitSessionDto(today, "session1", SessionTimeSlotDto(LocalTime.of(9, 0), LocalTime.of(10, 0)), OPEN, visitOrderRestriction = NONE)
     // next day session not available
-    val wednesdaySession = AvailableVisitSessionDto(today.plusDays(1), "session1", SessionTimeSlotDto(LocalTime.of(9, 0), LocalTime.of(10, 0)), OPEN)
+    val wednesdaySession = AvailableVisitSessionDto(today.plusDays(1), "session1", SessionTimeSlotDto(LocalTime.of(9, 0), LocalTime.of(10, 0)), OPEN, visitOrderRestriction = NONE)
     // as there are reviews this session will not be available
-    val thursdaySession = AvailableVisitSessionDto(today.plusDays(2), "session2", SessionTimeSlotDto(LocalTime.of(9, 0), LocalTime.of(10, 0)), OPEN)
+    val thursdaySession = AvailableVisitSessionDto(today.plusDays(2), "session2", SessionTimeSlotDto(LocalTime.of(9, 0), LocalTime.of(10, 0)), OPEN, visitOrderRestriction = NONE)
     // as there are reviews this session will not be available
-    val fridaySession = AvailableVisitSessionDto(today.plusDays(3), "session3", SessionTimeSlotDto(LocalTime.of(9, 0), LocalTime.of(10, 0)), OPEN)
+    val fridaySession = AvailableVisitSessionDto(today.plusDays(3), "session3", SessionTimeSlotDto(LocalTime.of(9, 0), LocalTime.of(10, 0)), OPEN, visitOrderRestriction = NONE)
     // as this is a weekend this session will not be available
-    val saturdaySession = AvailableVisitSessionDto(today.plusDays(4), "session4", SessionTimeSlotDto(LocalTime.of(9, 0), LocalTime.of(10, 0)), OPEN)
+    val saturdaySession = AvailableVisitSessionDto(today.plusDays(4), "session4", SessionTimeSlotDto(LocalTime.of(9, 0), LocalTime.of(10, 0)), OPEN, visitOrderRestriction = NONE)
     // as this is a weekend this session will not be available
-    val sundaySession = AvailableVisitSessionDto(today.plusDays(5), "session4", SessionTimeSlotDto(LocalTime.of(9, 0), LocalTime.of(10, 0)), OPEN)
+    val sundaySession = AvailableVisitSessionDto(today.plusDays(5), "session4", SessionTimeSlotDto(LocalTime.of(9, 0), LocalTime.of(10, 0)), OPEN, visitOrderRestriction = NONE)
     // this should be the first session but this should not be available as MONDAY is a holiday
-    val mondaySession = AvailableVisitSessionDto(today.plusDays(6), "session4", SessionTimeSlotDto(LocalTime.of(9, 0), LocalTime.of(10, 0)), OPEN)
+    val mondaySession = AvailableVisitSessionDto(today.plusDays(6), "session4", SessionTimeSlotDto(LocalTime.of(9, 0), LocalTime.of(10, 0)), OPEN, visitOrderRestriction = NONE)
     // this should be the first session available
-    val nextTuesdaySession = AvailableVisitSessionDto(today.plusDays(7), "session4", SessionTimeSlotDto(LocalTime.of(9, 0), LocalTime.of(10, 0)), OPEN)
+    val nextTuesdaySession = AvailableVisitSessionDto(today.plusDays(7), "session4", SessionTimeSlotDto(LocalTime.of(9, 0), LocalTime.of(10, 0)), OPEN, visitOrderRestriction = NONE)
 
     val dateRange = DateRange(today.plusDays(2).plusDays(1), today.plusDays(28))
     Mockito.`when`(currentDateUtils.getCurrentDate()).thenReturn(today)
@@ -375,23 +376,23 @@ class AvailableVisitSessionsForReviewWithWeekendCheckTest : IntegrationTestBase(
     // Given
     val today = if (LocalDate.now().dayOfWeek == DayOfWeek.TUESDAY) LocalDate.now() else LocalDate.now().with(TemporalAdjusters.next(DayOfWeek.TUESDAY))
     // same day session not available
-    val tuesdaySession = AvailableVisitSessionDto(today, "session1", SessionTimeSlotDto(LocalTime.of(9, 0), LocalTime.of(10, 0)), OPEN)
+    val tuesdaySession = AvailableVisitSessionDto(today, "session1", SessionTimeSlotDto(LocalTime.of(9, 0), LocalTime.of(10, 0)), OPEN, visitOrderRestriction = NONE)
     // next day session not available
-    val wednesdaySession = AvailableVisitSessionDto(today.plusDays(1), "session1", SessionTimeSlotDto(LocalTime.of(9, 0), LocalTime.of(10, 0)), OPEN)
+    val wednesdaySession = AvailableVisitSessionDto(today.plusDays(1), "session1", SessionTimeSlotDto(LocalTime.of(9, 0), LocalTime.of(10, 0)), OPEN, visitOrderRestriction = NONE)
     // 2 days after session not available
-    val thursdaySession = AvailableVisitSessionDto(today.plusDays(2), "session2", SessionTimeSlotDto(LocalTime.of(9, 0), LocalTime.of(10, 0)), OPEN)
+    val thursdaySession = AvailableVisitSessionDto(today.plusDays(2), "session2", SessionTimeSlotDto(LocalTime.of(9, 0), LocalTime.of(10, 0)), OPEN, visitOrderRestriction = NONE)
     // as there are reviews this session will not be available
-    val fridaySession = AvailableVisitSessionDto(today.plusDays(3), "session3", SessionTimeSlotDto(LocalTime.of(9, 0), LocalTime.of(10, 0)), OPEN)
+    val fridaySession = AvailableVisitSessionDto(today.plusDays(3), "session3", SessionTimeSlotDto(LocalTime.of(9, 0), LocalTime.of(10, 0)), OPEN, visitOrderRestriction = NONE)
     // as there are reviews this session will not be available
-    val saturdaySession = AvailableVisitSessionDto(today.plusDays(4), "session4", SessionTimeSlotDto(LocalTime.of(9, 0), LocalTime.of(10, 0)), OPEN)
+    val saturdaySession = AvailableVisitSessionDto(today.plusDays(4), "session4", SessionTimeSlotDto(LocalTime.of(9, 0), LocalTime.of(10, 0)), OPEN, visitOrderRestriction = NONE)
     // as this is a weekend this session will not be available
-    val sundaySession = AvailableVisitSessionDto(today.plusDays(5), "session5", SessionTimeSlotDto(LocalTime.of(9, 0), LocalTime.of(10, 0)), OPEN)
+    val sundaySession = AvailableVisitSessionDto(today.plusDays(5), "session5", SessionTimeSlotDto(LocalTime.of(9, 0), LocalTime.of(10, 0)), OPEN, visitOrderRestriction = NONE)
     // this should be the first session but this should not be available as MONDAY is a holiday
-    val mondaySession = AvailableVisitSessionDto(today.plusDays(6), "session6", SessionTimeSlotDto(LocalTime.of(9, 0), LocalTime.of(10, 0)), OPEN)
+    val mondaySession = AvailableVisitSessionDto(today.plusDays(6), "session6", SessionTimeSlotDto(LocalTime.of(9, 0), LocalTime.of(10, 0)), OPEN, visitOrderRestriction = NONE)
     // this should be the next session but this should not be available as TUESDAY is a holiday
-    val nextTuesdaySession = AvailableVisitSessionDto(today.plusDays(7), "session7", SessionTimeSlotDto(LocalTime.of(9, 0), LocalTime.of(10, 0)), OPEN)
+    val nextTuesdaySession = AvailableVisitSessionDto(today.plusDays(7), "session7", SessionTimeSlotDto(LocalTime.of(9, 0), LocalTime.of(10, 0)), OPEN, visitOrderRestriction = NONE)
     // this should be the first session available
-    val nextWednesdaySession = AvailableVisitSessionDto(today.plusDays(8), "session8", SessionTimeSlotDto(LocalTime.of(9, 0), LocalTime.of(10, 0)), OPEN)
+    val nextWednesdaySession = AvailableVisitSessionDto(today.plusDays(8), "session8", SessionTimeSlotDto(LocalTime.of(9, 0), LocalTime.of(10, 0)), OPEN, visitOrderRestriction = NONE)
 
     val dateRange = DateRange(today.plusDays(2).plusDays(1), today.plusDays(28))
     Mockito.`when`(currentDateUtils.getCurrentDate()).thenReturn(today)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/sessions/AvailableVisitSessionsWithAppointmentsCheckTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/sessions/AvailableVisitSessionsWithAppointmentsCheckTest.kt
@@ -14,6 +14,10 @@ import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.vis
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.visit.scheduler.SessionTimeSlotDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.visit.scheduler.VisitSchedulerPrisonDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.visit.scheduler.enums.SessionRestriction.OPEN
+import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.visit.scheduler.enums.SessionTemplateVisitOrderRestrictionType.NONE
+import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.visit.scheduler.enums.SessionTemplateVisitOrderRestrictionType.PVO
+import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.visit.scheduler.enums.SessionTemplateVisitOrderRestrictionType.VO
+import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.visit.scheduler.enums.SessionTemplateVisitOrderRestrictionType.VO_PVO
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.visit.scheduler.enums.UserType.PUBLIC
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.whereabouts.enums.HigherPriorityMedicalOrLegalEvents.ADJUDICATION_HEARING
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.whereabouts.enums.HigherPriorityMedicalOrLegalEvents.MEDICAL_OPTICIAN
@@ -27,10 +31,10 @@ import java.time.LocalTime
 class AvailableVisitSessionsWithAppointmentsCheckTest : IntegrationTestBase() {
   private val prisonCode = "MDI"
   private val prisonerId = "AA123456B"
-  private val visitSession1 = AvailableVisitSessionDto(LocalDate.now().plusDays(3), "session1", SessionTimeSlotDto(LocalTime.of(9, 0), LocalTime.of(10, 0)), OPEN)
-  private val visitSession2 = AvailableVisitSessionDto(LocalDate.now().plusDays(4), "session2", SessionTimeSlotDto(LocalTime.of(9, 0), LocalTime.of(10, 0)), OPEN)
-  private val visitSession3 = AvailableVisitSessionDto(LocalDate.now().plusDays(5), "session3", SessionTimeSlotDto(LocalTime.of(9, 0), LocalTime.of(10, 0)), OPEN)
-  private val visitSession4 = AvailableVisitSessionDto(visitSession1.sessionDate, "session1", SessionTimeSlotDto(LocalTime.of(15, 0), LocalTime.of(16, 0)), OPEN)
+  private val visitSession1 = AvailableVisitSessionDto(LocalDate.now().plusDays(3), "session1", SessionTimeSlotDto(LocalTime.of(9, 0), LocalTime.of(10, 0)), OPEN, visitOrderRestriction = VO)
+  private val visitSession2 = AvailableVisitSessionDto(LocalDate.now().plusDays(4), "session2", SessionTimeSlotDto(LocalTime.of(9, 0), LocalTime.of(10, 0)), OPEN, visitOrderRestriction = PVO)
+  private val visitSession3 = AvailableVisitSessionDto(LocalDate.now().plusDays(5), "session3", SessionTimeSlotDto(LocalTime.of(9, 0), LocalTime.of(10, 0)), OPEN, visitOrderRestriction = VO_PVO)
+  private val visitSession4 = AvailableVisitSessionDto(visitSession1.sessionDate, "session1", SessionTimeSlotDto(LocalTime.of(15, 0), LocalTime.of(16, 0)), OPEN, visitOrderRestriction = NONE)
 
   private val visitSchedulerPrisonDto = VisitSchedulerPrisonDto(prisonCode, true, 2, 28, 6, 3, 3, 18, DayOfWeek.MONDAY, 3)
   private val visitorIds = listOf(1L, 2L, 3L)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/sessions/AvailableVisitSessionsWithoutAppointmentsCheckTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/sessions/AvailableVisitSessionsWithoutAppointmentsCheckTest.kt
@@ -9,6 +9,7 @@ import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR
 import org.springframework.http.HttpStatus.NOT_FOUND
+import org.springframework.test.web.reactive.server.WebTestClient
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.config.ErrorResponse
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.prison.api.OffenderRestrictionDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.prison.api.OffenderRestrictionsDto
@@ -18,6 +19,10 @@ import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.vis
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.visit.scheduler.VisitSchedulerPrisonDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.visit.scheduler.enums.SessionRestriction.CLOSED
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.visit.scheduler.enums.SessionRestriction.OPEN
+import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.visit.scheduler.enums.SessionTemplateVisitOrderRestrictionType.NONE
+import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.visit.scheduler.enums.SessionTemplateVisitOrderRestrictionType.PVO
+import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.visit.scheduler.enums.SessionTemplateVisitOrderRestrictionType.VO
+import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.visit.scheduler.enums.SessionTemplateVisitOrderRestrictionType.VO_PVO
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.visit.scheduler.enums.UserType.PUBLIC
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.integration.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.integration.TestObjectMapper
@@ -32,9 +37,9 @@ class AvailableVisitSessionsWithoutAppointmentsCheckTest : IntegrationTestBase()
     // Given
     val prisonCode = "MDI"
     val prisonerId = "AA123456B"
-    val visitSession1 = AvailableVisitSessionDto(LocalDate.now(), "session1", SessionTimeSlotDto(LocalTime.of(9, 0), LocalTime.of(10, 0)), OPEN)
-    val visitSession2 = AvailableVisitSessionDto(LocalDate.now().plusDays(1), "session2", SessionTimeSlotDto(LocalTime.of(9, 0), LocalTime.of(10, 0)), OPEN)
-    val visitSession3 = AvailableVisitSessionDto(LocalDate.now().plusDays(2), "session3", SessionTimeSlotDto(LocalTime.of(9, 0), LocalTime.of(10, 0)), OPEN)
+    val visitSession1 = AvailableVisitSessionDto(LocalDate.now(), "session1", SessionTimeSlotDto(LocalTime.of(9, 0), LocalTime.of(10, 0)), OPEN, visitOrderRestriction = VO)
+    val visitSession2 = AvailableVisitSessionDto(LocalDate.now().plusDays(1), "session2", SessionTimeSlotDto(LocalTime.of(9, 0), LocalTime.of(10, 0)), OPEN, visitOrderRestriction = PVO)
+    val visitSession3 = AvailableVisitSessionDto(LocalDate.now().plusDays(2), "session3", SessionTimeSlotDto(LocalTime.of(9, 0), LocalTime.of(10, 0)), OPEN, visitOrderRestriction = NONE)
 
     val visitSchedulerPrisonDto = VisitSchedulerPrisonDto(prisonCode, true, 2, 28, 6, 3, 3, 18, DayOfWeek.MONDAY, 3)
     val dateRange = visitSchedulerMockServer.stubGetAvailableVisitSessions(visitSchedulerPrisonDto, prisonerId, OPEN, mutableListOf(visitSession1, visitSession2, visitSession3), userType = PUBLIC)
@@ -49,9 +54,13 @@ class AvailableVisitSessionsWithoutAppointmentsCheckTest : IntegrationTestBase()
     val responseSpec = callGetAvailableVisitSessions(webTestClient, prisonCode, prisonerId, OPEN, visitorIds = visitorIds, false, userType = PUBLIC, authHttpHeaders = roleVSIPOrchestrationServiceHttpHeaders)
 
     // Then
-    responseSpec.expectStatus().isOk
+    val returnResult = responseSpec.expectStatus().isOk
       .expectBody()
       .jsonPath("$.size()").isEqualTo(3)
+    val availableSessions = getResults(returnResult)
+    assertThat(availableSessions[0].visitOrderRestriction).isEqualTo(visitSession1.visitOrderRestriction)
+    assertThat(availableSessions[1].visitOrderRestriction).isEqualTo(visitSession2.visitOrderRestriction)
+    assertThat(availableSessions[2].visitOrderRestriction).isEqualTo(visitSession3.visitOrderRestriction)
     verify(appointmentsServiceSpy, times(0)).getHigherPriorityAppointments(any(), any(), any())
   }
 
@@ -60,7 +69,7 @@ class AvailableVisitSessionsWithoutAppointmentsCheckTest : IntegrationTestBase()
     // Given
     val prisonCode = "MDI"
     val prisonerId = "AA123456B"
-    val visitSession1 = AvailableVisitSessionDto(LocalDate.now(), "session1", SessionTimeSlotDto(LocalTime.of(9, 0), LocalTime.of(10, 0)), OPEN)
+    val visitSession1 = AvailableVisitSessionDto(LocalDate.now(), "session1", SessionTimeSlotDto(LocalTime.of(9, 0), LocalTime.of(10, 0)), OPEN, visitOrderRestriction = VO_PVO)
 
     val visitSchedulerPrisonDto = VisitSchedulerPrisonDto(prisonCode, true, 2, 28, 6, 3, 3, 18, DayOfWeek.MONDAY, 3)
     val dateRange = visitSchedulerMockServer.stubGetAvailableVisitSessions(visitSchedulerPrisonDto, prisonerId, OPEN, mutableListOf(visitSession1), excludedApplicationReference = "aledTheGreat", userType = PUBLIC)
@@ -75,9 +84,11 @@ class AvailableVisitSessionsWithoutAppointmentsCheckTest : IntegrationTestBase()
     val responseSpec = callGetAvailableVisitSessions(webTestClient, prisonCode, prisonerId, OPEN, visitorIds = visitorIds, false, userType = PUBLIC, authHttpHeaders = roleVSIPOrchestrationServiceHttpHeaders, excludedApplicationReference = "aledTheGreat")
 
     // Then
-    responseSpec.expectStatus().isOk
+    val returnResult = responseSpec.expectStatus().isOk
       .expectBody()
       .jsonPath("$.size()").isEqualTo(1)
+    val availableSessions = getResults(returnResult)
+    assertThat(availableSessions[0].visitOrderRestriction).isEqualTo(visitSession1.visitOrderRestriction)
   }
 
   @Test
@@ -85,7 +96,7 @@ class AvailableVisitSessionsWithoutAppointmentsCheckTest : IntegrationTestBase()
     // Given
     val prisonCode = "MDI"
     val prisonerId = "AA123456B"
-    val visitSession1 = AvailableVisitSessionDto(LocalDate.now(), "s1", SessionTimeSlotDto(LocalTime.of(9, 0), LocalTime.of(10, 0)), OPEN)
+    val visitSession1 = AvailableVisitSessionDto(LocalDate.now(), "s1", SessionTimeSlotDto(LocalTime.of(9, 0), LocalTime.of(10, 0)), OPEN, visitOrderRestriction = PVO)
     val prisonDto = VisitSchedulerPrisonDto(prisonCode, true, 2, 28, 6, 3, 3, 18, DayOfWeek.MONDAY, 3)
     visitSchedulerMockServer.stubGetAvailableVisitSessions(prisonDto, prisonerId, OPEN, mutableListOf(visitSession1), userType = PUBLIC)
     visitSchedulerMockServer.stubGetPrison(prisonCode, prisonDto)
@@ -95,9 +106,11 @@ class AvailableVisitSessionsWithoutAppointmentsCheckTest : IntegrationTestBase()
     val responseSpec = callGetAvailableVisitSessions(webTestClient, prisonCode, prisonerId, OPEN, withAppointmentsCheck = false, userType = PUBLIC, authHttpHeaders = roleVSIPOrchestrationServiceHttpHeaders)
 
     // Then
-    responseSpec.expectStatus().isOk
+    val returnResult = responseSpec.expectStatus().isOk
       .expectBody()
       .jsonPath("$.size()").isEqualTo(1)
+    val availableSessions = getResults(returnResult)
+    assertThat(availableSessions[0].visitOrderRestriction).isEqualTo(visitSession1.visitOrderRestriction)
     verify(appointmentsServiceSpy, times(0)).getHigherPriorityAppointments(any(), any(), any())
   }
 
@@ -106,9 +119,9 @@ class AvailableVisitSessionsWithoutAppointmentsCheckTest : IntegrationTestBase()
     // Given
     val prisonCode = "MDI"
     val prisonerId = "AA123456B"
-    val visitSession1 = AvailableVisitSessionDto(LocalDate.now(), "s1", SessionTimeSlotDto(LocalTime.of(9, 0), LocalTime.of(10, 0)), OPEN)
-    val visitSession2 = AvailableVisitSessionDto(LocalDate.now().plusDays(1), "s2", SessionTimeSlotDto(LocalTime.of(9, 0), LocalTime.of(10, 0)), OPEN)
-    val visitSession3 = AvailableVisitSessionDto(LocalDate.now().plusDays(2), "s3", SessionTimeSlotDto(LocalTime.of(9, 0), LocalTime.of(10, 0)), OPEN)
+    val visitSession1 = AvailableVisitSessionDto(LocalDate.now(), "s1", SessionTimeSlotDto(LocalTime.of(9, 0), LocalTime.of(10, 0)), OPEN, visitOrderRestriction = VO)
+    val visitSession2 = AvailableVisitSessionDto(LocalDate.now().plusDays(1), "s2", SessionTimeSlotDto(LocalTime.of(9, 0), LocalTime.of(10, 0)), OPEN, visitOrderRestriction = NONE)
+    val visitSession3 = AvailableVisitSessionDto(LocalDate.now().plusDays(2), "s3", SessionTimeSlotDto(LocalTime.of(9, 0), LocalTime.of(10, 0)), OPEN, visitOrderRestriction = NONE)
     val prisonDto = VisitSchedulerPrisonDto(prisonCode, true, 2, 28, 6, 3, 3, 18, DayOfWeek.MONDAY, 3)
     val dateRange = visitSchedulerMockServer.stubGetAvailableVisitSessions(prisonDto, prisonerId, OPEN, mutableListOf(visitSession1, visitSession2, visitSession3), userType = PUBLIC)
     visitSchedulerMockServer.stubGetPrison(prisonCode, prisonDto)
@@ -154,7 +167,7 @@ class AvailableVisitSessionsWithoutAppointmentsCheckTest : IntegrationTestBase()
     val prisonerId = "AA123456B"
     val visitorIds = listOf(1L)
 
-    val visitSession1 = AvailableVisitSessionDto(LocalDate.now(), "s1", SessionTimeSlotDto(LocalTime.of(9, 0), LocalTime.of(10, 0)), OPEN)
+    val visitSession1 = AvailableVisitSessionDto(LocalDate.now(), "s1", SessionTimeSlotDto(LocalTime.of(9, 0), LocalTime.of(10, 0)), OPEN, visitOrderRestriction = NONE)
     val prisonDto = VisitSchedulerPrisonDto(prisonCode, true, 2, 28, 6, 3, 3, 18, DayOfWeek.MONDAY, 3)
 
     val toDay = LocalDate.now()
@@ -175,9 +188,11 @@ class AvailableVisitSessionsWithoutAppointmentsCheckTest : IntegrationTestBase()
     val responseSpec = callGetAvailableVisitSessions(webTestClient, prisonCode, prisonerId, OPEN, visitorIds = visitorIds, withAppointmentsCheck = false, userType = PUBLIC, authHttpHeaders = roleVSIPOrchestrationServiceHttpHeaders)
 
     // Then
-    responseSpec.expectStatus().isOk
+    val returnResult = responseSpec.expectStatus().isOk
       .expectBody()
       .jsonPath("$.size()").isEqualTo(1)
+    val availableSessions = getResults(returnResult)
+    assertThat(availableSessions[0].visitOrderRestriction).isEqualTo(visitSession1.visitOrderRestriction)
     verify(appointmentsServiceSpy, times(0)).getHigherPriorityAppointments(any(), any(), any())
   }
 
@@ -186,7 +201,7 @@ class AvailableVisitSessionsWithoutAppointmentsCheckTest : IntegrationTestBase()
     // Given
     val prisonCode = "MDI"
     val prisonerId = "AA123456B"
-    val visitSession1 = AvailableVisitSessionDto(LocalDate.now(), "session1", SessionTimeSlotDto(LocalTime.of(9, 0), LocalTime.of(10, 0)), CLOSED)
+    val visitSession1 = AvailableVisitSessionDto(LocalDate.now(), "session1", SessionTimeSlotDto(LocalTime.of(9, 0), LocalTime.of(10, 0)), CLOSED, visitOrderRestriction = VO_PVO)
 
     val offenderRestrictionsDto = OffenderRestrictionsDto(
       bookingId = 1,
@@ -217,9 +232,11 @@ class AvailableVisitSessionsWithoutAppointmentsCheckTest : IntegrationTestBase()
     )
 
     // Then
-    responseSpec.expectStatus().isOk
+    val returnResult = responseSpec.expectStatus().isOk
       .expectBody()
       .jsonPath("$.size()").isEqualTo(1)
+    val availableSessions = getResults(returnResult)
+    assertThat(availableSessions[0].visitOrderRestriction).isEqualTo(visitSession1.visitOrderRestriction)
     verify(appointmentsServiceSpy, times(0)).getHigherPriorityAppointments(any(), any(), any())
   }
 
@@ -228,7 +245,7 @@ class AvailableVisitSessionsWithoutAppointmentsCheckTest : IntegrationTestBase()
     // Given
     val prisonCode = "MDI"
     val prisonerId = "AA123456B"
-    val visitSession1 = AvailableVisitSessionDto(LocalDate.now(), "s1", SessionTimeSlotDto(LocalTime.of(9, 0), LocalTime.of(10, 0)), CLOSED)
+    val visitSession1 = AvailableVisitSessionDto(LocalDate.now(), "s1", SessionTimeSlotDto(LocalTime.of(9, 0), LocalTime.of(10, 0)), CLOSED, visitOrderRestriction = PVO)
 
     val offenderRestrictionsDto = OffenderRestrictionsDto(
       bookingId = 1,
@@ -260,9 +277,11 @@ class AvailableVisitSessionsWithoutAppointmentsCheckTest : IntegrationTestBase()
     )
 
     // Then
-    responseSpec.expectStatus().isOk
+    val returnResult = responseSpec.expectStatus().isOk
       .expectBody()
       .jsonPath("$.size()").isEqualTo(1)
+    val availableSessions = getResults(returnResult)
+    assertThat(availableSessions[0].visitOrderRestriction).isEqualTo(visitSession1.visitOrderRestriction)
     verify(appointmentsServiceSpy, times(0)).getHigherPriorityAppointments(any(), any(), any())
   }
 
@@ -271,7 +290,7 @@ class AvailableVisitSessionsWithoutAppointmentsCheckTest : IntegrationTestBase()
     // Given
     val prisonCode = "MDI"
     val prisonerId = "AA123456B"
-    val visitSession1 = AvailableVisitSessionDto(LocalDate.now(), "s1", SessionTimeSlotDto(LocalTime.of(9, 0), LocalTime.of(10, 0)), CLOSED)
+    val visitSession1 = AvailableVisitSessionDto(LocalDate.now(), "s1", SessionTimeSlotDto(LocalTime.of(9, 0), LocalTime.of(10, 0)), CLOSED, visitOrderRestriction = VO)
 
     val prisonDto = VisitSchedulerPrisonDto(prisonCode, true, 2, 28, 6, 3, 3, 18, DayOfWeek.MONDAY, 3)
     val dateRange = visitSchedulerMockServer.stubGetAvailableVisitSessions(prisonDto, prisonerId, CLOSED, mutableListOf(visitSession1), userType = PUBLIC)
@@ -295,9 +314,11 @@ class AvailableVisitSessionsWithoutAppointmentsCheckTest : IntegrationTestBase()
     )
 
     // Then
-    responseSpec.expectStatus().isOk
+    val returnResult = responseSpec.expectStatus().isOk
       .expectBody()
       .jsonPath("$.size()").isEqualTo(1)
+    val availableSessions = getResults(returnResult)
+    assertThat(availableSessions[0].visitOrderRestriction).isEqualTo(visitSession1.visitOrderRestriction)
     verify(appointmentsServiceSpy, times(0)).getHigherPriorityAppointments(any(), any(), any())
   }
 
@@ -473,4 +494,6 @@ class AvailableVisitSessionsWithoutAppointmentsCheckTest : IntegrationTestBase()
     // Then
     responseSpec.expectStatus().isUnauthorized
   }
+
+  private fun getResults(returnResult: WebTestClient.BodyContentSpec): Array<AvailableVisitSessionDto> = TestObjectMapper.mapper.readValue(returnResult.returnResult().responseBody, Array<AvailableVisitSessionDto>::class.java)
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/sessions/VisitSessionTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/sessions/VisitSessionTest.kt
@@ -40,6 +40,7 @@ class VisitSessionTest : IntegrationTestBase() {
     val visitSessionDtoResponse = TestObjectMapper.mapper.readValue(responseSpec.expectBody().returnResult().responseBody, VisitSessionDto::class.java)
 
     Assertions.assertThat(visitSessionDtoResponse.sessionTemplateReference).isEqualTo(sessionTemplateReference)
+    Assertions.assertThat(visitSessionDtoResponse.visitOrderRestriction).isEqualTo(visitSessionDto.visitOrderRestriction)
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/sessions/VisitSessionsAndScheduleTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/sessions/VisitSessionsAndScheduleTest.kt
@@ -10,6 +10,8 @@ import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpStatus
 import org.springframework.test.web.reactive.server.WebTestClient
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.visit.scheduler.VisitSchedulerPrisonDto
+import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.visit.scheduler.VisitSessionDto
+import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.visit.scheduler.enums.SessionTemplateVisitOrderRestrictionType
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.visit.scheduler.enums.UserType.STAFF
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.visit.scheduler.sessions.VisitSessionsAndScheduleDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.integration.IntegrationTestBase
@@ -61,13 +63,45 @@ class VisitSessionsAndScheduleTest : IntegrationTestBase() {
   @Test
   fun `when visit sessions and a schedule exists then allowed sessions are returned for all dates starting today`() {
     // Given
-    val visitSessionDto1 = createVisitSessionDto(prisonCode, "1", startTimestamp = LocalDateTime.of(today.plusDays(3), sessionStartTime), endTimestamp = LocalDateTime.of(today.plusDays(3), sessionEndTime))
-    val visitSessionDto2 = createVisitSessionDto(prisonCode, "2", startTimestamp = LocalDateTime.of(today.plusDays(4), sessionStartTime), endTimestamp = LocalDateTime.of(today.plusDays(4), sessionEndTime))
-    val visitSessionDto3 = createVisitSessionDto(prisonCode, "3", startTimestamp = LocalDateTime.of(today.plusDays(5), sessionStartTime), endTimestamp = LocalDateTime.of(today.plusDays(5), sessionEndTime))
-    val visitSessionDto4 = createVisitSessionDto(prisonCode, "4", startTimestamp = LocalDateTime.of(today.plusDays(6), sessionStartTime), endTimestamp = LocalDateTime.of(today.plusDays(6), sessionEndTime))
-    val visitSessionDto5 = createVisitSessionDto(prisonCode, "5", startTimestamp = LocalDateTime.of(today.plusDays(7), sessionStartTime), endTimestamp = LocalDateTime.of(today.plusDays(7), sessionEndTime))
+    val visitSessionDtos = listOf(
+      createVisitSessionDto(
+        prisonCode,
+        "1",
+        startTimestamp = LocalDateTime.of(today.plusDays(3), sessionStartTime),
+        endTimestamp = LocalDateTime.of(today.plusDays(3), sessionEndTime),
+        visitOrderRestriction = SessionTemplateVisitOrderRestrictionType.VO,
+      ),
+      createVisitSessionDto(
+        prisonCode,
+        "2",
+        startTimestamp = LocalDateTime.of(today.plusDays(4), sessionStartTime),
+        endTimestamp = LocalDateTime.of(today.plusDays(4), sessionEndTime),
+        visitOrderRestriction = SessionTemplateVisitOrderRestrictionType.PVO,
+      ),
+      createVisitSessionDto(
+        prisonCode,
+        "3",
+        startTimestamp = LocalDateTime.of(today.plusDays(5), sessionStartTime),
+        endTimestamp = LocalDateTime.of(today.plusDays(5), sessionEndTime),
+        visitOrderRestriction = SessionTemplateVisitOrderRestrictionType.VO_PVO,
+      ),
+      createVisitSessionDto(
+        prisonCode,
+        "4",
+        startTimestamp = LocalDateTime.of(today.plusDays(6), sessionStartTime),
+        endTimestamp = LocalDateTime.of(today.plusDays(6), sessionEndTime),
+        visitOrderRestriction = SessionTemplateVisitOrderRestrictionType.NONE,
+      ),
+      createVisitSessionDto(
+        prisonCode,
+        "5",
+        startTimestamp = LocalDateTime.of(today.plusDays(7), sessionStartTime),
+        endTimestamp = LocalDateTime.of(today.plusDays(7), sessionEndTime),
+        visitOrderRestriction = SessionTemplateVisitOrderRestrictionType.VO,
+      ),
+    )
 
-    visitSchedulerMockServer.stubGetVisitSessions(prisonCode, prisonerId, mutableListOf(visitSessionDto1, visitSessionDto2, visitSessionDto3, visitSessionDto4, visitSessionDto5), userType = STAFF)
+    visitSchedulerMockServer.stubGetVisitSessions(prisonCode, prisonerId, visitSessionDtos, userType = STAFF)
 
     val appointment1 = createScheduledEvent(1L, today.plusDays(4), eventStartTime = LocalDateTime.of(today.plusDays(4), LocalTime.of(9, 0)), eventEndTime = LocalDateTime.of(today.plusDays(4), LocalTime.of(10, 0)))
     val appointment2 = createScheduledEvent(2L, today.plusDays(5), eventStartTime = LocalDateTime.of(today.plusDays(5), LocalTime.of(9, 0)), eventEndTime = LocalDateTime.of(today.plusDays(5), LocalTime.of(10, 0)))
@@ -95,6 +129,7 @@ class VisitSessionsAndScheduleTest : IntegrationTestBase() {
 
     val datesWithNoSessionsOrSchedule = sessionsAndScheduleDto.sessionsAndSchedule.map { it.date }.filter { !datesWithSessionsAndSchedule.contains(it) && !datesWithSessionsNoSchedule.contains(it) }
     assertSessionsAndScheduleCount(sessionsAndScheduleDto, datesWithNoSessionsOrSchedule, 0, 0)
+    assertVisitOrderRestrictions(sessionsAndScheduleDto, visitSessionDtos)
     verify(visitSchedulerClientSpy, times(1)).getVisitSessions(prisonCode, prisonerId, null, null, null, STAFF)
     verify(whereAboutsApiClientSpy, times(1)).getEvents(prisonerId, LocalDate.now().plusDays(minDays.toLong() + 1), LocalDate.now().plusDays(maxDays.toLong()))
   }
@@ -161,6 +196,7 @@ class VisitSessionsAndScheduleTest : IntegrationTestBase() {
 
     val datesWithNoSessionsOrSchedule = sessionsAndScheduleDto.sessionsAndSchedule.map { it.date }.filter { !datesWithSessionsAndSchedule.contains(it) && !datesWithSessionsNoSchedule.contains(it) }
     assertSessionsAndScheduleCount(sessionsAndScheduleDto, datesWithNoSessionsOrSchedule, 0, 0)
+    assertVisitOrderRestrictions(sessionsAndScheduleDto, listOf(visitSessionDto1, visitSessionDto2, visitSessionDto3, visitSessionDto4, visitSessionDto5))
     verify(visitSchedulerClientSpy, times(1)).getVisitSessions(prisonCode, prisonerId, null, null, null, STAFF)
     verify(whereAboutsApiClientSpy, times(1)).getEvents(prisonerId, LocalDate.now().plusDays(minDays.toLong() + 1), LocalDate.now().plusDays(maxDays.toLong()))
   }
@@ -229,6 +265,7 @@ class VisitSessionsAndScheduleTest : IntegrationTestBase() {
 
     // no scheduled events are returned for any dates
     assertThat(sessionsAndScheduleDto.sessionsAndSchedule.map { it.scheduledEvents }.sumOf { it.count() }).isEqualTo(0)
+    assertVisitOrderRestrictions(sessionsAndScheduleDto, listOf(visitSessionDto1, visitSessionDto2, visitSessionDto3, visitSessionDto4, visitSessionDto5))
     verify(visitSchedulerClientSpy, times(1)).getVisitSessions(prisonCode, prisonerId, null, null, null, STAFF)
     verify(whereAboutsApiClientSpy, times(1)).getEvents(prisonerId, LocalDate.now().plusDays(minDays.toLong() + 1), LocalDate.now().plusDays(maxDays.toLong()))
   }
@@ -259,6 +296,7 @@ class VisitSessionsAndScheduleTest : IntegrationTestBase() {
 
     // no scheduled events are returned for any dates
     assertThat(sessionsAndScheduleDto.sessionsAndSchedule.map { it.scheduledEvents }.sumOf { it.count() }).isEqualTo(0)
+    assertVisitOrderRestrictions(sessionsAndScheduleDto, listOf(visitSessionDto1, visitSessionDto2, visitSessionDto3, visitSessionDto4, visitSessionDto5))
     verify(visitSchedulerClientSpy, times(1)).getVisitSessions(prisonCode, prisonerId, null, null, null, STAFF)
     verify(whereAboutsApiClientSpy, times(1)).getEvents(prisonerId, LocalDate.now().plusDays(minDays.toLong() + 1), LocalDate.now().plusDays(maxDays.toLong()))
   }
@@ -267,6 +305,19 @@ class VisitSessionsAndScheduleTest : IntegrationTestBase() {
     for (date in dates) {
       assertThat(sessionsAndScheduleDto.sessionsAndSchedule.first { it.date == date }.visitSessions.size).isEqualTo(sessions)
       assertThat(sessionsAndScheduleDto.sessionsAndSchedule.first { it.date == date }.scheduledEvents.size).isEqualTo(schedules)
+    }
+  }
+
+  private fun assertVisitOrderRestrictions(
+    sessionsAndScheduleDto: VisitSessionsAndScheduleDto,
+    expectedVisitSessions: List<VisitSessionDto>,
+  ) {
+    val actualRestrictionsBySessionTemplateReference = sessionsAndScheduleDto.sessionsAndSchedule
+      .flatMap { it.visitSessions }
+      .associate { it.sessionTemplateReference to it.visitOrderRestriction }
+
+    expectedVisitSessions.forEach {
+      assertThat(actualRestrictionsBySessionTemplateReference[it.sessionTemplateReference]).isEqualTo(it.visitOrderRestriction)
     }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/sessions/VisitSessionsScheduleTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/sessions/VisitSessionsScheduleTest.kt
@@ -9,6 +9,7 @@ import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.vis
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.visit.scheduler.SessionDateRangeDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.visit.scheduler.SessionScheduleDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.visit.scheduler.SessionTimeSlotDto
+import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.visit.scheduler.enums.SessionTemplateVisitOrderRestrictionType
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.visit.scheduler.enums.VisitType
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.integration.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.integration.TestObjectMapper
@@ -54,6 +55,7 @@ class VisitSessionsScheduleTest : IntegrationTestBase() {
       areCategoryGroupsInclusive = false,
       areIncentiveGroupsInclusive = false,
       visitRoom = "Visit Room 2",
+      visitOrderRestriction = SessionTemplateVisitOrderRestrictionType.NONE,
     )
     visitSchedulerMockServer.stubGetSessionSchedule(
       prisonCode,
@@ -80,6 +82,7 @@ class VisitSessionsScheduleTest : IntegrationTestBase() {
     assertThat(sessionScheduleResults[0].areCategoryGroupsInclusive).isTrue()
     assertThat(sessionScheduleResults[0].areIncentiveGroupsInclusive).isTrue()
     assertThat(sessionScheduleResults[0].visitRoom).isEqualTo("Visit Room 1")
+    assertThat(sessionScheduleResults[0].visitOrderRestriction).isEqualTo(SessionTemplateVisitOrderRestrictionType.VO_PVO)
 
     assertThat(sessionScheduleResults[1].sessionTemplateReference).isEqualTo(sessionScheduleDto2.sessionTemplateReference)
     assertThat(sessionScheduleResults[1].sessionTimeSlot.startTime).isEqualTo(LocalTime.parse("10:00"))
@@ -93,6 +96,7 @@ class VisitSessionsScheduleTest : IntegrationTestBase() {
     assertThat(sessionScheduleResults[1].areCategoryGroupsInclusive).isFalse()
     assertThat(sessionScheduleResults[1].areIncentiveGroupsInclusive).isFalse()
     assertThat(sessionScheduleResults[1].visitRoom).isEqualTo("Visit Room 2")
+    assertThat(sessionScheduleResults[1].visitOrderRestriction).isEqualTo(SessionTemplateVisitOrderRestrictionType.NONE)
   }
 
   @Test
@@ -128,6 +132,7 @@ class VisitSessionsScheduleTest : IntegrationTestBase() {
     prisonerLocationGroupNames: List<String> = mutableListOf(),
     prisonerCategoryGroupNames: List<String> = mutableListOf(),
     prisonerIncentiveLevelGroupNames: List<String> = mutableListOf(),
+    visitOrderRestriction: SessionTemplateVisitOrderRestrictionType = SessionTemplateVisitOrderRestrictionType.VO_PVO,
   ): SessionScheduleDto = SessionScheduleDto(
     sessionTemplateReference = reference,
     sessionDateRange = SessionDateRangeDto(validFromDate, validToDate),
@@ -142,6 +147,7 @@ class VisitSessionsScheduleTest : IntegrationTestBase() {
     areIncentiveGroupsInclusive = areIncentiveGroupsInclusive,
     prisonerIncentiveLevelGroupNames = prisonerIncentiveLevelGroupNames,
     visitRoom = visitRoom,
+    visitOrderRestriction = visitOrderRestriction,
   )
 
   private fun getResults(returnResult: WebTestClient.BodyContentSpec): Array<SessionScheduleDto> = TestObjectMapper.mapper.readValue(returnResult.returnResult().responseBody, Array<SessionScheduleDto>::class.java)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/sessions/VisitSessionsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/sessions/VisitSessionsTest.kt
@@ -1,14 +1,18 @@
 package uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.integration.sessions
 
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.springframework.http.HttpHeaders
 import org.springframework.test.web.reactive.server.WebTestClient
+import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.visit.scheduler.VisitSessionDto
+import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.visit.scheduler.enums.SessionTemplateVisitOrderRestrictionType
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.visit.scheduler.enums.UserType
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.visit.scheduler.enums.UserType.STAFF
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.integration.IntegrationTestBase
+import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.integration.TestObjectMapper
 
 @DisplayName("Get visit sessions")
 class VisitSessionsTest : IntegrationTestBase() {
@@ -40,21 +44,28 @@ class VisitSessionsTest : IntegrationTestBase() {
     // Given
     val prisonCode = "MDI"
     val prisonerId = "ABC"
-    val visitSessionDto1 = createVisitSessionDto(prisonCode, "1")
-    val visitSessionDto2 = createVisitSessionDto(prisonCode, "2")
-    val visitSessionDto3 = createVisitSessionDto(prisonCode, "3")
-    val visitSessionDto4 = createVisitSessionDto(prisonCode, "4")
-    val visitSessionDto5 = createVisitSessionDto(prisonCode, "5")
+    val expectedVisitSessionDtos = listOf(
+      createVisitSessionDto(prisonCode, "1", visitOrderRestriction = SessionTemplateVisitOrderRestrictionType.VO),
+      createVisitSessionDto(prisonCode, "2", visitOrderRestriction = SessionTemplateVisitOrderRestrictionType.PVO),
+      createVisitSessionDto(prisonCode, "3", visitOrderRestriction = SessionTemplateVisitOrderRestrictionType.VO_PVO),
+      createVisitSessionDto(prisonCode, "4", visitOrderRestriction = SessionTemplateVisitOrderRestrictionType.NONE),
+      createVisitSessionDto(prisonCode, "5", visitOrderRestriction = SessionTemplateVisitOrderRestrictionType.VO),
+    )
 
-    visitSchedulerMockServer.stubGetVisitSessions(prisonCode, prisonerId, mutableListOf(visitSessionDto1, visitSessionDto2, visitSessionDto3, visitSessionDto4, visitSessionDto5), userType = STAFF)
+    visitSchedulerMockServer.stubGetVisitSessions(prisonCode, prisonerId, expectedVisitSessionDtos, userType = STAFF)
 
     // When
     val responseSpec = callGetVisitSessions(webTestClient, prisonCode, prisonerId, username = null, userType = STAFF, roleVSIPOrchestrationServiceHttpHeaders)
 
     // Then
-    responseSpec.expectStatus().isOk
+    val returnResult = responseSpec.expectStatus().isOk
       .expectBody()
       .jsonPath("$.size()").isEqualTo(5)
+
+    val actualVisitSessionDtos = TestObjectMapper.mapper.readValue(returnResult.returnResult().responseBody, Array<VisitSessionDto>::class.java)
+    assertThat(actualVisitSessionDtos.map { it.visitOrderRestriction }).containsExactlyElementsOf(
+      expectedVisitSessionDtos.map { it.visitOrderRestriction },
+    )
   }
 
   @Test


### PR DESCRIPTION
## Not Ready For Merge ##
Can only be merged once frontend is ready.

## What does this pull request do?

Expose visit order restriction type on all DTOs which require it. Eventually this will be used to display to staff (or filter for public) which visit order restriction is present on the session.

## JIRA Link
https://dsdmoj.atlassian.net/browse/VB-6495