### PR TITLE
Bug fix - contacts call skipped when no contacts to look-up

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/client/PrisonerProfileClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/client/PrisonerProfileClient.kt
@@ -95,6 +95,11 @@ class PrisonerProfileClient(
         .map { it.nomisPersonId }
         .distinct()
 
+      if (contactIds.isEmpty()) {
+        LOG.info("No visitors found on visits list for prisoner {} on prisoner-profile, skipping visitor details retrieval", prisonerProfile.prisonerId)
+        return null
+      }
+
       val contacts = prisonerContactRegistryClient.searchContacts(
         contactIds = contactIds,
         prisonerId = prisonerProfile.prisonerId,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/prisoner/profile/GetPrisonerProfileTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/prisoner/profile/GetPrisonerProfileTest.kt
@@ -320,12 +320,6 @@ class GetPrisonerProfileTest(
     prisonOffenderSearchMockServer.stubGetPrisonerById(PRISONER_ID, prisonerDto)
     prisonApiMockServer.stubGetInmateDetails(PRISONER_ID, inmateDetailDto)
     visitAllocationApiMockServer.stubGetPrisonerVOBalanceDetailed(PRISONER_ID, visitBalancesDto)
-    prisonerContactRegistryMockServer.stubSearchContacts(
-      contactIds = emptyList(),
-      prisonerId = PRISONER_ID,
-      withRestrictions = false,
-      contactsList = contactsDto,
-    )
     alertApiMockServer.stubGetPrisonerAlertsMono(PRISONER_ID, listOf(alertResponseDto))
     prisonApiMockServer.stubGetPrisonerRestrictions(PRISONER_ID, OffenderRestrictionsDto(bookingId = 1, listOf(prisonerRestrictionDto)))
     prisonRegisterMockServer.stubGetPrisonNames(prisons)
@@ -346,6 +340,11 @@ class GetPrisonerProfileTest(
     Assertions.assertThat(prisonerProfile.visits).isEmpty()
 
     verifyExternalAPIClientCalls()
+    verify(prisonerContactRegistryClientSpy, times(0)).searchContactsAsMono(
+      any(),
+      eq(PRISONER_ID),
+      eq(false),
+    )
   }
 
   @Test
@@ -391,39 +390,6 @@ class GetPrisonerProfileTest(
 
     verify(prisonerContactRegistryClientSpy, times(1)).searchContactsAsMono(
       eq(getContactIdsFromVisits(listOf(visit1, visit2))),
-      eq(PRISONER_ID),
-      eq(false),
-    )
-  }
-
-  @Test
-  fun `when visits have no visitors then prisoner contact registry is not called`() {
-    // Given
-    val visitWithNoVisitors = createVisitDto(reference = "visit-with-no-visitors", prisonerId = PRISONER_ID, visitors = emptyList(), prisonCode = "ABC")
-
-    prisonOffenderSearchMockServer.stubGetPrisonerById(PRISONER_ID, prisonerDto)
-    prisonApiMockServer.stubGetInmateDetails(PRISONER_ID, inmateDetailDto)
-    visitAllocationApiMockServer.stubGetPrisonerVOBalanceDetailed(PRISONER_ID, visitBalancesDto)
-    alertApiMockServer.stubGetPrisonerAlertsMono(PRISONER_ID, listOf(alertResponseDto))
-    prisonApiMockServer.stubGetPrisonerRestrictions(PRISONER_ID, OffenderRestrictionsDto(bookingId = 1, listOf(prisonerRestrictionDto)))
-    prisonRegisterMockServer.stubGetPrisonNames(prisons)
-    stubGetVisits(listOf(visitWithNoVisitors))
-
-    // When
-    val responseSpec = callGetPrisonerProfile(webTestClient, roleVSIPOrchestrationServiceHttpHeaders, PRISON_CODE, PRISONER_ID)
-
-    // Then
-    val returnResult = responseSpec.expectStatus().isOk.expectBody()
-    val prisonerProfile = getResults(returnResult)
-
-    assertPrisonerDtoDetails(prisonerProfile, prisonerDto)
-    Assertions.assertThat(prisonerProfile.visits).hasSize(1)
-    Assertions.assertThat(prisonerProfile.visits[0].visitors).isEmpty()
-    assertPrisonDetails(prisonerProfile.visits[0], visitWithNoVisitors.prisonCode, "ABC Prison")
-
-    verifyExternalAPIClientCalls()
-    verify(prisonerContactRegistryClientSpy, times(0)).searchContactsAsMono(
-      any(),
       eq(PRISONER_ID),
       eq(false),
     )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/prisoner/profile/GetPrisonerProfileTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/integration/prisoner/profile/GetPrisonerProfileTest.kt
@@ -397,6 +397,39 @@ class GetPrisonerProfileTest(
   }
 
   @Test
+  fun `when visits have no visitors then prisoner contact registry is not called`() {
+    // Given
+    val visitWithNoVisitors = createVisitDto(reference = "visit-with-no-visitors", prisonerId = PRISONER_ID, visitors = emptyList(), prisonCode = "ABC")
+
+    prisonOffenderSearchMockServer.stubGetPrisonerById(PRISONER_ID, prisonerDto)
+    prisonApiMockServer.stubGetInmateDetails(PRISONER_ID, inmateDetailDto)
+    visitAllocationApiMockServer.stubGetPrisonerVOBalanceDetailed(PRISONER_ID, visitBalancesDto)
+    alertApiMockServer.stubGetPrisonerAlertsMono(PRISONER_ID, listOf(alertResponseDto))
+    prisonApiMockServer.stubGetPrisonerRestrictions(PRISONER_ID, OffenderRestrictionsDto(bookingId = 1, listOf(prisonerRestrictionDto)))
+    prisonRegisterMockServer.stubGetPrisonNames(prisons)
+    stubGetVisits(listOf(visitWithNoVisitors))
+
+    // When
+    val responseSpec = callGetPrisonerProfile(webTestClient, roleVSIPOrchestrationServiceHttpHeaders, PRISON_CODE, PRISONER_ID)
+
+    // Then
+    val returnResult = responseSpec.expectStatus().isOk.expectBody()
+    val prisonerProfile = getResults(returnResult)
+
+    assertPrisonerDtoDetails(prisonerProfile, prisonerDto)
+    Assertions.assertThat(prisonerProfile.visits).hasSize(1)
+    Assertions.assertThat(prisonerProfile.visits[0].visitors).isEmpty()
+    assertPrisonDetails(prisonerProfile.visits[0], visitWithNoVisitors.prisonCode, "ABC Prison")
+
+    verifyExternalAPIClientCalls()
+    verify(prisonerContactRegistryClientSpy, times(0)).searchContactsAsMono(
+      any(),
+      eq(PRISONER_ID),
+      eq(false),
+    )
+  }
+
+  @Test
   fun `when visit has visitors but call to prisoner contact registry returns BAD_REQUEST visitors first and last name are not populated`() {
     // Given
     prisonOffenderSearchMockServer.stubGetPrisonerById(PRISONER_ID, prisonerDto)


### PR DESCRIPTION
## What does this PR do?
When the prisoner profile is called, but no visitorIds are found then we shouldn't be calling the prisoner-contact-registry. 

Before fix
- An empty contactIds list was passed to the contact search on prisoner-contact-registry and ended with a 400.

After fix
- If the contactIds list is empty, we skip the call to prisoner-contact-registry.