### PR TITLE
VB-6817 - Bug fix - Remove visits which are blocked from visit pass printing

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/service/PrisonAndSessionsExcludeDatesService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/service/PrisonAndSessionsExcludeDatesService.kt
@@ -23,15 +23,19 @@ class PrisonAndSessionsExcludeDatesService(
     )
   }
 
-  fun getFuturePrisonAndSessionExcludeDates(prisonCode: String, includeSessions: Boolean): PrisonAndSessionsExcludeDatesDto {
+  fun getFuturePrisonAndSessionExcludeDates(
+    prisonCode: String,
+    includeSessions: Boolean,
+    withUsernames: Boolean = true,
+  ): PrisonAndSessionsExcludeDatesDto {
     logger.info("Getting future exclude dates for prison $prisonCode and sessions")
-    val prisonExcludeDates = prisonService.getFutureExcludeDatesForPrison(prisonCode)
-    val sessionExclusions = if (includeSessions) getCurrentAndFutureSessionExclusions(prisonCode) else emptyList()
+    val prisonExcludeDates = prisonService.getFutureExcludeDatesForPrison(prisonCode, withUsernames)
+    val sessionExclusions = if (includeSessions) getCurrentAndFutureSessionExclusions(prisonCode, withUsernames) else emptyList()
 
     return PrisonAndSessionsExcludeDatesDto(fullDateExclusions = prisonExcludeDates, sessionExclusions = sessionExclusions)
   }
 
-  private fun getCurrentAndFutureSessionExclusions(prisonCode: String): List<SessionExcludeDateDto> {
+  private fun getCurrentAndFutureSessionExclusions(prisonCode: String, withUsernames: Boolean): List<SessionExcludeDateDto> {
     // get all current or future sessions that have date exclusions
     val currentOrFutureSessions = visitSchedulerClient.getFutureSessionTemplateExclusions(prisonCode)
     val sessionExclusions = mutableListOf<SessionExcludeDateDto>()
@@ -42,8 +46,9 @@ class PrisonAndSessionsExcludeDatesService(
       }
     }
 
-    // set actual names for actionedBy
-    setActionedByFullName(sessionExclusions)
+    if (withUsernames) {
+      setActionedByFullName(sessionExclusions)
+    }
 
     return sessionExclusions.sortedWith(sessionExclusionSortOrder)
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/service/PrisonService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/service/PrisonService.kt
@@ -53,9 +53,9 @@ class PrisonService(
     return supportedPrisons.sortedBy { it.prisonName.uppercase() }
   }
 
-  fun getFutureExcludeDatesForPrison(prisonCode: String): List<ExcludeDateDto> {
+  fun getFutureExcludeDatesForPrison(prisonCode: String, withUsernames: Boolean = true): List<ExcludeDateDto> {
     val excludeDates = getExcludeDatesForPrison(prisonCode)
-    return excludeDatesService.getFutureExcludeDates(excludeDates)
+    return excludeDatesService.getFutureExcludeDates(excludeDates, withUsernames)
   }
 
   fun isDateExcludedForPrisonVisits(prisonCode: String, date: LocalDate): IsExcludeDateDto {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/service/VisitPassesService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/service/VisitPassesService.kt
@@ -20,6 +20,7 @@ class VisitPassesService(
   private val visitPassesClient: VisitPassesClient,
   private val visitSchedulerClient: VisitSchedulerClient,
   private val telemetryClientService: TelemetryClientService,
+  private val prisonAndSessionsExcludeDatesService: PrisonAndSessionsExcludeDatesService,
 ) {
   companion object {
     val logger: Logger = LoggerFactory.getLogger(this::class.java)
@@ -46,7 +47,21 @@ class VisitPassesService(
       }
     }
 
-    val visitPasses = visitPassesClient.getVisitPasses(visits)
+    val blockedDatesAndSessions = prisonAndSessionsExcludeDatesService.getFuturePrisonAndSessionExcludeDates(prisonCode, includeSessions = true)
+
+    // We filter out visits which fall on blocked dates or whose session is blocked - as these shouldn't be printed.
+    val filteredVisits = visits
+      .filterNot { visit ->
+        visit.startTimestamp.toLocalDate() in blockedDatesAndSessions.fullDateExclusions.map { it.excludeDate }
+      }
+      .filterNot { visit ->
+        blockedDatesAndSessions.sessionExclusions.any { exclusion ->
+          exclusion.sessionTemplateReference == visit.sessionTemplateReference &&
+            exclusion.excludeDate.excludeDate == visit.startTimestamp.toLocalDate()
+        }
+      }
+
+    val visitPasses = visitPassesClient.getVisitPasses(filteredVisits)
     // write to app insights
     telemetryClientService.trackVisitPassesEvent(prisonCode = prisonCode, visitDate = visitDate, actionedBy = visitPassRequest.actionedBy, totalVisits = visits.size)
     return visitPasses

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/service/VisitPassesService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/service/VisitPassesService.kt
@@ -47,7 +47,7 @@ class VisitPassesService(
       }
     }
 
-    val blockedDatesAndSessions = prisonAndSessionsExcludeDatesService.getFuturePrisonAndSessionExcludeDates(prisonCode, includeSessions = true)
+    val blockedDatesAndSessions = prisonAndSessionsExcludeDatesService.getFuturePrisonAndSessionExcludeDates(prisonCode, includeSessions = true, withUsernames = false)
 
     // We filter out visits which fall on blocked dates or whose session is blocked - as these shouldn't be printed.
     val filteredVisits = visits
@@ -93,17 +93,19 @@ class VisitPassesService(
       throw InvalidVisitPassException("Visit with reference - ${visit.reference} is not in BOOKED status")
     }
 
-    val blockedDatesAndSessions = prisonAndSessionsExcludeDatesService.getFuturePrisonAndSessionExcludeDates(prisonCode, includeSessions = true)
+    val blockedDatesAndSessions = prisonAndSessionsExcludeDatesService.getFuturePrisonAndSessionExcludeDates(prisonCode, includeSessions = true, withUsernames = false)
 
     // We filter out visits which fall on blocked dates or whose session is blocked - as these shouldn't be printed.
-    if(visit.startTimestamp.toLocalDate() in blockedDatesAndSessions.fullDateExclusions.map { it.excludeDate }) {
-        throw InvalidVisitPassException("Visit with reference - ${visit.reference} is on a blocked date - ${visit.startTimestamp.toLocalDate()}")
+    if (visit.startTimestamp.toLocalDate() in blockedDatesAndSessions.fullDateExclusions.map { it.excludeDate }) {
+      throw InvalidVisitPassException("Visit with reference - ${visit.reference} is on a blocked date - ${visit.startTimestamp.toLocalDate()}")
     }
 
-    if(blockedDatesAndSessions.sessionExclusions.any { exclusion ->
+    if (
+      blockedDatesAndSessions.sessionExclusions.any { exclusion ->
         exclusion.sessionTemplateReference == visit.sessionTemplateReference &&
           exclusion.excludeDate.excludeDate == visit.startTimestamp.toLocalDate()
-      }) {
+      }
+    ) {
       throw InvalidVisitPassException("Visit with reference - ${visit.reference} is on a blocked session, session template - ${visit.sessionTemplateReference} and date - ${visit.startTimestamp.toLocalDate()}")
     }
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/service/VisitPassesService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/service/VisitPassesService.kt
@@ -92,6 +92,20 @@ class VisitPassesService(
     if (visit.visitStatus != VisitStatus.BOOKED) {
       throw InvalidVisitPassException("Visit with reference - ${visit.reference} is not in BOOKED status")
     }
+
+    val blockedDatesAndSessions = prisonAndSessionsExcludeDatesService.getFuturePrisonAndSessionExcludeDates(prisonCode, includeSessions = true)
+
+    // We filter out visits which fall on blocked dates or whose session is blocked - as these shouldn't be printed.
+    if(visit.startTimestamp.toLocalDate() in blockedDatesAndSessions.fullDateExclusions.map { it.excludeDate }) {
+        throw InvalidVisitPassException("Visit with reference - ${visit.reference} is on a blocked date - ${visit.startTimestamp.toLocalDate()}")
+    }
+
+    if(blockedDatesAndSessions.sessionExclusions.any { exclusion ->
+        exclusion.sessionTemplateReference == visit.sessionTemplateReference &&
+          exclusion.excludeDate.excludeDate == visit.startTimestamp.toLocalDate()
+      }) {
+      throw InvalidVisitPassException("Visit with reference - ${visit.reference} is on a blocked session, session template - ${visit.sessionTemplateReference} and date - ${visit.startTimestamp.toLocalDate()}")
+    }
   }
 
   private fun getVisitRequestSearchFilter(prisonCode: String, visitDate: LocalDate) = VisitSearchRequestFilter(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/service/VisitPassesService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/service/VisitPassesService.kt
@@ -57,7 +57,8 @@ class VisitPassesService(
       // We filter out visits which fall on blocked dates or whose session is blocked - as these shouldn't be printed.
       val filteredVisits = visits.filterNot { visit ->
         val visitDate = visit.startTimestamp.toLocalDate()
-        visitDate in blockedDates || (visit.sessionTemplateReference to visitDate) in blockedSessions
+        val sessionBlocked = visit.sessionTemplateReference?.let { (it to visitDate) in blockedSessions } ?: false
+        visitDate in blockedDates || sessionBlocked
       }
 
       visitPassesClient.getVisitPasses(filteredVisits)
@@ -104,7 +105,7 @@ class VisitPassesService(
       throw InvalidVisitPassException("Visit with reference - ${visit.reference} is on a blocked date - $visitDate")
     }
 
-    if ((visit.sessionTemplateReference to visitDate) in blockedSessions) {
+    if (visit.sessionTemplateReference?.let { (it to visitDate) in blockedSessions } == true) {
       throw InvalidVisitPassException("Visit with reference - ${visit.reference} is on a blocked session, session template - ${visit.sessionTemplateReference} and date - $visitDate")
     }
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/service/VisitPassesService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/service/VisitPassesService.kt
@@ -47,21 +47,22 @@ class VisitPassesService(
       }
     }
 
-    val blockedDatesAndSessions = prisonAndSessionsExcludeDatesService.getFuturePrisonAndSessionExcludeDates(prisonCode, includeSessions = true, withUsernames = false)
+    val visitPasses = if (visits.isEmpty()) {
+      emptyList()
+    } else {
+      val blockedDatesAndSessions = prisonAndSessionsExcludeDatesService.getFuturePrisonAndSessionExcludeDates(prisonCode, includeSessions = true, withUsernames = false)
+      val blockedDates = blockedDatesAndSessions.fullDateExclusions.map { it.excludeDate }.toSet()
+      val blockedSessions = blockedDatesAndSessions.sessionExclusions.map { it.sessionTemplateReference to it.excludeDate.excludeDate }.toSet()
 
-    // We filter out visits which fall on blocked dates or whose session is blocked - as these shouldn't be printed.
-    val filteredVisits = visits
-      .filterNot { visit ->
-        visit.startTimestamp.toLocalDate() in blockedDatesAndSessions.fullDateExclusions.map { it.excludeDate }
-      }
-      .filterNot { visit ->
-        blockedDatesAndSessions.sessionExclusions.any { exclusion ->
-          exclusion.sessionTemplateReference == visit.sessionTemplateReference &&
-            exclusion.excludeDate.excludeDate == visit.startTimestamp.toLocalDate()
-        }
+      // We filter out visits which fall on blocked dates or whose session is blocked - as these shouldn't be printed.
+      val filteredVisits = visits.filterNot { visit ->
+        val visitDate = visit.startTimestamp.toLocalDate()
+        visitDate in blockedDates || (visit.sessionTemplateReference to visitDate) in blockedSessions
       }
 
-    val visitPasses = visitPassesClient.getVisitPasses(filteredVisits)
+      visitPassesClient.getVisitPasses(filteredVisits)
+    }
+
     // write to app insights
     telemetryClientService.trackVisitPassesEvent(prisonCode = prisonCode, visitDate = visitDate, actionedBy = visitPassRequest.actionedBy, totalVisits = visits.size)
     return visitPasses
@@ -94,19 +95,17 @@ class VisitPassesService(
     }
 
     val blockedDatesAndSessions = prisonAndSessionsExcludeDatesService.getFuturePrisonAndSessionExcludeDates(prisonCode, includeSessions = true, withUsernames = false)
+    val visitDate = visit.startTimestamp.toLocalDate()
+    val blockedDates = blockedDatesAndSessions.fullDateExclusions.map { it.excludeDate }.toSet()
+    val blockedSessions = blockedDatesAndSessions.sessionExclusions.map { it.sessionTemplateReference to it.excludeDate.excludeDate }.toSet()
 
     // We filter out visits which fall on blocked dates or whose session is blocked - as these shouldn't be printed.
-    if (visit.startTimestamp.toLocalDate() in blockedDatesAndSessions.fullDateExclusions.map { it.excludeDate }) {
-      throw InvalidVisitPassException("Visit with reference - ${visit.reference} is on a blocked date - ${visit.startTimestamp.toLocalDate()}")
+    if (visitDate in blockedDates) {
+      throw InvalidVisitPassException("Visit with reference - ${visit.reference} is on a blocked date - $visitDate")
     }
 
-    if (
-      blockedDatesAndSessions.sessionExclusions.any { exclusion ->
-        exclusion.sessionTemplateReference == visit.sessionTemplateReference &&
-          exclusion.excludeDate.excludeDate == visit.startTimestamp.toLocalDate()
-      }
-    ) {
-      throw InvalidVisitPassException("Visit with reference - ${visit.reference} is on a blocked session, session template - ${visit.sessionTemplateReference} and date - ${visit.startTimestamp.toLocalDate()}")
+    if ((visit.sessionTemplateReference to visitDate) in blockedSessions) {
+      throw InvalidVisitPassException("Visit with reference - ${visit.reference} is on a blocked session, session template - ${visit.sessionTemplateReference} and date - $visitDate")
     }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/visit/passes/GetVisitPassTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/visit/passes/GetVisitPassTest.kt
@@ -17,16 +17,20 @@ import org.springframework.test.web.reactive.server.WebTestClient
 import org.springframework.web.reactive.function.BodyInserters
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.controller.VISIT_PASS_BY_VISIT_REFERENCE_CONTROLLER_PATH
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.contact.registry.ContactWithOptionalPrisonerRelationshipDto
+import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.manage.users.UserExtendedDetailsDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.prisoner.search.PrisonerDto
+import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.visit.scheduler.SessionScheduleWithDateExclusionsDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.visit.scheduler.StaffUsernameDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.visit.scheduler.VisitDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.visit.scheduler.VisitorDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.visit.scheduler.enums.VisitStatus
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.visit.scheduler.passes.VisitPassDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.visit.scheduler.passes.VisitPassVisitorDto
+import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.visit.scheduler.prisons.ExcludeDateDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.integration.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.integration.TestObjectMapper
 import java.time.LocalDate
+import java.time.LocalTime
 
 @DisplayName("Get Visit pass for an individual visit")
 class GetVisitPassTest : IntegrationTestBase() {
@@ -44,6 +48,9 @@ class GetVisitPassTest : IntegrationTestBase() {
     // visit with 2 contacts (ids 1 and 2)
     val visitors = createVisitors(listOf(contact1.contactId, contact2.contactId))
     visit = createVisitDto(reference = "visit-1", prisonerId = prisoner.prisonerNumber, visitors = visitors, prisonCode = prisonCode, startTimestamp = LocalDate.now().atTime(10, 0), endTimestamp = LocalDate.now().atTime(11, 0))
+
+    visitSchedulerMockServer.stubGetExcludeDates(prisonCode, emptyList())
+    visitSchedulerMockServer.stubGetSessionSchedulesWithDateExclusions(prisonCode, emptyList())
   }
 
   @Test
@@ -121,6 +128,115 @@ class GetVisitPassTest : IntegrationTestBase() {
 
     // Then
     responseSpec.expectStatus().isBadRequest
+
+    verify(visitSchedulerClientSpy, times(1)).getVisitByReference(any())
+    verify(prisonerSearchClientSpy, times(0)).getPrisonerByIdAsMono(any())
+    verify(prisonerContactRegistryClientSpy, times(0)).searchContactsAsMono(any(), anyOrNull(), any())
+    verify(telemetryClientSpy, times(0)).trackEvent(any(), anyOrNull(), anyOrNull())
+  }
+
+  @Test
+  fun `when a visit reference is found but is on a blocked date then BAD_REQUEST error is thrown`() {
+    // Given
+    val blockedDate = ExcludeDateDto(visit.startTimestamp.toLocalDate(), "user-1")
+
+    visitSchedulerMockServer.stubGetVisit(visit.reference, visit)
+    visitSchedulerMockServer.stubGetExcludeDates(prisonCode, listOf(blockedDate))
+    manageUsersApiMockServer.stubGetMultipleUserDetails(
+      listOf("user-1"),
+      userDetails = mapOf("user-1" to UserExtendedDetailsDto("user-1", "User", "One")),
+    )
+
+    // When
+    val responseSpec = callGetVisitPass(webTestClient, prisonCode, visit.reference, "STAFF_USER1", roleVSIPOrchestrationServiceHttpHeaders)
+
+    // Then
+    responseSpec.expectStatus().isBadRequest
+
+    verify(visitSchedulerClientSpy, times(1)).getVisitByReference(any())
+    verify(prisonerSearchClientSpy, times(0)).getPrisonerByIdAsMono(any())
+    verify(prisonerContactRegistryClientSpy, times(0)).searchContactsAsMono(any(), anyOrNull(), any())
+    verify(telemetryClientSpy, times(0)).trackEvent(any(), anyOrNull(), anyOrNull())
+  }
+
+  @Test
+  fun `when a visit reference is found but is on a blocked session then BAD_REQUEST error is thrown`() {
+    // Given
+    val blockedSessionTemplateReference = "blocked-session"
+    val visitors = createVisitors(listOf(contact1.contactId, contact2.contactId))
+    val visit = createVisitDto(
+      reference = "visit-1",
+      prisonerId = prisoner.prisonerNumber,
+      visitors = visitors,
+      prisonCode = prisonCode,
+      startTimestamp = LocalDate.now().atTime(10, 0),
+      endTimestamp = LocalDate.now().atTime(11, 0),
+      sessionTemplateReference = blockedSessionTemplateReference,
+    )
+    val blockedSessionExcludeDate = ExcludeDateDto(visit.startTimestamp.toLocalDate(), "user-1")
+    val blockedSessionSchedule = createSessionScheduleDto(
+      reference = blockedSessionTemplateReference,
+      startTime = LocalTime.of(10, 0),
+      endTime = LocalTime.of(11, 0),
+      validFromDate = visit.startTimestamp.toLocalDate().minusWeeks(1),
+      areLocationGroupsInclusive = true,
+      areCategoryGroupsInclusive = true,
+      areIncentiveGroupsInclusive = true,
+      visitRoom = "Visit Room",
+    )
+    val sessionScheduleWithDateExclusions = SessionScheduleWithDateExclusionsDto(
+      sessionSchedule = blockedSessionSchedule,
+      excludeDates = listOf(blockedSessionExcludeDate),
+    )
+
+    visitSchedulerMockServer.stubGetVisit(visit.reference, visit)
+    visitSchedulerMockServer.stubGetSessionSchedulesWithDateExclusions(prisonCode, listOf(sessionScheduleWithDateExclusions))
+    manageUsersApiMockServer.stubGetMultipleUserDetails(
+      listOf("user-1"),
+      userDetails = mapOf("user-1" to UserExtendedDetailsDto("user-1", "User", "One")),
+    )
+
+    // When
+    val responseSpec = callGetVisitPass(webTestClient, prisonCode, visit.reference, "STAFF_USER1", roleVSIPOrchestrationServiceHttpHeaders)
+
+    // Then
+    responseSpec.expectStatus().isBadRequest
+
+    verify(visitSchedulerClientSpy, times(1)).getVisitByReference(any())
+    verify(prisonerSearchClientSpy, times(0)).getPrisonerByIdAsMono(any())
+    verify(prisonerContactRegistryClientSpy, times(0)).searchContactsAsMono(any(), anyOrNull(), any())
+    verify(telemetryClientSpy, times(0)).trackEvent(any(), anyOrNull(), anyOrNull())
+  }
+
+  @Test
+  fun `when prison exclude date lookup returns an INTERNAL_SERVER_ERROR then an INTERNAL_SERVER_ERROR error is returned`() {
+    // Given
+    visitSchedulerMockServer.stubGetVisit(visit.reference, visit)
+    visitSchedulerMockServer.stubGetExcludeDates(prisonCode, null, HttpStatus.INTERNAL_SERVER_ERROR)
+
+    // When
+    val responseSpec = callGetVisitPass(webTestClient, prisonCode, visit.reference, "STAFF_USER1", roleVSIPOrchestrationServiceHttpHeaders)
+
+    // Then
+    responseSpec.expectStatus().is5xxServerError
+
+    verify(visitSchedulerClientSpy, times(1)).getVisitByReference(any())
+    verify(prisonerSearchClientSpy, times(0)).getPrisonerByIdAsMono(any())
+    verify(prisonerContactRegistryClientSpy, times(0)).searchContactsAsMono(any(), anyOrNull(), any())
+    verify(telemetryClientSpy, times(0)).trackEvent(any(), anyOrNull(), anyOrNull())
+  }
+
+  @Test
+  fun `when session exclude date lookup returns an INTERNAL_SERVER_ERROR then an INTERNAL_SERVER_ERROR error is returned`() {
+    // Given
+    visitSchedulerMockServer.stubGetVisit(visit.reference, visit)
+    visitSchedulerMockServer.stubGetSessionSchedulesWithDateExclusions(prisonCode, null, HttpStatus.INTERNAL_SERVER_ERROR)
+
+    // When
+    val responseSpec = callGetVisitPass(webTestClient, prisonCode, visit.reference, "STAFF_USER1", roleVSIPOrchestrationServiceHttpHeaders)
+
+    // Then
+    responseSpec.expectStatus().is5xxServerError
 
     verify(visitSchedulerClientSpy, times(1)).getVisitByReference(any())
     verify(prisonerSearchClientSpy, times(0)).getPrisonerByIdAsMono(any())

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/visit/passes/GetVisitPassTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/visit/passes/GetVisitPassTest.kt
@@ -17,7 +17,6 @@ import org.springframework.test.web.reactive.server.WebTestClient
 import org.springframework.web.reactive.function.BodyInserters
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.controller.VISIT_PASS_BY_VISIT_REFERENCE_CONTROLLER_PATH
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.contact.registry.ContactWithOptionalPrisonerRelationshipDto
-import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.manage.users.UserExtendedDetailsDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.prisoner.search.PrisonerDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.visit.scheduler.SessionScheduleWithDateExclusionsDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.visit.scheduler.StaffUsernameDto
@@ -142,10 +141,6 @@ class GetVisitPassTest : IntegrationTestBase() {
 
     visitSchedulerMockServer.stubGetVisit(visit.reference, visit)
     visitSchedulerMockServer.stubGetExcludeDates(prisonCode, listOf(blockedDate))
-    manageUsersApiMockServer.stubGetMultipleUserDetails(
-      listOf("user-1"),
-      userDetails = mapOf("user-1" to UserExtendedDetailsDto("user-1", "User", "One")),
-    )
 
     // When
     val responseSpec = callGetVisitPass(webTestClient, prisonCode, visit.reference, "STAFF_USER1", roleVSIPOrchestrationServiceHttpHeaders)
@@ -154,6 +149,7 @@ class GetVisitPassTest : IntegrationTestBase() {
     responseSpec.expectStatus().isBadRequest
 
     verify(visitSchedulerClientSpy, times(1)).getVisitByReference(any())
+    verify(manageUsersApiClientSpy, times(0)).getUsersByUsernames(any())
     verify(prisonerSearchClientSpy, times(0)).getPrisonerByIdAsMono(any())
     verify(prisonerContactRegistryClientSpy, times(0)).searchContactsAsMono(any(), anyOrNull(), any())
     verify(telemetryClientSpy, times(0)).trackEvent(any(), anyOrNull(), anyOrNull())
@@ -191,10 +187,6 @@ class GetVisitPassTest : IntegrationTestBase() {
 
     visitSchedulerMockServer.stubGetVisit(visit.reference, visit)
     visitSchedulerMockServer.stubGetSessionSchedulesWithDateExclusions(prisonCode, listOf(sessionScheduleWithDateExclusions))
-    manageUsersApiMockServer.stubGetMultipleUserDetails(
-      listOf("user-1"),
-      userDetails = mapOf("user-1" to UserExtendedDetailsDto("user-1", "User", "One")),
-    )
 
     // When
     val responseSpec = callGetVisitPass(webTestClient, prisonCode, visit.reference, "STAFF_USER1", roleVSIPOrchestrationServiceHttpHeaders)
@@ -203,6 +195,7 @@ class GetVisitPassTest : IntegrationTestBase() {
     responseSpec.expectStatus().isBadRequest
 
     verify(visitSchedulerClientSpy, times(1)).getVisitByReference(any())
+    verify(manageUsersApiClientSpy, times(0)).getUsersByUsernames(any())
     verify(prisonerSearchClientSpy, times(0)).getPrisonerByIdAsMono(any())
     verify(prisonerContactRegistryClientSpy, times(0)).searchContactsAsMono(any(), anyOrNull(), any())
     verify(telemetryClientSpy, times(0)).trackEvent(any(), anyOrNull(), anyOrNull())

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/visit/passes/GetVisitPassTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/visit/passes/GetVisitPassTest.kt
@@ -46,7 +46,8 @@ class GetVisitPassTest : IntegrationTestBase() {
   fun setupData() {
     // visit with 2 contacts (ids 1 and 2)
     val visitors = createVisitors(listOf(contact1.contactId, contact2.contactId))
-    visit = createVisitDto(reference = "visit-1", prisonerId = prisoner.prisonerNumber, visitors = visitors, prisonCode = prisonCode, startTimestamp = LocalDate.now().atTime(10, 0), endTimestamp = LocalDate.now().atTime(11, 0))
+    val visitDate = LocalDate.now()
+    visit = createVisitDto(reference = "visit-1", prisonerId = prisoner.prisonerNumber, visitors = visitors, prisonCode = prisonCode, startTimestamp = visitDate.atTime(10, 0), endTimestamp = visitDate.atTime(11, 0))
 
     visitSchedulerMockServer.stubGetExcludeDates(prisonCode, emptyList())
     visitSchedulerMockServer.stubGetSessionSchedulesWithDateExclusions(prisonCode, emptyList())
@@ -91,7 +92,8 @@ class GetVisitPassTest : IntegrationTestBase() {
     val visitContacts = listOf(contact1, contact2)
 
     // visit is in a different prison to the prison code in the request
-    val visit = createVisitDto(reference = "visit-1", prisonerId = prisoner.prisonerNumber, visitors = visitors, prisonCode = "XYZ", startTimestamp = LocalDate.now().atTime(10, 0), endTimestamp = LocalDate.now().atTime(11, 0))
+    val visitDate = LocalDate.now()
+    val visit = createVisitDto(reference = "visit-1", prisonerId = prisoner.prisonerNumber, visitors = visitors, prisonCode = "XYZ", startTimestamp = visitDate.atTime(10, 0), endTimestamp = visitDate.atTime(11, 0))
 
     visitSchedulerMockServer.stubGetVisit(visit.reference, visit)
     prisonerContactRegistryMockServer.stubSearchContacts(contactIds = visitContacts.map { it.contactId }.distinct(), contactsList = visitContacts)
@@ -116,7 +118,8 @@ class GetVisitPassTest : IntegrationTestBase() {
     val visitContacts = listOf(contact1, contact2)
 
     // visit is not BOOKED
-    val visit = createVisitDto(reference = "visit-1", prisonerId = prisoner.prisonerNumber, visitors = visitors, prisonCode = prisonCode, startTimestamp = LocalDate.now().atTime(10, 0), endTimestamp = LocalDate.now().atTime(11, 0), visitStatus = VisitStatus.CANCELLED)
+    val visitDate = LocalDate.now()
+    val visit = createVisitDto(reference = "visit-1", prisonerId = prisoner.prisonerNumber, visitors = visitors, prisonCode = prisonCode, startTimestamp = visitDate.atTime(10, 0), endTimestamp = visitDate.atTime(11, 0), visitStatus = VisitStatus.CANCELLED)
 
     visitSchedulerMockServer.stubGetVisit(visit.reference, visit)
     prisonerContactRegistryMockServer.stubSearchContacts(contactIds = visitContacts.map { it.contactId }.distinct(), contactsList = visitContacts)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/visit/passes/GetVisitPassTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/visit/passes/GetVisitPassTest.kt
@@ -160,13 +160,14 @@ class GetVisitPassTest : IntegrationTestBase() {
     // Given
     val blockedSessionTemplateReference = "blocked-session"
     val visitors = createVisitors(listOf(contact1.contactId, contact2.contactId))
+    val visitDate = LocalDate.now()
     val visit = createVisitDto(
       reference = "visit-1",
       prisonerId = prisoner.prisonerNumber,
       visitors = visitors,
       prisonCode = prisonCode,
-      startTimestamp = LocalDate.now().atTime(10, 0),
-      endTimestamp = LocalDate.now().atTime(11, 0),
+      startTimestamp = visitDate.atTime(10, 0),
+      endTimestamp = visitDate.atTime(11, 0),
       sessionTemplateReference = blockedSessionTemplateReference,
     )
     val blockedSessionExcludeDate = ExcludeDateDto(visit.startTimestamp.toLocalDate(), "user-1")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/visit/passes/GetVisitPassesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/visit/passes/GetVisitPassesTest.kt
@@ -18,7 +18,6 @@ import org.springframework.web.reactive.function.BodyInserters
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.controller.VISIT_PASSES_CONTROLLER_PATH
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.contact.registry.AddressDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.contact.registry.ContactWithOptionalPrisonerRelationshipDto
-import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.manage.users.UserExtendedDetailsDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.prisoner.search.PrisonerDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.visit.scheduler.SessionScheduleWithDateExclusionsDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.visit.scheduler.VisitDto
@@ -192,10 +191,6 @@ class GetVisitPassesTest : IntegrationTestBase() {
 
     visitSchedulerMockServer.stubGetVisits(prisonCode = prisonCode, startDate = visitDate, endDate = visitDate, page = 0, size = 250, visitStatus = listOf(VisitStatus.BOOKED.name), visits = allVisits)
     visitSchedulerMockServer.stubGetExcludeDates(prisonCode, listOf(blockedDate))
-    manageUsersApiMockServer.stubGetMultipleUserDetails(
-      listOf("user-1"),
-      userDetails = mapOf("user-1" to UserExtendedDetailsDto("user-1", "User", "One")),
-    )
 
     // When
     val responseSpec = callGetVisitPasses(webTestClient, prisonCode, visitDate, "STAFF_USER1", roleVSIPOrchestrationServiceHttpHeaders)
@@ -206,6 +201,7 @@ class GetVisitPassesTest : IntegrationTestBase() {
     assertThat(visitPasses).isEmpty()
 
     verify(visitSchedulerClientSpy, times(1)).getVisits(any())
+    verify(manageUsersApiClientSpy, times(0)).getUsersByUsernames(any())
     verify(prisonerSearchClientSpy, times(0)).getPrisonersByPrisonerIdsAttributeSearchAsMono(any())
     verify(prisonerContactRegistryClientSpy, times(0)).searchContactsAsMono(any(), anyOrNull(), any())
     verify(telemetryClientSpy).trackEvent(
@@ -264,10 +260,6 @@ class GetVisitPassesTest : IntegrationTestBase() {
 
     visitSchedulerMockServer.stubGetVisits(prisonCode = prisonCode, startDate = visitDate, endDate = visitDate, page = 0, size = 250, visitStatus = listOf(VisitStatus.BOOKED.name), visits = allVisits)
     visitSchedulerMockServer.stubGetSessionSchedulesWithDateExclusions(prisonCode, listOf(sessionScheduleWithDateExclusions))
-    manageUsersApiMockServer.stubGetMultipleUserDetails(
-      listOf("user-1"),
-      userDetails = mapOf("user-1" to UserExtendedDetailsDto("user-1", "User", "One")),
-    )
     prisonerContactRegistryMockServer.stubSearchContacts(contactIds = returnedContacts.map { it.contactId }.distinct(), contactsList = returnedContacts)
     prisonOffenderSearchMockServer.stubGetPrisonersByPrisonerIds(prisonerIds = returnedPrisoners.map { it.prisonerNumber }.distinct(), prisoners = returnedPrisoners)
 
@@ -282,6 +274,7 @@ class GetVisitPassesTest : IntegrationTestBase() {
     assertThat(visitPasses.map { it.reference }).doesNotContain(blockedSessionVisit.reference)
 
     verify(visitSchedulerClientSpy, times(1)).getVisits(any())
+    verify(manageUsersApiClientSpy, times(0)).getUsersByUsernames(any())
     verify(prisonerSearchClientSpy, times(1)).getPrisonersByPrisonerIdsAttributeSearchAsMono(any())
     verify(prisonerContactRegistryClientSpy, times(1)).searchContactsAsMono(any(), anyOrNull(), any())
     verify(telemetryClientSpy).trackEvent(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/visit/passes/GetVisitPassesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/visit/passes/GetVisitPassesTest.kt
@@ -18,16 +18,20 @@ import org.springframework.web.reactive.function.BodyInserters
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.controller.VISIT_PASSES_CONTROLLER_PATH
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.contact.registry.AddressDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.contact.registry.ContactWithOptionalPrisonerRelationshipDto
+import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.manage.users.UserExtendedDetailsDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.prisoner.search.PrisonerDto
+import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.visit.scheduler.SessionScheduleWithDateExclusionsDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.visit.scheduler.VisitDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.visit.scheduler.VisitorDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.visit.scheduler.enums.VisitStatus
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.visit.scheduler.passes.VisitPassDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.visit.scheduler.passes.VisitPassRequestDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.visit.scheduler.passes.VisitPassVisitorDto
+import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.visit.scheduler.prisons.ExcludeDateDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.integration.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.integration.TestObjectMapper
 import java.time.LocalDate
+import java.time.LocalTime
 import java.time.format.DateTimeFormatter
 import kotlin.random.Random
 
@@ -104,6 +108,9 @@ class GetVisitPassesTest : IntegrationTestBase() {
     // visit8 with 2 contacts (ids 14 and 15, 14 is on a separate visit)
     val visit8visitors = createVisitors(listOf(contact14.contactId, contact15.contactId))
     visit8 = createVisitDto(reference = "visit-8", prisonerId = prisoner1.prisonerNumber, visitors = visit8visitors, prisonCode = prisonCode, startTimestamp = visitDate.atTime(11, 0), endTimestamp = visitDate.atTime(12, 0))
+
+    visitSchedulerMockServer.stubGetExcludeDates(prisonCode, emptyList())
+    visitSchedulerMockServer.stubGetSessionSchedulesWithDateExclusions(prisonCode, emptyList())
   }
 
   @Test
@@ -175,6 +182,156 @@ class GetVisitPassesTest : IntegrationTestBase() {
       },
       isNull(),
     )
+  }
+
+  @Test
+  fun `when a prison has booked visits on a blocked date then no visit passes are returned`() {
+    // Given
+    val allVisits = listOf(visit1, visit2)
+    val blockedDate = ExcludeDateDto(visitDate, "user-1")
+
+    visitSchedulerMockServer.stubGetVisits(prisonCode = prisonCode, startDate = visitDate, endDate = visitDate, page = 0, size = 250, visitStatus = listOf(VisitStatus.BOOKED.name), visits = allVisits)
+    visitSchedulerMockServer.stubGetExcludeDates(prisonCode, listOf(blockedDate))
+    manageUsersApiMockServer.stubGetMultipleUserDetails(
+      listOf("user-1"),
+      userDetails = mapOf("user-1" to UserExtendedDetailsDto("user-1", "User", "One")),
+    )
+
+    // When
+    val responseSpec = callGetVisitPasses(webTestClient, prisonCode, visitDate, "STAFF_USER1", roleVSIPOrchestrationServiceHttpHeaders)
+
+    // Then
+    responseSpec.expectStatus().isOk
+    val visitPasses = getResults(responseSpec.expectBody())
+    assertThat(visitPasses).isEmpty()
+
+    verify(visitSchedulerClientSpy, times(1)).getVisits(any())
+    verify(prisonerSearchClientSpy, times(0)).getPrisonersByPrisonerIdsAttributeSearchAsMono(any())
+    verify(prisonerContactRegistryClientSpy, times(0)).searchContactsAsMono(any(), anyOrNull(), any())
+    verify(telemetryClientSpy).trackEvent(
+      eq("print-visit-passes"),
+      check {
+        assertThat(it["prisonCode"]).isEqualTo(prisonCode)
+        assertThat(it["visitDate"]).isEqualTo(visitDate.format(DateTimeFormatter.ISO_DATE))
+        assertThat(it["actionedBy"]).isEqualTo("STAFF_USER1")
+        assertThat(it["totalVisits"]).isEqualTo("2")
+      },
+      isNull(),
+    )
+  }
+
+  @Test
+  fun `when a prison has booked visits on a blocked session then those visits are not returned`() {
+    // Given
+    val blockedSessionTemplateReference = "blocked-session"
+    val openSessionTemplateReference = "open-session"
+    val openVisit = createVisitDto(
+      reference = "visit-1",
+      prisonerId = prisoner1.prisonerNumber,
+      visitors = createVisitors(listOf(contact1.contactId, contact2.contactId)),
+      prisonCode = prisonCode,
+      startTimestamp = visitDate.atTime(10, 0),
+      endTimestamp = visitDate.atTime(11, 0),
+      sessionTemplateReference = openSessionTemplateReference,
+    )
+    val blockedSessionVisit = createVisitDto(
+      reference = "visit-2",
+      prisonerId = prisoner2.prisonerNumber,
+      visitors = createVisitors(listOf(contact3.contactId, contact4.contactId)),
+      prisonCode = prisonCode,
+      startTimestamp = visitDate.atTime(10, 0),
+      endTimestamp = visitDate.atTime(11, 0),
+      sessionTemplateReference = blockedSessionTemplateReference,
+    )
+    val allVisits = listOf(openVisit, blockedSessionVisit)
+    val returnedContacts = listOf(contact1, contact2)
+    val returnedPrisoners = listOf(prisoner1)
+    val blockedSessionExcludeDate = ExcludeDateDto(visitDate, "user-1")
+    val blockedSessionSchedule = createSessionScheduleDto(
+      reference = blockedSessionTemplateReference,
+      startTime = LocalTime.of(10, 0),
+      endTime = LocalTime.of(11, 0),
+      validFromDate = visitDate.minusWeeks(1),
+      areLocationGroupsInclusive = true,
+      areCategoryGroupsInclusive = true,
+      areIncentiveGroupsInclusive = true,
+      visitRoom = "Visit Room",
+    )
+    val sessionScheduleWithDateExclusions = SessionScheduleWithDateExclusionsDto(
+      sessionSchedule = blockedSessionSchedule,
+      excludeDates = listOf(blockedSessionExcludeDate),
+    )
+
+    visitSchedulerMockServer.stubGetVisits(prisonCode = prisonCode, startDate = visitDate, endDate = visitDate, page = 0, size = 250, visitStatus = listOf(VisitStatus.BOOKED.name), visits = allVisits)
+    visitSchedulerMockServer.stubGetSessionSchedulesWithDateExclusions(prisonCode, listOf(sessionScheduleWithDateExclusions))
+    manageUsersApiMockServer.stubGetMultipleUserDetails(
+      listOf("user-1"),
+      userDetails = mapOf("user-1" to UserExtendedDetailsDto("user-1", "User", "One")),
+    )
+    prisonerContactRegistryMockServer.stubSearchContacts(contactIds = returnedContacts.map { it.contactId }.distinct(), contactsList = returnedContacts)
+    prisonOffenderSearchMockServer.stubGetPrisonersByPrisonerIds(prisonerIds = returnedPrisoners.map { it.prisonerNumber }.distinct(), prisoners = returnedPrisoners)
+
+    // When
+    val responseSpec = callGetVisitPasses(webTestClient, prisonCode, visitDate, "STAFF_USER1", roleVSIPOrchestrationServiceHttpHeaders)
+
+    // Then
+    responseSpec.expectStatus().isOk
+    val visitPasses = getResults(responseSpec.expectBody())
+    assertThat(visitPasses).hasSize(1)
+    assertVisitPassDetails(openVisit, prisoner1, listOf(contact1, contact2), visitPasses.first())
+    assertThat(visitPasses.map { it.reference }).doesNotContain(blockedSessionVisit.reference)
+
+    verify(visitSchedulerClientSpy, times(1)).getVisits(any())
+    verify(prisonerSearchClientSpy, times(1)).getPrisonersByPrisonerIdsAttributeSearchAsMono(any())
+    verify(prisonerContactRegistryClientSpy, times(1)).searchContactsAsMono(any(), anyOrNull(), any())
+    verify(telemetryClientSpy).trackEvent(
+      eq("print-visit-passes"),
+      check {
+        assertThat(it["prisonCode"]).isEqualTo(prisonCode)
+        assertThat(it["visitDate"]).isEqualTo(visitDate.format(DateTimeFormatter.ISO_DATE))
+        assertThat(it["actionedBy"]).isEqualTo("STAFF_USER1")
+        assertThat(it["totalVisits"]).isEqualTo("2")
+      },
+      isNull(),
+    )
+  }
+
+  @Test
+  fun `when prison exclude date lookup returns an INTERNAL_SERVER_ERROR then an INTERNAL_SERVER_ERROR error is returned`() {
+    // Given
+    val allVisits = listOf(visit1, visit2)
+
+    visitSchedulerMockServer.stubGetVisits(prisonCode = prisonCode, startDate = visitDate, endDate = visitDate, page = 0, size = 250, visitStatus = listOf(VisitStatus.BOOKED.name), visits = allVisits)
+    visitSchedulerMockServer.stubGetExcludeDates(prisonCode, null, HttpStatus.INTERNAL_SERVER_ERROR)
+
+    // When
+    val responseSpec = callGetVisitPasses(webTestClient, prisonCode, visitDate, "STAFF_USER1", roleVSIPOrchestrationServiceHttpHeaders)
+
+    // Then
+    responseSpec.expectStatus().is5xxServerError
+    verify(visitSchedulerClientSpy, times(1)).getVisits(any())
+    verify(prisonerSearchClientSpy, times(0)).getPrisonersByPrisonerIdsAttributeSearchAsMono(any())
+    verify(prisonerContactRegistryClientSpy, times(0)).searchContactsAsMono(any(), anyOrNull(), any())
+    verify(telemetryClientSpy, times(0)).trackEvent(any(), anyOrNull(), anyOrNull())
+  }
+
+  @Test
+  fun `when session exclude date lookup returns an INTERNAL_SERVER_ERROR then an INTERNAL_SERVER_ERROR error is returned`() {
+    // Given
+    val allVisits = listOf(visit1, visit2)
+
+    visitSchedulerMockServer.stubGetVisits(prisonCode = prisonCode, startDate = visitDate, endDate = visitDate, page = 0, size = 250, visitStatus = listOf(VisitStatus.BOOKED.name), visits = allVisits)
+    visitSchedulerMockServer.stubGetSessionSchedulesWithDateExclusions(prisonCode, null, HttpStatus.INTERNAL_SERVER_ERROR)
+
+    // When
+    val responseSpec = callGetVisitPasses(webTestClient, prisonCode, visitDate, "STAFF_USER1", roleVSIPOrchestrationServiceHttpHeaders)
+
+    // Then
+    responseSpec.expectStatus().is5xxServerError
+    verify(visitSchedulerClientSpy, times(1)).getVisits(any())
+    verify(prisonerSearchClientSpy, times(0)).getPrisonersByPrisonerIdsAttributeSearchAsMono(any())
+    verify(prisonerContactRegistryClientSpy, times(0)).searchContactsAsMono(any(), anyOrNull(), any())
+    verify(telemetryClientSpy, times(0)).trackEvent(any(), anyOrNull(), anyOrNull())
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/visit/passes/GetVisitPassesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/visit/passes/GetVisitPassesTest.kt
@@ -169,6 +169,8 @@ class GetVisitPassesTest : IntegrationTestBase() {
     assertThat(visitPasses.size).isEqualTo(0)
 
     verify(visitSchedulerClientSpy, times(1)).getVisits(any())
+    verify(visitSchedulerClientSpy, times(0)).getPrisonExcludeDates(any())
+    verify(visitSchedulerClientSpy, times(0)).getFutureSessionTemplateExclusions(any())
     verify(prisonerSearchClientSpy, times(0)).getPrisonersByPrisonerIdsAttributeSearchAsMono(any())
     verify(prisonerContactRegistryClientSpy, times(0)).searchContactsAsMono(any(), anyOrNull(), any())
     verify(telemetryClientSpy).trackEvent(


### PR DESCRIPTION
## What does this PR do?

If a visit falls on a blocked date or blocked session, remove it from the visit passes to be printed.

Also make the look-up of the manager-users-api usernames optional - as we don't need it for this flow.

## JIRA Link
https://dsdmoj.atlassian.net/browse/VB-6817