### PR TITLE
Fix pvb booking window bug

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/service/PrisonService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/service/PrisonService.kt
@@ -14,7 +14,6 @@ import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.vis
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.visit.scheduler.enums.UserType
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.visit.scheduler.prisons.ExcludeDateDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.visit.scheduler.prisons.IsExcludeDateDto
-import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.exception.NotFoundException
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.utils.DateUtils
 import java.time.LocalDate
 
@@ -83,7 +82,7 @@ class PrisonService(
         ?: prison.clients.firstOrNull { it.userType == UserType.STAFF }
         ?: run {
           val message = "No client found for prison $prisonCode and user type $userType"
-          throw NotFoundException(message, IllegalStateException(message))
+          throw IllegalStateException(message)
         }
     return dateUtils.getToDaysDateRange(client = client, minOverride = fromDateOverride, maxOverride = toDateOverride)
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/service/PrisonService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/service/PrisonService.kt
@@ -79,10 +79,12 @@ class PrisonService(
   ): DateRange {
     val prison = visitSchedulerClient.getPrison(prisonCode)
     val client =
-      prison.clients.firstOrNull { it.userType == userType } ?: run {
-        val message = "No client found for prison $prisonCode and user type $userType"
-        throw NotFoundException(message, IllegalStateException(message))
-      }
+      prison.clients.firstOrNull { it.userType == userType }
+        ?: prison.clients.firstOrNull { it.userType == UserType.STAFF }
+        ?: run {
+          val message = "No client found for prison $prisonCode and user type $userType"
+          throw NotFoundException(message, IllegalStateException(message))
+        }
     return dateUtils.getToDaysDateRange(client = client, minOverride = fromDateOverride, maxOverride = toDateOverride)
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/service/PrisonService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/service/PrisonService.kt
@@ -79,8 +79,10 @@ class PrisonService(
     val prison = visitSchedulerClient.getPrison(prisonCode)
     val client =
       prison.clients.firstOrNull { it.userType == userType }
+        // PVB doesn't have a user client, default to STAFF if called and PUBLIC doesn't exist.
         ?: prison.clients.firstOrNull { it.userType == UserType.STAFF }
         ?: run {
+          // Throw a 500 if we reach here. As PUBLIC or STAFF must exist. (If PRISONER / SYSTEM is passed it's also invalid, so 500 is correct).
           val message = "No client found for prison $prisonCode and user type $userType"
           throw IllegalStateException(message)
         }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/service/PrisonServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/service/PrisonServiceTest.kt
@@ -1,0 +1,93 @@
+package uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.service
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.client.PrisonRegisterClient
+import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.client.VisitSchedulerClient
+import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.visit.scheduler.PrisonUserClientDto
+import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.visit.scheduler.VisitSchedulerPrisonDto
+import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.visit.scheduler.enums.UserType
+import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.exception.NotFoundException
+import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.utils.CurrentDateUtils
+import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.utils.DateUtils
+import java.time.DayOfWeek
+import java.time.LocalDate
+
+@ExtendWith(MockitoExtension::class)
+class PrisonServiceTest {
+  private val visitSchedulerClient = mock<VisitSchedulerClient>()
+  private val prisonRegisterClient = mock<PrisonRegisterClient>()
+  private val currentDateUtils = mock<CurrentDateUtils>()
+  private val dateUtils = DateUtils(currentDateUtils)
+  private val excludeDatesService = mock<ExcludeDatesService>()
+  private val prisonService = PrisonService(visitSchedulerClient, prisonRegisterClient, dateUtils, excludeDatesService)
+
+  private val today = LocalDate.of(2026, 7, 16)
+
+  @Test
+  fun `getToDaysBookableDateRange uses requested user type client when present`() {
+    val publicClient = prisonClient(UserType.PUBLIC, policyNoticeDaysMin = 5, policyNoticeDaysMax = 30)
+    val staffClient = prisonClient(UserType.STAFF, policyNoticeDaysMin = 1, policyNoticeDaysMax = 10)
+    whenever(currentDateUtils.getCurrentDate()).thenReturn(today)
+    whenever(visitSchedulerClient.getPrison("MDI")).thenReturn(prison(clients = listOf(staffClient, publicClient)))
+
+    val dateRange = prisonService.getToDaysBookableDateRange(prisonCode = "MDI", userType = UserType.PUBLIC)
+
+    assertThat(dateRange.fromDate).isEqualTo(today.plusDays(6))
+    assertThat(dateRange.toDate).isEqualTo(today.plusDays(30))
+  }
+
+  @Test
+  fun `getToDaysBookableDateRange falls back to staff client when requested user type client is not present`() {
+    val staffClient = prisonClient(UserType.STAFF, policyNoticeDaysMin = 2, policyNoticeDaysMax = 28)
+    whenever(currentDateUtils.getCurrentDate()).thenReturn(today)
+    whenever(visitSchedulerClient.getPrison("MDI")).thenReturn(prison(clients = listOf(staffClient)))
+
+    val dateRange = prisonService.getToDaysBookableDateRange(prisonCode = "MDI", userType = UserType.PUBLIC)
+
+    assertThat(dateRange.fromDate).isEqualTo(today.plusDays(3))
+    assertThat(dateRange.toDate).isEqualTo(today.plusDays(28))
+  }
+
+  @Test
+  fun `getToDaysBookableDateRange throws NotFoundException when requested and staff clients are not present`() {
+    val prisonerClient = prisonClient(UserType.PRISONER, policyNoticeDaysMin = 3, policyNoticeDaysMax = 21)
+    whenever(visitSchedulerClient.getPrison("MDI")).thenReturn(prison(clients = listOf(prisonerClient)))
+
+    val exception = assertThrows<NotFoundException> {
+      prisonService.getToDaysBookableDateRange(prisonCode = "MDI", userType = UserType.PUBLIC)
+    }
+
+    assertThat(exception.message).isEqualTo("No client found for prison MDI and user type PUBLIC")
+  }
+
+  private fun prison(clients: List<PrisonUserClientDto>) = VisitSchedulerPrisonDto(
+    code = "MDI",
+    active = true,
+    policyNoticeDaysMin = 1,
+    policyNoticeDaysMax = 28,
+    maxTotalVisitors = 6,
+    maxAdultVisitors = 3,
+    maxChildVisitors = 3,
+    adultAgeYears = 18,
+    weekStartDay = DayOfWeek.MONDAY,
+    remandVisitLimitPerWeek = 1,
+    clients = clients,
+  )
+
+  private fun prisonClient(
+    userType: UserType,
+    policyNoticeDaysMin: Int,
+    policyNoticeDaysMax: Int,
+  ) = PrisonUserClientDto(
+    userType = userType,
+    policyNoticeDaysMin = policyNoticeDaysMin,
+    policyNoticeDaysMax = policyNoticeDaysMax,
+    active = true,
+  )
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/service/PrisonServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/service/PrisonServiceTest.kt
@@ -54,8 +54,20 @@ class PrisonServiceTest {
   }
 
   @Test
-  fun `getToDaysBookableDateRange throws IllegalStateException when requested and staff clients are not present`() {
+  fun `getToDaysBookableDateRange throws IllegalStateException when requested and staff clients are not present - PRISONER`() {
     val prisonerClient = prisonClient(UserType.PRISONER, policyNoticeDaysMin = 3, policyNoticeDaysMax = 21)
+    whenever(visitSchedulerClient.getPrison("MDI")).thenReturn(prison(clients = listOf(prisonerClient)))
+
+    val exception = assertThrows<IllegalStateException> {
+      prisonService.getToDaysBookableDateRange(prisonCode = "MDI", userType = UserType.PUBLIC)
+    }
+
+    assertThat(exception.message).isEqualTo("No client found for prison MDI and user type PUBLIC")
+  }
+
+  @Test
+  fun `getToDaysBookableDateRange throws IllegalStateException when requested and staff clients are not present - SYSTEM`() {
+    val prisonerClient = prisonClient(UserType.SYSTEM, policyNoticeDaysMin = 3, policyNoticeDaysMax = 21)
     whenever(visitSchedulerClient.getPrison("MDI")).thenReturn(prison(clients = listOf(prisonerClient)))
 
     val exception = assertThrows<IllegalStateException> {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/service/PrisonServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsmanageprisonvisitsorchestration/service/PrisonServiceTest.kt
@@ -12,7 +12,6 @@ import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.client.
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.visit.scheduler.PrisonUserClientDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.visit.scheduler.VisitSchedulerPrisonDto
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.dto.visit.scheduler.enums.UserType
-import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.exception.NotFoundException
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.utils.CurrentDateUtils
 import uk.gov.justice.digital.hmpps.hmppsmanageprisonvisitsorchestration.utils.DateUtils
 import java.time.DayOfWeek
@@ -55,11 +54,11 @@ class PrisonServiceTest {
   }
 
   @Test
-  fun `getToDaysBookableDateRange throws NotFoundException when requested and staff clients are not present`() {
+  fun `getToDaysBookableDateRange throws IllegalStateException when requested and staff clients are not present`() {
     val prisonerClient = prisonClient(UserType.PRISONER, policyNoticeDaysMin = 3, policyNoticeDaysMax = 21)
     whenever(visitSchedulerClient.getPrison("MDI")).thenReturn(prison(clients = listOf(prisonerClient)))
 
-    val exception = assertThrows<NotFoundException> {
+    val exception = assertThrows<IllegalStateException> {
       prisonService.getToDaysBookableDateRange(prisonCode = "MDI", userType = UserType.PUBLIC)
     }
 


### PR DESCRIPTION
## What does this PR do?
New booking windows sit within the User Client table. Because PVB passes a "PUBLIC" UserType, it then tries to retrieve the booking window from the PUBLIC User Client. However, we don't have a PUBLIC User Client for PVB prisons.

Introduce backwards compatibility behaviour, if the PUBLIC client cannot be found then default to search for the STAFF client first. Then, if neither are found, throw a 500 exception so it doesn't fail silently.