### PR TITLE
VB-5864 - Allow booker to update prisoners location

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/client/PrisonVisitBookerRegistryClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/client/PrisonVisitBookerRegistryClient.kt
@@ -29,6 +29,7 @@ import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.boo
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.booker.registry.RegisterPrisonerForBookerDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.booker.registry.RegisterVisitorForBookerPrisonerDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.booker.registry.RejectVisitorRequestDto
+import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.booker.registry.UpdateRegisteredPrisonersPrisonDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.booker.registry.VisitorRequestsCountByPrisonCodeDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.booker.registry.admin.BookerInfoDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.booker.registry.admin.BookerSearchResultsDto
@@ -48,6 +49,7 @@ const val BOOKER_REGISTRY_AUDIT_HISTORY: String = "$PUBLIC_BOOKER_CONTROLLER_PAT
 const val PERMITTED_PRISONERS: String = "$PUBLIC_BOOKER_CONTROLLER_PATH/{bookerReference}/permitted/prisoners"
 const val REGISTER_PRISONER: String = "$PERMITTED_PRISONERS/register"
 const val VALIDATE_PRISONER: String = "$PERMITTED_PRISONERS/{prisonerId}/validate"
+const val UPDATE_PERMITTED_PRISONER_PRISON: String = "$PERMITTED_PRISONERS/{prisonerId}/prison"
 
 const val PERMITTED_VISITORS: String = "$PERMITTED_PRISONERS/{prisonerId}/permitted/visitors"
 
@@ -153,6 +155,20 @@ class PrisonVisitBookerRegistryClient(
         }
       }
       .block(apiTimeout)
+  }
+
+  fun updatePermittedPrisonerPrison(bookerReference: String, prisonerId: String, updateRegisteredPrisonersPrisonDto: UpdateRegisteredPrisonersPrisonDto): PermittedPrisonerForBookerDto {
+    val uri = UPDATE_PERMITTED_PRISONER_PRISON
+      .replace("{bookerReference}", bookerReference)
+      .replace("{prisonerId}", prisonerId)
+
+    return webClient.put()
+      .uri(uri)
+      .body(BodyInserters.fromValue(updateRegisteredPrisonersPrisonDto))
+      .retrieve()
+      .bodyToMono<PermittedPrisonerForBookerDto>()
+      .blockOptional(apiTimeout)
+      .orElseThrow { IllegalStateException("Empty response from updatePermittedPrisonerPrison call with URL $uri") }
   }
 
   fun registerVisitorForBookerPrisoner(bookerReference: String, prisonerId: String, registerVisitorForBookerPrisonerDto: RegisterVisitorForBookerPrisonerDto): PermittedVisitorsForPermittedPrisonerBookerDto {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/client/PrisonVisitBookerRegistryClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/client/PrisonVisitBookerRegistryClient.kt
@@ -29,7 +29,7 @@ import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.boo
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.booker.registry.RegisterPrisonerForBookerDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.booker.registry.RegisterVisitorForBookerPrisonerDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.booker.registry.RejectVisitorRequestDto
-import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.booker.registry.UpdateRegisteredPrisonersPrisonDto
+import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.booker.registry.UpdateRegisteredPrisonerPrisonDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.booker.registry.VisitorRequestsCountByPrisonCodeDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.booker.registry.admin.BookerInfoDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.booker.registry.admin.BookerSearchResultsDto
@@ -157,14 +157,14 @@ class PrisonVisitBookerRegistryClient(
       .block(apiTimeout)
   }
 
-  fun updatePermittedPrisonerPrison(bookerReference: String, prisonerId: String, updateRegisteredPrisonersPrisonDto: UpdateRegisteredPrisonersPrisonDto): PermittedPrisonerForBookerDto {
+  fun updatePermittedPrisonerPrison(bookerReference: String, prisonerId: String, updateRegisteredPrisonerPrisonDto: UpdateRegisteredPrisonerPrisonDto): PermittedPrisonerForBookerDto {
     val uri = UPDATE_PERMITTED_PRISONER_PRISON
       .replace("{bookerReference}", bookerReference)
       .replace("{prisonerId}", prisonerId)
 
     return webClient.put()
       .uri(uri)
-      .body(BodyInserters.fromValue(updateRegisteredPrisonersPrisonDto))
+      .body(BodyInserters.fromValue(updateRegisteredPrisonerPrisonDto))
       .retrieve()
       .bodyToMono<PermittedPrisonerForBookerDto>()
       .blockOptional(apiTimeout)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/controller/PublicBookerController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/controller/PublicBookerController.kt
@@ -38,7 +38,7 @@ import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.boo
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.booker.registry.RegisterVisitorForBookerPrisonerDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.booker.registry.RejectVisitorRequestDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.booker.registry.SingleVisitorRequestForReviewDto
-import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.booker.registry.UpdateRegisteredPrisonersPrisonDto
+import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.booker.registry.UpdateRegisteredPrisonerPrisonDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.booker.registry.VisitorInfoDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.booker.registry.VisitorRequestsCountByPrisonCodeDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.booker.registry.admin.BookerDetailedInfoDto
@@ -355,8 +355,8 @@ class PublicBookerController(
     prisonerId: String,
     @RequestBody
     @Valid
-    updateRegisteredPrisonersPrisonDto: UpdateRegisteredPrisonersPrisonDto,
-  ): PermittedPrisonerForBookerDto = publicBookerService.updatePermittedPrisonerPrison(bookerReference, prisonerId, updateRegisteredPrisonersPrisonDto)
+    updateRegisteredPrisonerPrisonDto: UpdateRegisteredPrisonerPrisonDto,
+  ): PermittedPrisonerForBookerDto = publicBookerService.updatePermittedPrisonerPrison(bookerReference, prisonerId, updateRegisteredPrisonerPrisonDto)
 
   @PreAuthorize("hasAnyRole('VISIT_SCHEDULER', 'VSIP_ORCHESTRATION_SERVICE')")
   @GetMapping(PUBLIC_BOOKER_GET_BOOKER_AUDIT_PATH)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/controller/PublicBookerController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/controller/PublicBookerController.kt
@@ -30,6 +30,7 @@ import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.boo
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.booker.registry.BookerPrisonerVisitorRequestDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.booker.registry.BookerReference
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.booker.registry.CreateVisitorRequestResponseDto
+import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.booker.registry.PermittedPrisonerForBookerDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.booker.registry.PermittedVisitorsForPermittedPrisonerBookerDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.booker.registry.PrisonVisitorRequestDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.booker.registry.PrisonVisitorRequestListEntryDto
@@ -37,6 +38,7 @@ import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.boo
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.booker.registry.RegisterVisitorForBookerPrisonerDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.booker.registry.RejectVisitorRequestDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.booker.registry.SingleVisitorRequestForReviewDto
+import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.booker.registry.UpdateRegisteredPrisonersPrisonDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.booker.registry.VisitorInfoDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.booker.registry.VisitorRequestsCountByPrisonCodeDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.booker.registry.admin.BookerDetailedInfoDto
@@ -55,6 +57,7 @@ const val PUBLIC_BOOKER_GET_BOOKER_AUDIT_PATH: String = "$PUBLIC_BOOKER_CONTROLL
 const val PUBLIC_BOOKER_GET_PRISONERS_CONTROLLER_PATH: String = "$PUBLIC_BOOKER_CONTROLLER_PATH/{bookerReference}/permitted/prisoners"
 const val PUBLIC_BOOKER_REGISTER_PRISONER_CONTROLLER_PATH: String = "$PUBLIC_BOOKER_GET_PRISONERS_CONTROLLER_PATH/register"
 const val PUBLIC_BOOKER_VALIDATE_PRISONER_CONTROLLER_PATH: String = "$PUBLIC_BOOKER_GET_PRISONERS_CONTROLLER_PATH/{prisonerId}/validate"
+const val PUBLIC_BOOKER_UPDATE_PERMITTED_PRISONER_PRISON_CONTROLLER_PATH: String = "$PUBLIC_BOOKER_GET_PRISONERS_CONTROLLER_PATH/{prisonerId}/prison"
 const val PUBLIC_BOOKER_GET_SOCIAL_CONTACTS_BY_PRISONER_PATH = "$PUBLIC_BOOKER_DETAILS/prisoners/{prisonerId}/social-contacts"
 
 const val PUBLIC_BOOKER_VISITORS_CONTROLLER_PATH: String = "$PUBLIC_BOOKER_GET_PRISONERS_CONTROLLER_PATH/{prisonerId}/permitted/visitors"
@@ -309,6 +312,51 @@ class PublicBookerController(
     @RequestBody
     registerPrisonerForBookerDto: RegisterPrisonerForBookerDto,
   ) = publicBookerService.registerPrisoner(bookerReference, registerPrisonerForBookerDto)
+
+  @PreAuthorize("hasAnyRole('VISIT_SCHEDULER', 'VSIP_ORCHESTRATION_SERVICE')")
+  @PutMapping(PUBLIC_BOOKER_UPDATE_PERMITTED_PRISONER_PRISON_CONTROLLER_PATH)
+  @ResponseStatus(HttpStatus.OK)
+  @Operation(
+    summary = "Update a permitted prisoner's registered prison code",
+    description = "Update a permitted prisoner's registered prison code",
+    responses = [
+      ApiResponse(
+        responseCode = "200",
+        description = "Permitted prisoner's registered prison code was updated successfully",
+      ),
+      ApiResponse(
+        responseCode = "400",
+        description = "Validation failure, incorrect request to update permitted prisoner's registered prison code",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "401",
+        description = "Unauthorized to access this endpoint",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "403",
+        description = "Incorrect permissions for this action",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "404",
+        description = "Booker / prisoner not found",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+    ],
+  )
+  fun updatePermittedPrisonerPrison(
+    @PathVariable(value = "bookerReference", required = true)
+    @NotBlank
+    bookerReference: String,
+    @PathVariable(value = "prisonerId", required = true)
+    @NotBlank
+    prisonerId: String,
+    @RequestBody
+    @Valid
+    updateRegisteredPrisonersPrisonDto: UpdateRegisteredPrisonersPrisonDto,
+  ): PermittedPrisonerForBookerDto = publicBookerService.updatePermittedPrisonerPrison(bookerReference, prisonerId, updateRegisteredPrisonersPrisonDto)
 
   @PreAuthorize("hasAnyRole('VISIT_SCHEDULER', 'VSIP_ORCHESTRATION_SERVICE')")
   @GetMapping(PUBLIC_BOOKER_GET_BOOKER_AUDIT_PATH)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/dto/booker/registry/UpdateRegisteredPrisonerPrisonDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/dto/booker/registry/UpdateRegisteredPrisonerPrisonDto.kt
@@ -5,7 +5,7 @@ import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.constraints.NotBlank
 
 @Schema(description = "Update a booker prisoner's prison code.")
-data class UpdateRegisteredPrisonersPrisonDto(
+data class UpdateRegisteredPrisonerPrisonDto(
   @param:JsonProperty("prisonId")
   @field:NotBlank
   @param:Schema(description = "Prison Id", example = "MDI", required = true)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/dto/booker/registry/UpdateRegisteredPrisonersPrisonDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/dto/booker/registry/UpdateRegisteredPrisonersPrisonDto.kt
@@ -1,0 +1,13 @@
+package uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.booker.registry
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.NotBlank
+
+@Schema(description = "Update a booker prisoner's prison code.")
+data class UpdateRegisteredPrisonersPrisonDto(
+  @param:JsonProperty("prisonId")
+  @field:NotBlank
+  @param:Schema(description = "Prison Id", example = "MDI", required = true)
+  val prisonCode: String,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/service/PublicBookerService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/service/PublicBookerService.kt
@@ -14,9 +14,11 @@ import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.boo
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.booker.registry.BookerHistoryAuditDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.booker.registry.BookerPrisonerInfoDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.booker.registry.BookerReference
+import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.booker.registry.PermittedPrisonerForBookerDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.booker.registry.PermittedVisitorsForPermittedPrisonerBookerDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.booker.registry.RegisterPrisonerForBookerDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.booker.registry.RegisterVisitorForBookerPrisonerDto
+import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.booker.registry.UpdateRegisteredPrisonersPrisonDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.booker.registry.VisitorInfoDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.booker.registry.admin.BookerDetailedInfoDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.booker.registry.admin.BookerPrisonerDetailedInfoDto
@@ -157,6 +159,11 @@ class PublicBookerService(
   fun registerPrisoner(bookerReference: String, registerPrisonerForBookerDto: RegisterPrisonerForBookerDto) {
     logger.trace("register prisoner called for ${registerPrisonerForBookerDto.prisonerId} with booker reference $bookerReference")
     prisonVisitBookerRegistryClient.registerPrisoner(bookerReference, registerPrisonerForBookerDto)
+  }
+
+  fun updatePermittedPrisonerPrison(bookerReference: String, prisonerId: String, updateRegisteredPrisonersPrisonDto: UpdateRegisteredPrisonersPrisonDto): PermittedPrisonerForBookerDto {
+    logger.info("update permitted prisoner prison called for $prisonerId with booker reference $bookerReference")
+    return prisonVisitBookerRegistryClient.updatePermittedPrisonerPrison(bookerReference, prisonerId, updateRegisteredPrisonersPrisonDto)
   }
 
   fun registerVisitorForBookerPrisoner(bookerReference: String, prisonerId: String, registerVisitorForBookerPrisonerDto: RegisterVisitorForBookerPrisonerDto): PermittedVisitorsForPermittedPrisonerBookerDto {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/service/PublicBookerService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/service/PublicBookerService.kt
@@ -18,7 +18,7 @@ import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.boo
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.booker.registry.PermittedVisitorsForPermittedPrisonerBookerDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.booker.registry.RegisterPrisonerForBookerDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.booker.registry.RegisterVisitorForBookerPrisonerDto
-import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.booker.registry.UpdateRegisteredPrisonersPrisonDto
+import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.booker.registry.UpdateRegisteredPrisonerPrisonDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.booker.registry.VisitorInfoDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.booker.registry.admin.BookerDetailedInfoDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.booker.registry.admin.BookerPrisonerDetailedInfoDto
@@ -161,9 +161,9 @@ class PublicBookerService(
     prisonVisitBookerRegistryClient.registerPrisoner(bookerReference, registerPrisonerForBookerDto)
   }
 
-  fun updatePermittedPrisonerPrison(bookerReference: String, prisonerId: String, updateRegisteredPrisonersPrisonDto: UpdateRegisteredPrisonersPrisonDto): PermittedPrisonerForBookerDto {
+  fun updatePermittedPrisonerPrison(bookerReference: String, prisonerId: String, updateRegisteredPrisonerPrisonDto: UpdateRegisteredPrisonerPrisonDto): PermittedPrisonerForBookerDto {
     logger.info("update permitted prisoner prison called for $prisonerId with booker reference $bookerReference")
-    return prisonVisitBookerRegistryClient.updatePermittedPrisonerPrison(bookerReference, prisonerId, updateRegisteredPrisonersPrisonDto)
+    return prisonVisitBookerRegistryClient.updatePermittedPrisonerPrison(bookerReference, prisonerId, updateRegisteredPrisonerPrisonDto)
   }
 
   fun registerVisitorForBookerPrisoner(bookerReference: String, prisonerId: String, registerVisitorForBookerPrisonerDto: RegisterVisitorForBookerPrisonerDto): PermittedVisitorsForPermittedPrisonerBookerDto {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/booker/UpdatePermittedPrisonerPrisonTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/booker/UpdatePermittedPrisonerPrisonTest.kt
@@ -1,0 +1,133 @@
+package uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.integration.booker
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpStatus
+import org.springframework.test.web.reactive.server.WebTestClient
+import org.springframework.web.reactive.function.BodyInserters
+import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.controller.PUBLIC_BOOKER_UPDATE_PERMITTED_PRISONER_PRISON_CONTROLLER_PATH
+import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.booker.registry.PermittedPrisonerForBookerDto
+import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.booker.registry.UpdateRegisteredPrisonersPrisonDto
+import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.integration.IntegrationTestBase
+import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.integration.TestObjectMapper
+
+@DisplayName("$PUBLIC_BOOKER_UPDATE_PERMITTED_PRISONER_PRISON_CONTROLLER_PATH - Update a permitted prisoner's registered prison")
+class UpdatePermittedPrisonerPrisonTest : IntegrationTestBase() {
+  @Test
+  fun `when update permitted prisoner prison is successful HTTP status OK and updated prisoner are returned`() {
+    // Given
+    val bookerReference = "booker-reference"
+    val prisonerId = "AA12345"
+    val updateRegisteredPrisonersPrisonDto = UpdateRegisteredPrisonersPrisonDto("MDI")
+    val response = PermittedPrisonerForBookerDto(
+      prisonerId = prisonerId,
+      prisonCode = updateRegisteredPrisonersPrisonDto.prisonCode,
+      permittedVisitors = emptyList(),
+    )
+
+    prisonVisitBookerRegistryMockServer.stubUpdatePermittedPrisonerPrison(
+      bookerReference = bookerReference,
+      prisonerId = prisonerId,
+      updateRegisteredPrisonersPrisonDto = updateRegisteredPrisonersPrisonDto,
+      response = response,
+      httpStatus = HttpStatus.OK,
+    )
+
+    // When
+    val responseSpec = callUpdatePermittedPrisonerPrison(bookerReference, prisonerId, updateRegisteredPrisonersPrisonDto, webTestClient, roleVSIPOrchestrationServiceHttpHeaders)
+
+    // Then
+    responseSpec.expectStatus().isOk
+    val updatedPrisoner = getResponse(responseSpec)
+    assertThat(updatedPrisoner.prisonerId).isEqualTo(prisonerId)
+    assertThat(updatedPrisoner.prisonCode).isEqualTo(updateRegisteredPrisonersPrisonDto.prisonCode)
+    verify(prisonVisitBookerRegistryClientSpy, times(1)).updatePermittedPrisonerPrison(bookerReference, prisonerId, updateRegisteredPrisonersPrisonDto)
+  }
+
+  @Test
+  fun `when booker registry returns a bad request then it is returned to caller`() {
+    // Given
+    val bookerReference = "booker-reference"
+    val prisonerId = "AA12345"
+    val updateRegisteredPrisonersPrisonDto = UpdateRegisteredPrisonersPrisonDto("MDI")
+
+    prisonVisitBookerRegistryMockServer.stubUpdatePermittedPrisonerPrison(
+      bookerReference = bookerReference,
+      prisonerId = prisonerId,
+      updateRegisteredPrisonersPrisonDto = updateRegisteredPrisonersPrisonDto,
+      httpStatus = HttpStatus.BAD_REQUEST,
+    )
+
+    // When
+    val responseSpec = callUpdatePermittedPrisonerPrison(bookerReference, prisonerId, updateRegisteredPrisonersPrisonDto, webTestClient, roleVSIPOrchestrationServiceHttpHeaders)
+
+    // Then
+    responseSpec.expectStatus().isBadRequest
+    verify(prisonVisitBookerRegistryClientSpy, times(1)).updatePermittedPrisonerPrison(bookerReference, prisonerId, updateRegisteredPrisonersPrisonDto)
+  }
+
+  @Test
+  fun `when booker registry returns not found then it is returned to caller`() {
+    // Given
+    val bookerReference = "booker-reference"
+    val prisonerId = "AA12345"
+    val updateRegisteredPrisonersPrisonDto = UpdateRegisteredPrisonersPrisonDto("MDI")
+
+    prisonVisitBookerRegistryMockServer.stubUpdatePermittedPrisonerPrison(
+      bookerReference = bookerReference,
+      prisonerId = prisonerId,
+      updateRegisteredPrisonersPrisonDto = updateRegisteredPrisonersPrisonDto,
+      httpStatus = HttpStatus.NOT_FOUND,
+    )
+
+    // When
+    val responseSpec = callUpdatePermittedPrisonerPrison(bookerReference, prisonerId, updateRegisteredPrisonersPrisonDto, webTestClient, roleVSIPOrchestrationServiceHttpHeaders)
+
+    // Then
+    responseSpec.expectStatus().isNotFound
+    verify(prisonVisitBookerRegistryClientSpy, times(1)).updatePermittedPrisonerPrison(bookerReference, prisonerId, updateRegisteredPrisonersPrisonDto)
+  }
+
+  @Test
+  fun `when update permitted prisoner prison is called with no auth request is rejected`() {
+    // Given
+    val invalidRoleHttpHeaders = setAuthorisation(roles = listOf("ROLE_INVALID"))
+
+    // When
+    val responseSpec = callUpdatePermittedPrisonerPrison(
+      "booker-reference",
+      "AA12345",
+      UpdateRegisteredPrisonersPrisonDto("MDI"),
+      webTestClient,
+      invalidRoleHttpHeaders,
+    )
+
+    // Then
+    responseSpec.expectStatus().isForbidden
+    verify(prisonVisitBookerRegistryClientSpy, times(0)).updatePermittedPrisonerPrison(any(), any(), any())
+  }
+
+  private fun getResponse(responseSpec: WebTestClient.ResponseSpec): PermittedPrisonerForBookerDto = TestObjectMapper.mapper.readValue(responseSpec.expectBody().returnResult().responseBody, PermittedPrisonerForBookerDto::class.java)
+
+  private fun callUpdatePermittedPrisonerPrison(
+    bookerReference: String,
+    prisonerId: String,
+    updateRegisteredPrisonersPrisonDto: UpdateRegisteredPrisonersPrisonDto,
+    webTestClient: WebTestClient,
+    authHttpHeaders: (HttpHeaders) -> Unit,
+  ): WebTestClient.ResponseSpec {
+    val uri = PUBLIC_BOOKER_UPDATE_PERMITTED_PRISONER_PRISON_CONTROLLER_PATH
+      .replace("{bookerReference}", bookerReference)
+      .replace("{prisonerId}", prisonerId)
+
+    return webTestClient.put().uri(uri)
+      .headers(authHttpHeaders)
+      .body(BodyInserters.fromValue(updateRegisteredPrisonersPrisonDto))
+      .exchange()
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/booker/UpdatePermittedPrisonerPrisonTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/booker/UpdatePermittedPrisonerPrisonTest.kt
@@ -12,41 +12,40 @@ import org.springframework.test.web.reactive.server.WebTestClient
 import org.springframework.web.reactive.function.BodyInserters
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.controller.PUBLIC_BOOKER_UPDATE_PERMITTED_PRISONER_PRISON_CONTROLLER_PATH
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.booker.registry.PermittedPrisonerForBookerDto
-import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.booker.registry.UpdateRegisteredPrisonersPrisonDto
+import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.booker.registry.UpdateRegisteredPrisonerPrisonDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.integration.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.integration.TestObjectMapper
 
 @DisplayName("$PUBLIC_BOOKER_UPDATE_PERMITTED_PRISONER_PRISON_CONTROLLER_PATH - Update a permitted prisoner's registered prison")
 class UpdatePermittedPrisonerPrisonTest : IntegrationTestBase() {
   @Test
-  fun `when update permitted prisoner prison is successful HTTP status OK and updated prisoner are returned`() {
+  fun `when update permitted prisoner prison is successful HTTP status OK and updated prisoner is returned`() {
     // Given
     val bookerReference = "booker-reference"
     val prisonerId = "AA12345"
-    val updateRegisteredPrisonersPrisonDto = UpdateRegisteredPrisonersPrisonDto("MDI")
+    val updateRegisteredPrisonerPrisonDto = UpdateRegisteredPrisonerPrisonDto("MDI")
     val response = PermittedPrisonerForBookerDto(
       prisonerId = prisonerId,
-      prisonCode = updateRegisteredPrisonersPrisonDto.prisonCode,
+      prisonCode = updateRegisteredPrisonerPrisonDto.prisonCode,
       permittedVisitors = emptyList(),
     )
 
     prisonVisitBookerRegistryMockServer.stubUpdatePermittedPrisonerPrison(
       bookerReference = bookerReference,
       prisonerId = prisonerId,
-      updateRegisteredPrisonersPrisonDto = updateRegisteredPrisonersPrisonDto,
+      updateRegisteredPrisonerPrisonDto = updateRegisteredPrisonerPrisonDto,
       response = response,
-      httpStatus = HttpStatus.OK,
     )
 
     // When
-    val responseSpec = callUpdatePermittedPrisonerPrison(bookerReference, prisonerId, updateRegisteredPrisonersPrisonDto, webTestClient, roleVSIPOrchestrationServiceHttpHeaders)
+    val responseSpec = callUpdatePermittedPrisonerPrison(bookerReference, prisonerId, updateRegisteredPrisonerPrisonDto, webTestClient, roleVSIPOrchestrationServiceHttpHeaders)
 
     // Then
     responseSpec.expectStatus().isOk
     val updatedPrisoner = getResponse(responseSpec)
     assertThat(updatedPrisoner.prisonerId).isEqualTo(prisonerId)
-    assertThat(updatedPrisoner.prisonCode).isEqualTo(updateRegisteredPrisonersPrisonDto.prisonCode)
-    verify(prisonVisitBookerRegistryClientSpy, times(1)).updatePermittedPrisonerPrison(bookerReference, prisonerId, updateRegisteredPrisonersPrisonDto)
+    assertThat(updatedPrisoner.prisonCode).isEqualTo(updateRegisteredPrisonerPrisonDto.prisonCode)
+    verify(prisonVisitBookerRegistryClientSpy, times(1)).updatePermittedPrisonerPrison(bookerReference, prisonerId, updateRegisteredPrisonerPrisonDto)
   }
 
   @Test
@@ -54,21 +53,21 @@ class UpdatePermittedPrisonerPrisonTest : IntegrationTestBase() {
     // Given
     val bookerReference = "booker-reference"
     val prisonerId = "AA12345"
-    val updateRegisteredPrisonersPrisonDto = UpdateRegisteredPrisonersPrisonDto("MDI")
+    val updateRegisteredPrisonerPrisonDto = UpdateRegisteredPrisonerPrisonDto("MDI")
 
     prisonVisitBookerRegistryMockServer.stubUpdatePermittedPrisonerPrison(
       bookerReference = bookerReference,
       prisonerId = prisonerId,
-      updateRegisteredPrisonersPrisonDto = updateRegisteredPrisonersPrisonDto,
+      updateRegisteredPrisonerPrisonDto = updateRegisteredPrisonerPrisonDto,
       httpStatus = HttpStatus.BAD_REQUEST,
     )
 
     // When
-    val responseSpec = callUpdatePermittedPrisonerPrison(bookerReference, prisonerId, updateRegisteredPrisonersPrisonDto, webTestClient, roleVSIPOrchestrationServiceHttpHeaders)
+    val responseSpec = callUpdatePermittedPrisonerPrison(bookerReference, prisonerId, updateRegisteredPrisonerPrisonDto, webTestClient, roleVSIPOrchestrationServiceHttpHeaders)
 
     // Then
     responseSpec.expectStatus().isBadRequest
-    verify(prisonVisitBookerRegistryClientSpy, times(1)).updatePermittedPrisonerPrison(bookerReference, prisonerId, updateRegisteredPrisonersPrisonDto)
+    verify(prisonVisitBookerRegistryClientSpy, times(1)).updatePermittedPrisonerPrison(bookerReference, prisonerId, updateRegisteredPrisonerPrisonDto)
   }
 
   @Test
@@ -76,21 +75,21 @@ class UpdatePermittedPrisonerPrisonTest : IntegrationTestBase() {
     // Given
     val bookerReference = "booker-reference"
     val prisonerId = "AA12345"
-    val updateRegisteredPrisonersPrisonDto = UpdateRegisteredPrisonersPrisonDto("MDI")
+    val updateRegisteredPrisonerPrisonDto = UpdateRegisteredPrisonerPrisonDto("MDI")
 
     prisonVisitBookerRegistryMockServer.stubUpdatePermittedPrisonerPrison(
       bookerReference = bookerReference,
       prisonerId = prisonerId,
-      updateRegisteredPrisonersPrisonDto = updateRegisteredPrisonersPrisonDto,
+      updateRegisteredPrisonerPrisonDto = updateRegisteredPrisonerPrisonDto,
       httpStatus = HttpStatus.NOT_FOUND,
     )
 
     // When
-    val responseSpec = callUpdatePermittedPrisonerPrison(bookerReference, prisonerId, updateRegisteredPrisonersPrisonDto, webTestClient, roleVSIPOrchestrationServiceHttpHeaders)
+    val responseSpec = callUpdatePermittedPrisonerPrison(bookerReference, prisonerId, updateRegisteredPrisonerPrisonDto, webTestClient, roleVSIPOrchestrationServiceHttpHeaders)
 
     // Then
     responseSpec.expectStatus().isNotFound
-    verify(prisonVisitBookerRegistryClientSpy, times(1)).updatePermittedPrisonerPrison(bookerReference, prisonerId, updateRegisteredPrisonersPrisonDto)
+    verify(prisonVisitBookerRegistryClientSpy, times(1)).updatePermittedPrisonerPrison(bookerReference, prisonerId, updateRegisteredPrisonerPrisonDto)
   }
 
   @Test
@@ -102,7 +101,7 @@ class UpdatePermittedPrisonerPrisonTest : IntegrationTestBase() {
     val responseSpec = callUpdatePermittedPrisonerPrison(
       "booker-reference",
       "AA12345",
-      UpdateRegisteredPrisonersPrisonDto("MDI"),
+      UpdateRegisteredPrisonerPrisonDto("MDI"),
       webTestClient,
       invalidRoleHttpHeaders,
     )
@@ -117,7 +116,7 @@ class UpdatePermittedPrisonerPrisonTest : IntegrationTestBase() {
   private fun callUpdatePermittedPrisonerPrison(
     bookerReference: String,
     prisonerId: String,
-    updateRegisteredPrisonersPrisonDto: UpdateRegisteredPrisonersPrisonDto,
+    updateRegisteredPrisonerPrisonDto: UpdateRegisteredPrisonerPrisonDto,
     webTestClient: WebTestClient,
     authHttpHeaders: (HttpHeaders) -> Unit,
   ): WebTestClient.ResponseSpec {
@@ -127,7 +126,7 @@ class UpdatePermittedPrisonerPrisonTest : IntegrationTestBase() {
 
     return webTestClient.put().uri(uri)
       .headers(authHttpHeaders)
-      .body(BodyInserters.fromValue(updateRegisteredPrisonersPrisonDto))
+      .body(BodyInserters.fromValue(updateRegisteredPrisonerPrisonDto))
       .exchange()
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/booker/UpdatePermittedPrisonerPrisonTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/booker/UpdatePermittedPrisonerPrisonTest.kt
@@ -93,7 +93,7 @@ class UpdatePermittedPrisonerPrisonTest : IntegrationTestBase() {
   }
 
   @Test
-  fun `when update permitted prisoner prison is called with no auth request is rejected`() {
+  fun `when update permitted prisoner prison is called with an invalid role request is rejected`() {
     // Given
     val invalidRoleHttpHeaders = setAuthorisation(roles = listOf("ROLE_INVALID"))
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/mock/PrisonVisitBookerRegistryMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/mock/PrisonVisitBookerRegistryMockServer.kt
@@ -32,7 +32,7 @@ import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.boo
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.booker.registry.PermittedVisitorsForPermittedPrisonerBookerDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.booker.registry.PrisonVisitorRequestDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.booker.registry.RegisterVisitorForBookerPrisonerDto
-import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.booker.registry.UpdateRegisteredPrisonersPrisonDto
+import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.booker.registry.UpdateRegisteredPrisonerPrisonDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.booker.registry.VisitorRequestsCountByPrisonCodeDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.booker.registry.admin.BookerInfoDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.booker.registry.admin.BookerSearchResultsDto
@@ -163,7 +163,7 @@ class PrisonVisitBookerRegistryMockServer : WireMockServer(8098) {
   fun stubUpdatePermittedPrisonerPrison(
     bookerReference: String,
     prisonerId: String,
-    updateRegisteredPrisonersPrisonDto: UpdateRegisteredPrisonersPrisonDto,
+    updateRegisteredPrisonerPrisonDto: UpdateRegisteredPrisonerPrisonDto,
     response: PermittedPrisonerForBookerDto? = null,
     httpStatus: HttpStatus = HttpStatus.NOT_FOUND,
   ) {
@@ -174,7 +174,7 @@ class PrisonVisitBookerRegistryMockServer : WireMockServer(8098) {
 
     stubFor(
       WireMock.put(uri)
-        .withRequestBody(equalToJson(getJsonString(updateRegisteredPrisonersPrisonDto)))
+        .withRequestBody(equalToJson(getJsonString(updateRegisteredPrisonerPrisonDto)))
         .willReturn(
           if (response != null) {
             responseBuilder.withStatus(HttpStatus.OK.value())

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/mock/PrisonVisitBookerRegistryMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/mock/PrisonVisitBookerRegistryMockServer.kt
@@ -18,6 +18,7 @@ import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.client.
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.client.REJECT_VISITOR_REQUEST
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.client.SEARCH_FOR_BOOKER
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.client.UNLINK_VISITOR
+import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.client.UPDATE_PERMITTED_PRISONER_PRISON
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.client.VALIDATE_PRISONER
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.config.BookerPrisonerRegistrationErrorResponse
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.config.BookerPrisonerValidationErrorResponse
@@ -31,6 +32,7 @@ import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.boo
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.booker.registry.PermittedVisitorsForPermittedPrisonerBookerDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.booker.registry.PrisonVisitorRequestDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.booker.registry.RegisterVisitorForBookerPrisonerDto
+import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.booker.registry.UpdateRegisteredPrisonersPrisonDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.booker.registry.VisitorRequestsCountByPrisonCodeDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.booker.registry.admin.BookerInfoDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.booker.registry.admin.BookerSearchResultsDto
@@ -155,6 +157,32 @@ class PrisonVisitBookerRegistryMockServer : WireMockServer(8098) {
     stubFor(
       WireMock.put(REGISTER_PRISONER.replace("{bookerReference}", bookerReference))
         .willReturn(responseBuilder),
+    )
+  }
+
+  fun stubUpdatePermittedPrisonerPrison(
+    bookerReference: String,
+    prisonerId: String,
+    updateRegisteredPrisonersPrisonDto: UpdateRegisteredPrisonersPrisonDto,
+    response: PermittedPrisonerForBookerDto? = null,
+    httpStatus: HttpStatus = HttpStatus.NOT_FOUND,
+  ) {
+    val responseBuilder = createJsonResponseBuilder()
+    val uri = UPDATE_PERMITTED_PRISONER_PRISON
+      .replace("{bookerReference}", bookerReference)
+      .replace("{prisonerId}", prisonerId)
+
+    stubFor(
+      WireMock.put(uri)
+        .withRequestBody(equalToJson(getJsonString(updateRegisteredPrisonersPrisonDto)))
+        .willReturn(
+          if (response != null) {
+            responseBuilder.withStatus(HttpStatus.OK.value())
+              .withBody(getJsonString(response))
+          } else {
+            responseBuilder.withStatus(httpStatus.value())
+          },
+        ),
     )
   }
 


### PR DESCRIPTION
## What does this PR do?
When a prisoner is transferred the booker can no longer book for them at their original registered location. This PR allows the booker to update the prisoner's location, to re-enable booking.

## JIRA Link
https://dsdmoj.atlassian.net/browse/VB-5864