### PR TITLE
VB-6283 - Visit request rejection reason

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -10,5 +10,10 @@
 # Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
 version: v1.25.1
 # ignores vulnerabilities until expiry date; change duration by modifying expiry date
-ignore: {}
+ignore:
+  SNYK-JAVA-IOOPENTELEMETRY-17280222:
+    - '*':
+        reason: Suppression for baggage limits issue as we use header size limits
+        expires: 2026-07-11T00:00:00.000Z
+        created: 2026-06-11T07:38:00.250Z
 patch: {}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/dto/visit/scheduler/RejectVisitRequestBodyDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/dto/visit/scheduler/RejectVisitRequestBodyDto.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.vi
 
 import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.constraints.NotNull
+import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.visit.scheduler.enums.VisitRequestRejectionReason
 
 data class RejectVisitRequestBodyDto(
   @field:Schema(description = "Reference of the visit for rejection", required = true)
@@ -10,4 +11,6 @@ data class RejectVisitRequestBodyDto(
   @field:Schema(description = "Username for user who actioned this request", required = true)
   @field:NotNull
   val actionedBy: String,
+  @field:Schema(description = "Reason for rejecting a visit request", required = false)
+  val visitRequestRejectionReason: VisitRequestRejectionReason? = null,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/dto/visit/scheduler/enums/VisitRequestRejectionReason.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/dto/visit/scheduler/enums/VisitRequestRejectionReason.kt
@@ -1,0 +1,6 @@
+package uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.visit.scheduler.enums
+
+enum class VisitRequestRejectionReason {
+  NO_VISIT_ALLOWANCE,
+  ALERT_OR_RESTRICTION,
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/mock/VisitSchedulerMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/mock/VisitSchedulerMockServer.kt
@@ -25,6 +25,7 @@ import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.vis
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.visit.scheduler.CreateVisitFromExternalSystemDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.visit.scheduler.DateRange
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.visit.scheduler.EventAuditDto
+import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.visit.scheduler.RejectVisitRequestBodyDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.visit.scheduler.SessionCapacityDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.visit.scheduler.SessionScheduleDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.visit.scheduler.UpdateVisitFromExternalSystemDto
@@ -492,12 +493,22 @@ class VisitSchedulerMockServer : WireMockServer(8092) {
     )
   }
 
-  fun stubRejectVisitRequestByReference(visitReference: String, rejectVisitRequestResponse: VisitDto?, status: HttpStatus? = null) {
+  fun stubRejectVisitRequestByReference(
+    visitReference: String,
+    rejectVisitRequestResponse: VisitDto?,
+    status: HttpStatus? = null,
+    expectedRequestBody: RejectVisitRequestBodyDto? = null,
+  ) {
     val responseBuilder = createJsonResponseBuilder()
     val url = VISIT_REQUESTS_REJECT_VISIT_BY_REFERENCE_PATH.replace("{reference}", visitReference)
+    val requestBuilder = put(url)
+
+    expectedRequestBody?.let {
+      requestBuilder.withRequestBody(equalToJson(getJsonString(it)))
+    }
 
     stubFor(
-      put(url)
+      requestBuilder
         .willReturn(
           if (rejectVisitRequestResponse == null) {
             responseBuilder.withStatus(status?.value() ?: HttpStatus.NOT_FOUND.value())

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/visit/RejectVisitRequestByReferenceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/visit/RejectVisitRequestByReferenceTest.kt
@@ -43,7 +43,7 @@ class RejectVisitRequestByReferenceTest : IntegrationTestBase() {
     val rejectVisitRequestBodyDto = RejectVisitRequestBodyDto(
       visitReference = visitReference,
       actionedBy = "user_1",
-      visitRequestRejectionReason = VisitRequestRejectionReason.NO_VISIT_ALLOWANCE,
+      visitRequestRejectionReason = null,
     )
 
     visitSchedulerMockServer.stubRejectVisitRequestByReference(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/visit/RejectVisitRequestByReferenceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/visit/RejectVisitRequestByReferenceTest.kt
@@ -13,6 +13,7 @@ import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.control
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.orchestration.OrchestrationApproveRejectVisitRequestResponseDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.visit.scheduler.RejectVisitRequestBodyDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.visit.scheduler.VisitSubStatus
+import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.visit.scheduler.enums.VisitRequestRejectionReason
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.visit.scheduler.enums.VisitStatus
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.integration.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.integration.TestObjectMapper
@@ -39,9 +40,17 @@ class RejectVisitRequestByReferenceTest : IntegrationTestBase() {
       dateOfBirth = LocalDate.of(1980, 1, 1),
       convictedStatus = "Convicted",
     )
-    val rejectVisitRequestBodyDto = RejectVisitRequestBodyDto(visitReference, "user_1")
+    val rejectVisitRequestBodyDto = RejectVisitRequestBodyDto(
+      visitReference = visitReference,
+      actionedBy = "user_1",
+      visitRequestRejectionReason = VisitRequestRejectionReason.NO_VISIT_ALLOWANCE,
+    )
 
-    visitSchedulerMockServer.stubRejectVisitRequestByReference(visitReference, createVisitDto(reference = visitReference, visitStatus = VisitStatus.CANCELLED, visitSubStatus = VisitSubStatus.REJECTED))
+    visitSchedulerMockServer.stubRejectVisitRequestByReference(
+      visitReference,
+      createVisitDto(reference = visitReference, visitStatus = VisitStatus.CANCELLED, visitSubStatus = VisitSubStatus.REJECTED),
+      expectedRequestBody = rejectVisitRequestBodyDto,
+    )
 
     // When
     prisonOffenderSearchMockServer.stubGetPrisonerById("AB12345DS", prisonerDto)
@@ -59,9 +68,17 @@ class RejectVisitRequestByReferenceTest : IntegrationTestBase() {
   fun `when reject visit request is called but prisoner response fails, then success response is returned with placeholder`() {
     // Given
     val visitReference = "ab-cd-ef-gh"
-    val rejectVisitRequestBodyDto = RejectVisitRequestBodyDto(visitReference, "user_1")
+    val rejectVisitRequestBodyDto = RejectVisitRequestBodyDto(
+      visitReference = visitReference,
+      actionedBy = "user_1",
+      visitRequestRejectionReason = VisitRequestRejectionReason.NO_VISIT_ALLOWANCE,
+    )
 
-    visitSchedulerMockServer.stubRejectVisitRequestByReference(visitReference, createVisitDto(reference = visitReference, visitStatus = VisitStatus.CANCELLED, visitSubStatus = VisitSubStatus.REJECTED))
+    visitSchedulerMockServer.stubRejectVisitRequestByReference(
+      visitReference,
+      createVisitDto(reference = visitReference, visitStatus = VisitStatus.CANCELLED, visitSubStatus = VisitSubStatus.REJECTED),
+      expectedRequestBody = rejectVisitRequestBodyDto,
+    )
 
     // When
     prisonOffenderSearchMockServer.stubGetPrisonerById("AB12345DS", null, HttpStatus.INTERNAL_SERVER_ERROR)
@@ -79,9 +96,18 @@ class RejectVisitRequestByReferenceTest : IntegrationTestBase() {
   fun `when reject visit request is called but fails, then error response is returned up to caller`() {
     // Given
     val visitReference = "ab-cd-ef-gh"
-    val rejectVisitRequestBodyDto = RejectVisitRequestBodyDto(visitReference, "user_1")
+    val rejectVisitRequestBodyDto = RejectVisitRequestBodyDto(
+      visitReference = visitReference,
+      actionedBy = "user_1",
+      visitRequestRejectionReason = VisitRequestRejectionReason.NO_VISIT_ALLOWANCE,
+    )
 
-    visitSchedulerMockServer.stubRejectVisitRequestByReference(visitReference, null, HttpStatus.BAD_REQUEST)
+    visitSchedulerMockServer.stubRejectVisitRequestByReference(
+      visitReference,
+      null,
+      HttpStatus.BAD_REQUEST,
+      expectedRequestBody = rejectVisitRequestBodyDto,
+    )
 
     // When
     prisonOffenderSearchMockServer.stubGetPrisonerById("AB12345DS", null, HttpStatus.INTERNAL_SERVER_ERROR)
@@ -95,7 +121,11 @@ class RejectVisitRequestByReferenceTest : IntegrationTestBase() {
   fun `when no role specified then access forbidden status is returned`() {
     // Given
     val authHttpHeaders = setAuthorisation(roles = listOf())
-    val rejectVisitRequestBodyDto = RejectVisitRequestBodyDto("ab-cd-ef-gh", "user_1")
+    val rejectVisitRequestBodyDto = RejectVisitRequestBodyDto(
+      visitReference = "ab-cd-ef-gh",
+      actionedBy = "user_1",
+      visitRequestRejectionReason = VisitRequestRejectionReason.NO_VISIT_ALLOWANCE,
+    )
 
     // When
     val responseSpec = callRejectVisitRequestByReference(webTestClient, rejectVisitRequestBodyDto, authHttpHeaders)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/visit/RejectVisitRequestByReferenceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/visit/RejectVisitRequestByReferenceTest.kt
@@ -49,7 +49,6 @@ class RejectVisitRequestByReferenceTest : IntegrationTestBase() {
     visitSchedulerMockServer.stubRejectVisitRequestByReference(
       visitReference,
       createVisitDto(reference = visitReference, visitStatus = VisitStatus.CANCELLED, visitSubStatus = VisitSubStatus.REJECTED),
-      expectedRequestBody = rejectVisitRequestBodyDto,
     )
 
     // When


### PR DESCRIPTION
## What does this PR do?
Add new rejection reason to the manual reject visit request path. Staff can optionally pass in a rejection reason (from a list provided in the UI) which will be stored in the visit-scheduler visit history via the event_audit table.

## JIRA Link
https://dsdmoj.atlassian.net/browse/VB-6283