### PR TITLE
Add visit date to Visit Pass Dto.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/client/VisitPassesClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/client/VisitPassesClient.kt
@@ -76,6 +76,7 @@ class VisitPassesClient(
 
   private fun getVisitPass(visit: VisitDto, prisoner: AttributeSearchPrisonerDto, visitors: List<VisitPassVisitorDto>) = VisitPassDto(
     reference = visit.reference,
+    visitDate = visit.startTimestamp.toLocalDate(),
     startTime = visit.startTimestamp.toLocalTime(),
     endTime = visit.endTimestamp.toLocalTime(),
     prisonerId = visit.prisonerId,
@@ -87,6 +88,7 @@ class VisitPassesClient(
 
   private fun getVisitPass(visit: VisitDto, prisoner: PrisonerDto, visitors: List<VisitPassVisitorDto>) = VisitPassDto(
     reference = visit.reference,
+    visitDate = visit.startTimestamp.toLocalDate(),
     startTime = visit.startTimestamp.toLocalTime(),
     endTime = visit.endTimestamp.toLocalTime(),
     prisonerId = visit.prisonerId,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/dto/visit/scheduler/passes/VisitPassDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/dto/visit/scheduler/passes/VisitPassDto.kt
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonFormat
 import com.fasterxml.jackson.annotation.JsonInclude
 import io.swagger.v3.oas.annotations.media.Schema
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.visit.scheduler.enums.VisitRestriction
+import java.time.LocalDate
 import java.time.LocalTime
 
 @Schema(description = "Visit Pass Details")
@@ -11,6 +12,8 @@ import java.time.LocalTime
 data class VisitPassDto(
   @param:Schema(description = "Visit Reference", example = "v9-d7-ed-7u", required = true)
   val reference: String,
+  @param:Schema(description = "Visit Date", example = "2026-09-21", required = true)
+  val visitDate: LocalDate,
   @field:JsonFormat(pattern = "HH:mm", shape = JsonFormat.Shape.STRING)
   @param:Schema(description = "Visit Start time", example = "11:00", required = true)
   val startTime: LocalTime,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/visit/passes/GetVisitPassTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/visit/passes/GetVisitPassTest.kt
@@ -331,6 +331,7 @@ class GetVisitPassTest : IntegrationTestBase() {
     contactDtoList: List<ContactWithOptionalPrisonerRelationshipDto>,
     visitPassDto: VisitPassDto,
   ) {
+    assertThat(visitPassDto.visitDate).isEqualTo(visitDto.startTimestamp.toLocalDate())
     assertThat(visitPassDto.startTime).isEqualTo(visitDto.startTimestamp.toLocalTime())
     assertThat(visitPassDto.endTime).isEqualTo(visitDto.endTimestamp.toLocalTime())
     assertThat(visitPassDto.prisonerId).isEqualTo(visitDto.prisonerId)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/visit/passes/GetVisitPassesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/visit/passes/GetVisitPassesTest.kt
@@ -425,6 +425,7 @@ class GetVisitPassesTest : IntegrationTestBase() {
     contactDtoList: List<ContactWithOptionalPrisonerRelationshipDto>,
     visitPassDto: VisitPassDto,
   ) {
+    assertThat(visitPassDto.visitDate).isEqualTo(visitDto.startTimestamp.toLocalDate())
     assertThat(visitPassDto.startTime).isEqualTo(visitDto.startTimestamp.toLocalTime())
     assertThat(visitPassDto.endTime).isEqualTo(visitDto.endTimestamp.toLocalTime())
     assertThat(visitPassDto.prisonerId).isEqualTo(visitDto.prisonerId)


### PR DESCRIPTION

Adds the visit date as an explicit field on the Visit Pass DTO so API consumers can access the date without deriving it from timestamps.

Changes:

Added visitDate: LocalDate to VisitPassDto (OpenAPI schema updated accordingly).
Populated visitDate when building VisitPassDto instances in VisitPassesClient.
Extended integration tests to assert the returned visitDate matches the visit start timestamp’s date.